### PR TITLE
Allow any HTML/components side of Modal

### DIFF
--- a/src/implementations/react/src/adapters/ModalAdapter.js
+++ b/src/implementations/react/src/adapters/ModalAdapter.js
@@ -3,8 +3,6 @@ import * as PropTypes from 'prop-types';
 import createComponent from './createComponent';
 import HIGElement from '../elements/HIGElement';
 import { ButtonAdapter } from './ButtonAdapter';
-import { Slot } from '../elements/components/GlobalNav/Slot'
-import React from 'react';
 
 class ModalAdapter extends HIGElement {
   constructor(initialProps) {
@@ -37,9 +35,6 @@ class ModalAdapter extends HIGElement {
       this.hig.addButton(button.hig);
       button.componentDidMount();
     });
-
-    console.log(this.props)
-
   }
 
   commitUpdate(updatePayload) {

--- a/src/implementations/react/src/adapters/ModalAdapter.js
+++ b/src/implementations/react/src/adapters/ModalAdapter.js
@@ -3,11 +3,12 @@ import * as PropTypes from 'prop-types';
 import createComponent from './createComponent';
 import HIGElement from '../elements/HIGElement';
 import { ButtonAdapter } from './ButtonAdapter';
+import { Slot } from '../elements/components/GlobalNav/Slot'
+import React from 'react';
 
 class ModalAdapter extends HIGElement {
   constructor(initialProps) {
     super(HIG.Modal, initialProps);
-
     this.buttons = [];
   }
 
@@ -18,6 +19,10 @@ class ModalAdapter extends HIGElement {
 
     if (this.props.buttons) {
       this.commitUpdate(['buttons', this.props.buttons]);
+    }
+
+    if (this.props.slotEl) {
+      this.commitUpdate(['slotEl', this.props.slotEl]);
     }
 
     if (this.props.onOverlayClick) {
@@ -32,6 +37,9 @@ class ModalAdapter extends HIGElement {
       this.hig.addButton(button.hig);
       button.componentDidMount();
     });
+
+    console.log(this.props)
+
   }
 
   commitUpdate(updatePayload) {
@@ -86,6 +94,10 @@ class ModalAdapter extends HIGElement {
           propValue ? this.hig.open() : this.hig.close();
           break;
         }
+        case 'slotEl': {
+          this.hig.addSlot(propValue);
+          break;
+        }
         case 'title': {
           this.hig.setTitle(propValue);
           break;
@@ -126,7 +138,7 @@ ModalAdapterComponent.propTypes = {
   open: PropTypes.bool,
   title: PropTypes.string,
   children: PropTypes.node
-}
+};
 
 ModalAdapterComponent.__docgenInfo = {
   props: {

--- a/src/implementations/react/src/adapters/SpacerAdapter.js
+++ b/src/implementations/react/src/adapters/SpacerAdapter.js
@@ -41,14 +41,6 @@ class SpacerAdapter extends HIGElement {
     }
   }
 
-  addSlot(element) {
-    if (this.mounted) {
-      this.hig.addSlot(element);
-    } else {
-      this.slot = element;
-    }
-  }
-
   insertBefore(instance) {
     this.appendChild(instance);
   }

--- a/src/implementations/react/src/adapters/SpacerAdapter.js
+++ b/src/implementations/react/src/adapters/SpacerAdapter.js
@@ -13,7 +13,7 @@ class SpacerAdapter extends HIGElement {
 
   componentDidMount() {
     if (this.slot) {
-      this.hig.addSlot(this.slot);
+      this.addSlot(this.slot);
     }
   }
 
@@ -38,6 +38,14 @@ class SpacerAdapter extends HIGElement {
         default:
           console.warn('Unknown key, not handled: ', propKey);
       }
+    }
+  }
+
+  addSlot(element) {
+    if (this.mounted) {
+      this.hig.addSlot(element);
+    } else {
+      this.slot = element;
     }
   }
 

--- a/src/implementations/react/src/adapters/SpacerAdapter.story.js
+++ b/src/implementations/react/src/adapters/SpacerAdapter.story.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { text, boolean } from '@storybook/addon-knobs';
+import { text, select } from '@storybook/addon-knobs';
 
 import { default as Spacer } from './SpacerAdapter';
 import {GlobalNav} from '../react-hig';
@@ -18,21 +18,45 @@ const paraStyle = {
   backgroundColor: '#ffffff'
 }
 
+const spanStyle  = {
+  border: '1px solid #ffbbbb',
+  backgroundColor: '#ffbbbb',
+};
+
+
+const typeOptions = { inline: 'inline', stack: 'stack' };
+const sizeOptions = { none: 'none', xxs: 'xxs', xs: 'xs', s: 's', m: 'm', l: 'l', xl: 'xl', xxl: 'xxl'}
 
 storiesOf('Spacer', module)
   .addWithInfo('Basic Spacer', '', () => {
     return (
+      <div>
       <div key='a' style={spacerStyle}>
         <Spacer
-          key="b"
-          type={text('spacer type', 'stack')}
-          width={text('spacer with', 'xs')}
-          inset={text('spacer inset', 'xs')}>
-          <Slot key="dfslkfsdjlk">
+          key="c"
+          type={select('spacer1 type', typeOptions, 'stack')}
+          width={select('spacer1 width', sizeOptions, 'm')}
+          inset={select('spacer1 inset', sizeOptions, 'm')} >
+          <Slot key="foo">
             <p key='1' style={paraStyle} className="spacer_para">STACK M WIDTH</p>
             <p key='2' style={paraStyle} className="spacer_para">STACK XL INSET</p>
           </Slot>
         </Spacer>
+      </div>
+      <div>
+        <Spacer
+          key="d"
+          type={select('spacer2 type', typeOptions, 'inline')}
+          width={select('spacer2 width', sizeOptions, 'm')}
+          inset={select('spacer2 inset', sizeOptions, 'm')}
+        >
+          <Slot key="bar">
+            <span key='1' style={paraStyle} className="spacer_para">STACK M WIDTH</span>
+            <span>&nbsp;</span>
+            <span key='2' style={paraStyle} className="spacer_para">STACK XL INSET</span>
+          </Slot>
+        </Spacer>
+      </div>
       </div>
     );
   });

--- a/src/implementations/react/src/elements/components/Modal.js
+++ b/src/implementations/react/src/elements/components/Modal.js
@@ -3,8 +3,18 @@ import ModalAdapter from '../../adapters/ModalAdapter';
 import * as PropTypes from 'prop-types';
 
 class Modal extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {};
+  }
+
   close = (event) => {
     return this.props.onClose(event);
+  };
+
+  setSlotEl = (el) => {
+    this.setState({ slotEl: el });
   };
 
   render() {
@@ -17,8 +27,9 @@ class Modal extends React.Component {
         onCloseClick={this.close}
         onOverlayClick={this.close}
         title={this.props.title}
+        slotEl={this.state.slotEl}
       >
-        {this.props.children}
+        <div ref={this.setSlotEl}>{this.props.children}</div>
       </ModalAdapter>
     );
   }

--- a/src/implementations/react/src/elements/components/Modal.story.js
+++ b/src/implementations/react/src/elements/components/Modal.story.js
@@ -31,7 +31,6 @@ storiesOf('Modal', module)
           title={'Wait a minute...'}
           headerColor={'Gray'}
           isOpen={boolean("isOpen", true)}
-          body="Here is some stuff"
           buttons={buttonProps}
           onClose={action('onClose')}
         >
@@ -41,4 +40,23 @@ storiesOf('Modal', module)
         </Modal>
       </div>
     );
+  })
+  .addWithInfo('With body text instead of children', ``, () => {
+    const buttonProps = [
+      { title: "I can't", type: 'secondary', onClick: action('No') },
+      { title: 'Yes', type: 'primary', onClick: action('Yes') },
+      { title: 'Literally Yes', type: 'primary', onClick: action('Literally') },
+    ];
+    return (
+      <div>
+        <Modal
+          title={'Just one question'}
+          body="Can you even?"
+          headerColor="Slate"
+          isOpen={boolean("isOpen", true)}
+          buttons={buttonProps}
+          onClose={action('onClose')}
+        >
+        </Modal>
+      </div>)
   });

--- a/src/implementations/react/src/elements/components/Modal.story.js
+++ b/src/implementations/react/src/elements/components/Modal.story.js
@@ -56,7 +56,6 @@ storiesOf('Modal', module)
           isOpen={boolean("isOpen", true)}
           buttons={buttonProps}
           onClose={action('onClose')}
-        >
-        </Modal>
+        />
       </div>)
   });

--- a/src/implementations/react/src/playground/sections/ModalSection.js
+++ b/src/implementations/react/src/playground/sections/ModalSection.js
@@ -31,11 +31,12 @@ class ModalSection extends Component {
           title="Are you sure?"
           isOpen={this.state.isOpen}
           buttons={buttonProps}
-          body="This is the body of my modal"
+          body="This is the text body of my modal"
           headerColor="gray"
           onClose={this.closeModal}
         >
-          <h1>This is my modal content</h1>
+          <h1><u>This is my HTML title</u></h1>
+          <p><i>This is my HTML content.</i></p>
         </Modal>
       </PlaygroundSection>
     )


### PR DESCRIPTION
#252 This lets you put HTML/React component content inside of Modal:
```
    const buttonProps = [
      { title: 'Cancel', type: 'secondary', onClick: this.closeModal },
      { title: 'Ok', onClick: this.closeModal }
    ];
...
    return (
      <PlaygroundSection title="Modal">
        <Button title="Open modal" onClick={this.openModal} />
        <Modal
          title="Are you sure?"
          isOpen={this.state.isOpen}
          buttons={buttonProps}
          body="This is the text body of my modal"
          headerColor="gray"
          onClose={this.closeModal}
        >
          <h1><u>This is my HTML title</u></h1>
          <p><i>This is my HTML content.</i></p>
        </Modal>
      </PlaygroundSection>
    );
```
![screen shot 2017-08-17 at 5 40 30 pm](https://user-images.githubusercontent.com/502640/29439550-3919b72a-8373-11e7-90aa-a40778f37a85.png)
