### PR TITLE
Correctly reenable TextField when disabled

### DIFF
--- a/src/web/basics/form-elements/text-field/text-field.js
+++ b/src/web/basics/form-elements/text-field/text-field.js
@@ -51,7 +51,9 @@ class TextField extends Core {
     }
 
     setValue(value){
-        this._findDOMEl('.hig__text-field__input', this.el).setAttribute('value', value);
+        const inputEl = this._findDOMEl('.hig__text-field__input', this.el);
+        inputEl.setAttribute('value', value);
+        inputEl.value = value;
         this._detectPresenceOfValue(value);
     }
 
@@ -112,7 +114,7 @@ class TextField extends Core {
     }
 
     enable() {
-        this._findDOMEl('.hig__text-field__input', this.el).setAttribute('disabled', null);
+        this._findDOMEl('.hig__text-field__input', this.el).removeAttribute('disabled');
         this.el.classList.remove('hig__text-field--disabled');
     }
 


### PR DESCRIPTION
The `enable` method was disabling the text field 😂.

Fixes that.