### PR TITLE
Render buttons with tabindex

### DIFF
--- a/src/web/basics/button/button.html
+++ b/src/web/basics/button/button.html
@@ -1,4 +1,4 @@
-<a href='{{ link }}' class='hig__button hig__button--{{type}} hig__button--{{size}}' title='{{ title }}'>
+<a href="{{ link }}" tabindex="0" class="hig__button hig__button--{{type}} hig__button--{{size}}" title="{{ title }}">
     <!--ICON-->
     <span class="hig__button__title">{{ title }}</span>
 </a>

--- a/src/web/basics/icon-button/icon-button.html
+++ b/src/web/basics/icon-button/icon-button.html
@@ -1,3 +1,3 @@
-<a href="{{ link }}" class="hig__icon-button" title="{{ title }}">
+<a href="{{ link }}" tabindex="0" class="hig__icon-button" title="{{ title }}">
     <div class="hig__icon-button__icon">{{#renderIcon}}{{ icon }}{{/renderIcon}}</div>
 </a>


### PR DESCRIPTION
Button and IconButton templates include `tabindex` attribute so they render the same initially as they will when disabled and reenabled. 