### PR TITLE
Enable more settings in Profile for Orion Profile component

### DIFF
--- a/src/interface/interface.json
+++ b/src/interface/interface.json
@@ -295,7 +295,7 @@
                                 "image": "{String} url src of the image",
                                 "email": "{String} email for profile",
                                 "name": "{String} display name for profile",
-``                                "signOutLink": "{String} the linke for the sign out button",
+                                "signOutLink": "{String} the linke for the sign out button",
                                 "profileSettingsLabel": "{String} the label for the Profile Settings link",
                                 "profileSettingsLink": "{String} the URL for the Profile Settings link",
                                 "signOutLabel": "{String} the label for the sign out button"

--- a/src/interface/interface.json
+++ b/src/interface/interface.json
@@ -295,9 +295,10 @@
                                 "image": "{String} url src of the image",
                                 "email": "{String} email for profile",
                                 "name": "{String} display name for profile",
-                                "profileSettingsLabel": "{String} profileSettingsLabel",
-                                "profileSettingsLink": "{String} profileSettingsLink",
-                                "signOutLabel": "{String} signOutLabel"
+``                                "signOutLink": "{String} the linke for the sign out button",
+                                "profileSettingsLabel": "{String} the label for the Profile Settings link",
+                                "profileSettingsLink": "{String} the URL for the Profile Settings link",
+                                "signOutLabel": "{String} the label for the sign out button"
                             }
                         },
                         "ProjectAccountSwitcher": {

--- a/src/web/components/global-nav/top-nav/profile/_profile-flyout-content/profile-flyout-content.js
+++ b/src/web/components/global-nav/top-nav/profile/_profile-flyout-content/profile-flyout-content.js
@@ -22,7 +22,8 @@ class ProfileFlyoutContent extends Core {
 
     _componentDidMount() {
         this.signOutButton = new Button({
-            title: this.options.signOutLabel
+            title: this.options.signOutLabel,
+            link: this.options.signOutLink
         });
         this.mountPartialToComment('SIGN_OUT_BUTTON', this.signOutButton);
 

--- a/src/web/components/global-nav/top-nav/profile/profile.js
+++ b/src/web/components/global-nav/top-nav/profile/profile.js
@@ -93,6 +93,7 @@ Profile._defaults = {
   name: 'name',
   profileSettingsLink: 'https://www.autodesk.com',
   profileSettingsLabel: "Profile Settings",
+  signOutLink: '#',
   signOutLabel: "Sign Out"
 };
 


### PR DESCRIPTION
To enable setting the sign out link in initialOptions,
* Add signOutLink to defaults list for Profile
* Add signOutLink to props list when creating signOutButton
* Set a default value of '#' for the signOutLink (for completeness; it's not actually necessary)