### PR TITLE
Remove unsupported props from Tab template

### DIFF
--- a/src/web/components/global-nav/sub-nav/tabs/tab/tab.html
+++ b/src/web/components/global-nav/sub-nav/tabs/tab/tab.html
@@ -1,1 +1,1 @@
-<div class='hig__global-nav__sub-nav__tabs__tab {{active ? 'hig__global-nav__sub-nav__tabs__tab--active' : ''}}'>{{label}}</div>
+<div class='hig__global-nav__sub-nav__tabs__tab'>{{label}}</div>


### PR DESCRIPTION
Active is not a default specified in interface.json. 