### PR TITLE
Resolve ES5 compatibility bug in static table test

### DIFF
--- a/src/implementations/vanilla/src/components/table/tests/tests-table.html
+++ b/src/implementations/vanilla/src/components/table/tests/tests-table.html
@@ -400,7 +400,7 @@
       TableHead.addCell(BudgetHeadCell1);
 
       var SlotEl1 = document.createElement('div');
-      SlotEl1.innerHTML = `Raw denim flexitarian green juice kinfolk.`
+      SlotEl1.innerHTML = 'Raw denim flexitarian green juice kinfolk.'
       var SlotHeadCell1 = new TableHead.partials.SlotHeadCell({
         width: "2fr"
       });
@@ -413,7 +413,7 @@
       DefaultTable.addTableRow(TableRowDefault1);
 
       var TextCellDefault1 = new TableRowDefault1.partials.TextCell({
-        "text": 'Window Punch List', "alignment": "left", 
+        "text": 'Window Punch List', "alignment": "left",
       });
       TableRowDefault1.addCell(TextCellDefault1);
 
@@ -427,7 +427,7 @@
       var SlotCell1 = new TableRowDefault1.partials.SlotCell();
       TableRowDefault1.addCell(SlotCell1);
       var NewSlotEl1 = document.createElement('div');
-      NewSlotEl1.innerHTML = `Floor 3, Room 21.`;
+      NewSlotEl1.innerHTML = 'Floor 3, Room 21.';
       SlotCell1.addSlot(NewSlotEl1);
 
       var BudgetTextCellDefault1 = new TableRowDefault1.partials.TextCell({
@@ -451,7 +451,7 @@
       NewSlotEl2.style.display = 'flex';
       NewSlotEl2.style.alignItems = 'center';
       NewSlotEl2.style.justifyContent = 'center';
-      NewSlotEl2.innerHTML = `<img src="./images/table-image.png" style="width: 104px; height: 58px;">`;
+      NewSlotEl2.innerHTML = '<img src="./images/table-image.png" style="width: 104px; height: 58px;">';
       SlotCell2.addSlot(NewSlotEl2);
 
       var TextCellDefault2 = new TableRowDefault2.partials.TextCell({
@@ -469,7 +469,7 @@
       var SlotCell2 = new TableRowDefault2.partials.SlotCell();
       TableRowDefault2.addCell(SlotCell2);
       var NewSlotEl2 = document.createElement('div');
-      NewSlotEl2.innerHTML = `Floor 3, Room 21.`;
+      NewSlotEl2.innerHTML = 'Floor 3, Room 21.';
       SlotCell2.addSlot(NewSlotEl2);
 
       var BudgetTextCellDefault2 = new TableRowDefault2.partials.TextCell({


### PR DESCRIPTION
Story: https://github.com/Autodesk/hig/issues/237

Replaces backticks with quotes in order to maintain ES5 compatibility in the static table test.  This allows the page to build in IE11

http://calm-cream.surge.sh/src/components/table/tests/tests-table.html

<img width="1327" alt="screen shot 2017-08-23 at 4 22 52 pm" src="https://user-images.githubusercontent.com/140873/29636649-6c00581e-881f-11e7-8855-db814555cc48.png">
