### PR TITLE
Features/surge

### DIFF
--- a/src/implementations/react/.gitignore
+++ b/src/implementations/react/.gitignore
@@ -1,0 +1,5 @@
+build
+coverage
+gemini-report
+lib
+node_modules

--- a/src/implementations/react/package.json
+++ b/src/implementations/react/package.json
@@ -57,7 +57,9 @@
     "test-ci": "react-scripts test --env=jsdom --coverage --runInBand",
     "storybook": "start-storybook -p 9009 -s public",
     "build-storybook": "build-storybook -s public -o build/storybook",
-    "type-check": "tsc"
+    "type-check": "tsc",
+    "deploy-storybook": "npm run build-storybook && surge build/storybook",
+    "deploy-playground": "react-scripts build && surge build"
   },
   "dependencies": {
     "jest": "^20.0.4",

--- a/src/implementations/vanilla/.surgeignore
+++ b/src/implementations/vanilla/.surgeignore
@@ -1,0 +1,18 @@
+# Ignore dev resources
+dev/
+
+# Dont sync any js or scss file
+src/**/*.js
+src/**/*.scss
+
+# Dont sync any icon svg
+src/basics/icons/src/*
+
+# Dont sync html templates but DO sync test html files
+src/**/*.html
+!src/**/tests/*
+
+#ignore builder files
+package.json
+package-lock.json
+webpack.config.js

--- a/src/implementations/vanilla/package.json
+++ b/src/implementations/vanilla/package.json
@@ -8,7 +8,7 @@
     "build": "NODE_ENV=production webpack -p",
     "watch": "webpack --watch",
     "generate-index": "node ./dev/generate-index.js",
-    "deploy-dev": "./dev/deploy-dev.sh",
+    "deploy-dev": "surge",
     "build-icons": "node src/basics/icons/build/build.js",
     "gemini": "concurrently 'http-server' 'gemini test dev/gemini/*' --kill-others",
     "gemini-report": "concurrently 'http-server' 'gemini test dev/gemini/* --reporter html --reporter flat' --kill-others",

--- a/src/implementations/vanilla/package.json
+++ b/src/implementations/vanilla/package.json
@@ -8,7 +8,7 @@
     "build": "NODE_ENV=production webpack -p",
     "watch": "webpack --watch",
     "generate-index": "node ./dev/generate-index.js",
-    "deploy-dev": "surge",
+    "deploy": "surge .",
     "build-icons": "node src/basics/icons/build/build.js",
     "gemini": "concurrently 'http-server' 'gemini test dev/gemini/*' --kill-others",
     "gemini-report": "concurrently 'http-server' 'gemini test dev/gemini/* --reporter html --reporter flat' --kill-others",


### PR DESCRIPTION
@nfiniteset 
@aneyzberg 
@shannonwells 

after installing surge (see [surge.sh](surge.sh)) and signing up for an account, running `npm run deploy` in your terminal in the `/src/implementations/vanilla` directory uploads to surge subdomain and returns that domain

running `npm run deploy-playground` or `npm run deploy-storybook` will upload to surge the playground or storybook