### PR TITLE
Checkbox HIG component toggles checked attribute, plus Checkbox component

### DIFF
--- a/src/implementations/react/src/adapters/FormElements/CheckboxAdapter.js
+++ b/src/implementations/react/src/adapters/FormElements/CheckboxAdapter.js
@@ -130,23 +130,23 @@ CheckboxAdapterComponent.propTypes = {
 
 CheckboxAdapterComponent.__docgenInfo = {
   props: {
-    name: {
-      description: 'sets the name attribute of the checkbox input'
-    },
-    value: {
-      description: 'sets the value attribute of the checkbox input'
-    },
     checked: {
       description: 'boolean - sets whether the checkbox is checked'
     },
     disabled: {
       description: 'boolean - sets whether the checkbox is disabled'
     },
+    label: {
+      description: 'sets the label text for the checkbox'
+    },
+    name: {
+      description: 'sets the name attribute of the checkbox input'
+    },
     required: {
       description: 'string - sets the whether the checkbox is required and displays the provided message'
     },
-    label: {
-      description: 'sets the label text for the checkbox'
+    value: {
+      description: 'sets the value attribute of the checkbox input'
     },
     onHover: {
       description: 'triggers when you hover over the button'

--- a/src/implementations/react/src/adapters/FormElements/CheckboxAdapter.js
+++ b/src/implementations/react/src/adapters/FormElements/CheckboxAdapter.js
@@ -49,6 +49,10 @@ export class CheckboxAdapter extends HIGElement {
 
   }
 
+  forceReset(props) {
+    this.commitUpdate(['checked', props.checked]);
+  }
+
   commitUpdate(updatePayload, oldProps, newProps) {
     for (let i = 0; i < updatePayload.length; i += 2) {
       const propKey = updatePayload[i];

--- a/src/implementations/react/src/adapters/FormElements/__snapshots__/CheckboxAdapter.test.js.snap
+++ b/src/implementations/react/src/adapters/FormElements/__snapshots__/CheckboxAdapter.test.js.snap
@@ -22,7 +22,7 @@ exports[`<Checkbox> renders a Checkbox with updated props 1`] = `
 "<div class=\\"hig__input-button hig__input-button--checkbox hig__input-button--checked hig__input-button--required hig__input-button--disabled\\">
   <!--CHECKBOX_LABEL-->
   <label class=\\"hig__input-button__label\\" for=\\"1234\\">Label</label>
-  <input type=\\"checkbox\\" class=\\"hig__input-button__input\\" name=\\"checkbox-name\\" id=\\"1234\\" value=\\"checkbox-value\\" required=\\"\\" disabled=\\"true\\">
+  <input type=\\"checkbox\\" class=\\"hig__input-button__input\\" name=\\"checkbox-name\\" id=\\"1234\\" value=\\"checkbox-value\\" checked=\\"\\" required=\\"\\" disabled=\\"true\\">
   <span class=\\"hig__input-button__input-wrapper\\"><svg width=\\"11\\" height=\\"9\\" viewBox=\\"0 0 11 9\\" xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" title=\\"check-white\\"><title>Green Checked Box Copy 3</title><polygon points=\\"7.13516024 12 4 8.9767 4.97189967 7.9722 7.11774268 10.0281 12.0092894 5 13 5.9863\\" transform=\\"translate(-3 -4)\\" stroke-width=\\".5\\" stroke=\\"#FFF\\" fill=\\"#FFF\\" fill-rule=\\"evenodd\\"></polygon></svg></span>
 </div>"
 `;

--- a/src/implementations/react/src/adapters/FormElements/__snapshots__/RadioButtonAdapter.test.js.snap
+++ b/src/implementations/react/src/adapters/FormElements/__snapshots__/RadioButtonAdapter.test.js.snap
@@ -22,7 +22,7 @@ exports[`<RadioButton> renders with updated props 1`] = `
 "<div class=\\"hig__input-button hig__input-button--radio hig__input-button--checked hig__input-button--required hig__input-button--disabled\\">
   <!--RADIOBUTTON_LABEL-->
   <label for=\\"1234\\" class=\\"hig__input-button__label\\">Label</label>
-  <input type=\\"radio\\" class=\\"hig__input-button__input\\" name=\\"some-name\\" id=\\"1234\\" value=\\"some-value\\" required=\\"\\" disabled=\\"true\\">
+  <input type=\\"radio\\" class=\\"hig__input-button__input\\" name=\\"some-name\\" id=\\"1234\\" value=\\"some-value\\" checked=\\"\\" required=\\"\\" disabled=\\"true\\">
   <span class=\\"hig__input-button__input-wrapper\\"></span>
 </div>"
 `;

--- a/src/implementations/react/src/elements/basics/form-elements/TextField.js
+++ b/src/implementations/react/src/elements/basics/form-elements/TextField.js
@@ -8,7 +8,7 @@ class TextField extends Component {
   constructor(props) {
     super(props);
 
-    const controlled = this.props.value === undefined ? false : true;
+    const controlled = props.value === undefined ? false : true;
 
     this.state = {
       value: this.getDefaultValue(),

--- a/src/implementations/react/src/elements/components/FormElements/Checkbox.js
+++ b/src/implementations/react/src/elements/components/FormElements/Checkbox.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import CheckboxAdapter from '../../../adapters/FormElements/CheckboxAdapter';
+import PropTypes from 'prop-types';
+
+class Checkbox extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isChecked: props.checked === undefined ? false : props.checked
+    }
+  }
+  onCheckboxChange = (event) => {
+    this.setState({isChecked: !this.state.isChecked});
+    this.resolveChecked();
+    if (this.props.onChange) {
+      this.props.onChange(event);
+    }
+  };
+
+  resolveChecked = () => {
+    if (this.props.checked == undefined) {
+      return this.state.isChecked;
+    }
+    return this.props.checked;
+  };
+
+  render() {
+    return (
+      <CheckboxAdapter
+        checked={this.state.isChecked}
+        disabled={this.props.disabled}
+        name={this.props.name}
+        label={this.props.label}
+        required={this.props.required}
+        value={this.props.value}
+        onChange={this.onCheckboxChange}
+        onFocus={this.props.onFocus}
+        onHover={this.props.onHover}
+      />
+    );
+  }
+}
+
+Checkbox.propTypes = {
+  checked: PropTypes.bool,
+  disabled: PropTypes.bool,
+  label: PropTypes.string,
+  name: PropTypes.string,
+  required: PropTypes.bool,
+  value: PropTypes.string,
+  onChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  onHover: PropTypes.func
+};
+
+export default Checkbox;
+

--- a/src/implementations/react/src/elements/components/FormElements/Checkbox.js
+++ b/src/implementations/react/src/elements/components/FormElements/Checkbox.js
@@ -56,15 +56,10 @@ class Checkbox extends React.Component {
   };
 
   render() {
-    let checked = this.props.checked;
-    if (checked === undefined) {
-      checked = this.state.checked;
-    }
-
     return (
       <CheckboxAdapter
         ref={this.setCheckboxEl}
-        checked={checked}
+        checked={this.getRenderedChecked()}
         disabled={this.props.disabled}
         name={this.props.name}
         label={this.props.label}

--- a/src/implementations/react/src/elements/components/FormElements/Checkbox.js
+++ b/src/implementations/react/src/elements/components/FormElements/Checkbox.js
@@ -5,35 +5,72 @@ import PropTypes from 'prop-types';
 class Checkbox extends React.Component {
   constructor(props) {
     super(props);
+
+    const controlled = props.checked === undefined ? false : true;
+
     this.state = {
-      isChecked: props.checked === undefined ? false : props.checked
+      checked: this.getDefaultChecked(),
+      controlled
     }
   }
-  onCheckboxChange = (event) => {
-    this.setState({isChecked: !this.state.isChecked});
-    this.resolveChecked();
+
+  getDefaultChecked() {
+    const { defaultChecked, checked } = this.props;
+
+    if (checked !== undefined) {
+      return checked;
+    } else if (defaultChecked !== undefined) {
+      return defaultChecked;
+    } else {
+      return false;
+    }
+  }
+
+  getRenderedChecked() {
+    const { checked } = this.props;
+
+    if (checked !== undefined) {
+      return checked;
+    } else {
+      return this.state.checked;
+    }
+  }
+
+  handleChange = event => {
     if (this.props.onChange) {
       this.props.onChange(event);
     }
+
+    if (this.state.controlled) {
+      if (this.checkboxEl) {
+        this.checkboxEl.forceNextReset();
+        this.setState({ checked: this.state.checked });
+      }
+    } else {
+      this.setState({ value: event.target.value });
+    }
   };
 
-  resolveChecked = () => {
-    if (this.props.checked === undefined) {
-      return this.state.isChecked;
-    }
-    return this.props.checked;
+  setCheckboxEl = checkboxEl => {
+    this.checkboxEl = checkboxEl;
   };
 
   render() {
+    let checked = this.props.checked;
+    if (checked === undefined) {
+      checked = this.state.checked;
+    }
+
     return (
       <CheckboxAdapter
-        checked={this.state.isChecked}
+        ref={this.setCheckboxEl}
+        checked={checked}
         disabled={this.props.disabled}
         name={this.props.name}
         label={this.props.label}
         required={this.props.required}
         value={this.props.value}
-        onChange={this.onCheckboxChange}
+        onChange={this.handleChange}
         onFocus={this.props.onFocus}
         onHover={this.props.onHover}
       />
@@ -43,10 +80,11 @@ class Checkbox extends React.Component {
 
 Checkbox.propTypes = {
   checked: PropTypes.bool,
+  defaultChecked: PropTypes.bool,
   disabled: PropTypes.bool,
   label: PropTypes.string,
   name: PropTypes.string,
-  required: PropTypes.bool,
+  required: PropTypes.string,
   value: PropTypes.string,
   onChange: PropTypes.func,
   onFocus: PropTypes.func,

--- a/src/implementations/react/src/elements/components/FormElements/Checkbox.js
+++ b/src/implementations/react/src/elements/components/FormElements/Checkbox.js
@@ -18,7 +18,7 @@ class Checkbox extends React.Component {
   };
 
   resolveChecked = () => {
-    if (this.props.checked == undefined) {
+    if (this.props.checked === undefined) {
       return this.state.isChecked;
     }
     return this.props.checked;

--- a/src/implementations/react/src/elements/components/FormElements/Checkbox.story.js
+++ b/src/implementations/react/src/elements/components/FormElements/Checkbox.story.js
@@ -19,7 +19,7 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { text, boolean } from '@storybook/addon-knobs';
 
-import { default as Checkbox } from '';
+import { default as Checkbox } from './Checkbox';
 
 storiesOf('Checkbox', module)
   .addWithInfo('Basic checkbox', '', () => {
@@ -44,7 +44,6 @@ storiesOf('Checkbox', module)
           name="is_it_fancy"
           value="fanciness"
           label="Fancy!"
-          checked={false}
           required={text('Required text', "This field is required.")}
           disabled={false}
         />
@@ -71,11 +70,11 @@ storiesOf('Checkbox', module)
     return (
       <Checkbox
         name={localName}
-        value={localValue}
         label={localLabel}
-        onHover={action('Hovered')}
+        value={localValue}
         onChange={action('Changed')}
         onFocus={action('Focused')}
+        onHover={action('Hovered')}
       />
     );
   });

--- a/src/implementations/react/src/elements/components/Modal.js
+++ b/src/implementations/react/src/elements/components/Modal.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import  ModalAdapter  from '../../adapters/ModalAdapter'
+import ModalAdapter from '../../adapters/ModalAdapter'
 import PropTypes from 'prop-types';
 
 class Modal extends React.Component {

--- a/src/implementations/react/src/playground/sections/CheckboxSection.js
+++ b/src/implementations/react/src/playground/sections/CheckboxSection.js
@@ -50,6 +50,10 @@ class CheckboxSection extends Component {
           label="Uncontrolled"
         />
         <Checkbox
+          label="Uncontrolled w/ default"
+          defaultChecked={true}
+        />
+        <Checkbox
         label="With event logging"
         onHover={logEvent}
         onChange={logEvent}

--- a/src/implementations/react/src/playground/sections/CheckboxSection.js
+++ b/src/implementations/react/src/playground/sections/CheckboxSection.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 import PlaygroundSection from "../PlaygroundSection";
 import { Checkbox } from "../../react-hig";
 
@@ -16,28 +16,48 @@ function logEvent(event) {
   console.log(messageParts.join(""));
 }
 
-function CheckboxSection() {
-  return (
-    <PlaygroundSection title="Checkbox">
+class CheckboxSection extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      controlledChecked: false
+    }
+  }
+
+  setControlledChecked = event => {
+    this.setState({ controlledChecked: event.target.checked });
+  };
+
+  render() {
+    return (
+      <PlaygroundSection title="Checkbox">
       <div style={checkboxStyle}>
         <Checkbox
           label="Required"
-          name="tsandcs"
-          value="asd"
           required="You must check this box"
         />
-        <Checkbox label="Not required" name="tsandcs" value="dfdf" />
-        <Checkbox label="Disabled" name="tsandcs" value="hhh" disabled={true} />
-        <Checkbox label="Checked" name="tsandcs" value="werr" checked={true} />
-        <Checkbox name="nolabel" value="somevalue" />
         <Checkbox
-          label="Click me"
-          onHover={logEvent}
-          onChange={logEvent}
-          onFocus={logEvent}
+          label="Disabled"
+          disabled={true}
         />
+        <Checkbox
+          label="Controlled"
+          checked={this.state.controlledChecked}
+          onChange={this.setControlledChecked}
+        />
+        <Checkbox
+          label="Uncontrolled"
+        />
+        <Checkbox
+        label="With event logging"
+        onHover={logEvent}
+        onChange={logEvent}
+        onFocus={logEvent}
+      />
       </div>
     </PlaygroundSection>
   );
+  }
 }
 export default CheckboxSection;

--- a/src/implementations/react/src/react-hig.js
+++ b/src/implementations/react/src/react-hig.js
@@ -1,5 +1,5 @@
 export { default as Button } from './adapters/ButtonAdapter';
-export { default as Checkbox } from './adapters/FormElements/CheckboxAdapter';
+export { default as Checkbox } from './elements/components/FormElements/Checkbox';
 export { default as GlobalNav } from './adapters/GlobalNav/GlobalNavAdapter';
 export { default as IconButton } from './elements/basics/IconButton';
 export { default as Modal } from './elements/components/Modal';

--- a/src/implementations/react/src/stories/index.js
+++ b/src/implementations/react/src/stories/index.js
@@ -3,7 +3,7 @@ import 'hig-vanilla/dist/hig.css';
 
 import '../elements/basics/Button.story';
 import '../elements/basics/IconButton.story';
-import '../adapters/FormElements/CheckboxAdapter.story';
+import '../elements/components/FormElements/Checkbox.story';
 import '../adapters/FormElements/PasswordFieldAdapter.story';
 import '../adapters/FormElements/RangeAdapter.story';
 import '../adapters/FormElements/RadioButtonAdapter.story';

--- a/src/implementations/vanilla/src/basics/form-elements/input-button/input-button.js
+++ b/src/implementations/vanilla/src/basics/form-elements/input-button/input-button.js
@@ -43,11 +43,13 @@ class InputButton extends Core {
 
   check() {
     this._addClass(this._checkedClass());
+    this._setInputAttribute('checked', '');
     this._buttonEl().checked = true;
   }
 
   uncheck() {
     this._removeClass(this._checkedClass());
+    this._removeInputAttribute('checked');
     this._buttonEl().checked = false;
   }
 


### PR DESCRIPTION
This is a fix for #199, "Radiobutton "checked" state does not actually have "checked" attribute in HTML"

It fixes it for both Checkbox and Radiobutton. This also includes a Checkbox component (but not a RadioButton component).   The Checkbox component lets the consumer set the initial "checked" state but right now there is no way for the consumer to change it afterward;  the user will still have to click on the checkbox to change the state. I don't know of a way to allow both things (@nfiniteset ?)

The RadioButton component will be in a different PR.
