### PR TITLE
Features/project account switcher manages state

### DIFF
--- a/src/interface/interface.json
+++ b/src/interface/interface.json
@@ -316,7 +316,10 @@
                                         "{Project} [ReferenceProject] - (Optional) reference node for insertBefore"
                                     ]
                                 },
-                                "removeCaretFromTarget": {
+                                "addCaret": {
+                                    "desc": "adds caret to target in Project Account Switcher"
+                                },
+                                "removeCaret": {
                                     "desc": "removes caret from target in Project Account Switcher"
                                 },
                                 "open": {
@@ -608,7 +611,7 @@
                                     "desc": "Calls the provided callback when user clicks on the Help",
                                     "params": "HIG.abstract.EventObject.params",
                                     "returns": "HIG.abstract.EventObject.returns"
-                                },   
+                                },
                                 "onFocusOut": {
                                     "desc": "Calls the provided callback when user clicks on the Help",
                                     "params": "HIG.abstract.EventObject.params",

--- a/src/interface/interface.json
+++ b/src/interface/interface.json
@@ -316,11 +316,11 @@
                                         "{Project} [ReferenceProject] - (Optional) reference node for insertBefore"
                                     ]
                                 },
-                                "addCaret": {
-                                    "desc": "adds caret to target in Project Account Switcher"
+                                "showCaret": {
+                                    "desc": "shows a caret indicating a flyout in Project Account Switcher"
                                 },
-                                "removeCaret": {
-                                    "desc": "removes caret from target in Project Account Switcher"
+                                "hideCaret": {
+                                    "desc": "removes caret indicating a flyout in Project Account Switcher"
                                 },
                                 "open": {
                                     "desc": "opens the project/account switcher"

--- a/src/web/components/global-nav/top-nav/project-account-switcher/_target/target.js
+++ b/src/web/components/global-nav/top-nav/project-account-switcher/_target/target.js
@@ -41,8 +41,12 @@ class Target extends Core {
         return this._attachListener("click", this.el, this.el, fn);
     }
 
+    addCaret(){
+        this._findDOMEl('.hig__global-nav__top-nav__project-account-switcher__target__caret', this.el).classList.remove('hig__global-nav__top-nav__project-account-switcher__target__caret--hide');
+    }
+
     removeCaret(){
-        this._findDOMEl('.hig__global-nav__top-nav__project-account-switcher__target__caret', this.el).remove(); 
+        this._findDOMEl('.hig__global-nav__top-nav__project-account-switcher__target__caret', this.el).classList.add('hig__global-nav__top-nav__project-account-switcher__target__caret--hide');
     }
 }
 
@@ -54,6 +58,7 @@ Target._interface = {
         "setImage": {},
         "setType": {},
         "onClick": {},
+        "addCaret": {},
         "removeCaret": {}
     }
 };

--- a/src/web/components/global-nav/top-nav/project-account-switcher/_target/target.scss
+++ b/src/web/components/global-nav/top-nav/project-account-switcher/_target/target.scss
@@ -12,3 +12,7 @@
     display: inline-block;
     padding-left: 12px;
 }
+
+.hig__global-nav__top-nav__project-account-switcher__target__caret--hide {
+    display: none;
+}

--- a/src/web/components/global-nav/top-nav/project-account-switcher/project-account-switcher.js
+++ b/src/web/components/global-nav/top-nav/project-account-switcher/project-account-switcher.js
@@ -51,11 +51,11 @@ class ProjectAccountSwitcher extends Core {
         return this.target.onClick(fn);
     }
 
-    addCaret() {
+    showCaret() {
         this.target.addCaret();
     }
 
-    removeCaret() {
+    hideCaret() {
         this.target.removeCaret();
     }
 

--- a/src/web/components/global-nav/top-nav/project-account-switcher/project-account-switcher.js
+++ b/src/web/components/global-nav/top-nav/project-account-switcher/project-account-switcher.js
@@ -51,7 +51,11 @@ class ProjectAccountSwitcher extends Core {
         return this.target.onClick(fn);
     }
 
-    removeCaretFromTarget() {
+    addCaret() {
+        this.target.addCaret();
+    }
+
+    removeCaret() {
         this.target.removeCaret();
     }
 

--- a/src/web/helpers/js/_core.js
+++ b/src/web/helpers/js/_core.js
@@ -187,7 +187,7 @@ class Core {
      * @param {String} eventType - event type, for example "click"
      * @param {String} targetClass - query selector for target class
      * @param {HTMLElement} scopeElement - element that defines the scope in which this takes place
-     * @param {String} executeOnEventFunction - function that will be executed on event
+     * @param {Function} executeOnEventFunction - function that will be executed on event
      * @returns {Function} disposeFunction - function to call to remove event listener
      */
 
@@ -208,11 +208,11 @@ class Core {
             eventTarget = q;
             eventType = 'mouseenter';
         }else{
-            eventFn = function(event){
+            eventFn = (event) => {
                 var element = event.target;
 
                 if(q && (childOf(element, q) || element === q)){
-                    executeOnEventFunction(event);
+                    executeOnEventFunction(event, this);
                 }
             };
             eventTarget = document;


### PR DESCRIPTION
Some small changes to support Orion ProjectAccountSwitcher managing it's own state.
- Add an `addCaret` function
- Event handlers send back the originating HIG Element