### PR TITLE
Add slot to side nav

### DIFF
--- a/src/implementations/react/package-lock.json
+++ b/src/implementations/react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hig-react",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/implementations/react/package.json
+++ b/src/implementations/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hig-react",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "hig components in react",
   "main": "lib/hig-react.js",
   "css": "lib/hig-react.css",

--- a/src/implementations/react/src/adapters/GlobalNav/GlobalNavAdapter.js
+++ b/src/implementations/react/src/adapters/GlobalNav/GlobalNavAdapter.js
@@ -10,7 +10,7 @@ import SideNavAdapterComponent, {
 } from "./SideNav/SideNavAdapter";
 import TopNavAdapterComponent, { TopNavAdapter } from "./TopNav/TopNavAdapter";
 import SubNavAdapterComponent, { SubNavAdapter } from "./SubNav/SubNavAdapter";
-import Slot from "../../elements/components/GlobalNav/Slot";
+import Slot from "../SlotAdapter";
 import SideNav from "../../elements/components/GlobalNav/SideNav";
 
 class GlobalNavAdapter extends HIGElement {

--- a/src/implementations/react/src/adapters/GlobalNav/SideNav/SideNavAdapter.js
+++ b/src/implementations/react/src/adapters/GlobalNav/SideNav/SideNavAdapter.js
@@ -9,6 +9,7 @@ import GroupComponent, { GroupAdapter } from "./GroupAdapter";
 import LinkComponent, { LinkAdapter } from "./LinkAdapter";
 import SearchComponent, { SearchAdapter } from "./SearchAdapter";
 import Search from '../../../elements/components/GlobalNav/SideNav/Search';
+import Slot from '../../SlotAdapter';
 
 export class SideNavAdapter extends HIGElement {
   constructor(HIGConstructor, initialProps) {
@@ -66,6 +67,10 @@ export class SideNavAdapter extends HIGElement {
 
     if (this.props.onSuperHeaderClick) {
       this.commitUpdate(["onSuperHeaderClick", this.props.onSuperHeaderClick]);
+    }
+
+    if (this.slot) {
+      this.hig.addSlot(this.slot);
     }
   }
 
@@ -171,6 +176,14 @@ export class SideNavAdapter extends HIGElement {
     }
   }
 
+  addSlot(element) {
+    if (this.mounted) {
+      this.hig.addSlot(element);
+    } else {
+      this.slot = element;
+    }
+  }
+
   removeChild(instance) {
     if (instance instanceof GroupAdapter) {
       this.groups.removeChild(instance);
@@ -191,7 +204,7 @@ export class SideNavAdapter extends HIGElement {
 const SideNavComponent = createComponent(SideNavAdapter);
 
 SideNavComponent.propTypes = {
-  children: HIGChildValidator([GroupComponent, LinkComponent, SearchComponent, Search]),
+  children: HIGChildValidator([GroupComponent, LinkComponent, SearchComponent, Search, Slot]),
   copyright: PropTypes.string,
   headerLabel: PropTypes.string,
   headerLink: PropTypes.string,

--- a/src/implementations/react/src/adapters/GlobalNav/SideNav/SideNavAdapter.test.js
+++ b/src/implementations/react/src/adapters/GlobalNav/SideNav/SideNavAdapter.test.js
@@ -8,6 +8,7 @@ import Search from './SearchAdapter';
 import Group from './GroupAdapter';
 import Module from './ModuleAdapter';
 import Submodule from './SubmoduleAdapter';
+import Slot from '../../SlotAdapter';
 
 describe('<SideNav>', () => {
   function createHigComponent(defaults = {}) {
@@ -99,7 +100,7 @@ describe('<SideNav>', () => {
     );
   });
 
-  describe('<SideNav> with search', () => {
+  describe('with search', () => {
     const Context = props => {
       return (
         <GlobalNav>
@@ -131,6 +132,39 @@ describe('<SideNav>', () => {
         submoduleTitle1: 'Document',
         submoduleTitle2: 'Workflow'
       };
+      const { reactContainer } = setupReactContext(props);
+      expect(reactContainer.firstChild.outerHTML).toMatchSnapshot();
+    });
+  });
+
+  describe('with slot content', () => {
+    const Context = props => {
+      return (
+        <GlobalNav>
+          <SideNav>
+            <Group>
+              <Module title={props.moduleTitle} icon="assets">
+                <Submodule title={props.submoduleTitle1} icon="assets" />
+                <Submodule title={props.submoduleTitle2} icon="assets" />
+              </Module>
+            </Group>
+            <Slot>
+              <h1>Hello, world!</h1>
+            </Slot>
+            <Search query={props.query} />
+          </SideNav>
+        </GlobalNav>
+      );
+    };
+
+    function setupReactContext(props) {
+      const reactContainer = document.createElement('div');
+      mount(<Context {...props} />, { attachTo: reactContainer });
+      return { reactContainer };
+    }
+
+    it('renders children correctly', () => {
+      const props = {};
       const { reactContainer } = setupReactContext(props);
       expect(reactContainer.firstChild.outerHTML).toMatchSnapshot();
     });

--- a/src/implementations/react/src/adapters/GlobalNav/SideNav/__snapshots__/GroupAdapter.test.js.snap
+++ b/src/implementations/react/src/adapters/GlobalNav/SideNav/__snapshots__/GroupAdapter.test.js.snap
@@ -26,6 +26,7 @@ exports[`<Group> children: <Module> can insert <Module> elements before and afte
 </div><!--MODULE-->
 </div><!--GROUP-->
     </div>
+    <!--SLOT-->
     <div class=\\"hig__global-nav__sidenav__links\\">
       <!--LINK-->
     </div>
@@ -80,6 +81,7 @@ exports[`<Group> children: <Module> can insert <Module> elements before and afte
 </div><!--MODULE-->
 </div><!--GROUP-->
     </div>
+    <!--SLOT-->
     <div class=\\"hig__global-nav__sidenav__links\\">
       <!--LINK-->
     </div>
@@ -123,6 +125,7 @@ exports[`<Group> children: <Module> can insert <Module> elements before and afte
 </div><!--MODULE-->
 </div><!--GROUP-->
     </div>
+    <!--SLOT-->
     <div class=\\"hig__global-nav__sidenav__links\\">
       <!--LINK-->
     </div>
@@ -177,6 +180,7 @@ exports[`<Group> children: <Module> can insert <Module> elements before and afte
 </div><!--MODULE-->
 </div><!--GROUP-->
     </div>
+    <!--SLOT-->
     <div class=\\"hig__global-nav__sidenav__links\\">
       <!--LINK-->
     </div>
@@ -220,6 +224,7 @@ exports[`<Group> children: <Module> can insert <Module> elements before and afte
 </div><!--MODULE-->
 </div><!--GROUP-->
     </div>
+    <!--SLOT-->
     <div class=\\"hig__global-nav__sidenav__links\\">
       <!--LINK-->
     </div>
@@ -274,6 +279,7 @@ exports[`<Group> children: <Module> can render a list of <Module> elements 1`] =
 </div><!--MODULE-->
 </div><!--GROUP-->
     </div>
+    <!--SLOT-->
     <div class=\\"hig__global-nav__sidenav__links\\">
       <!--LINK-->
     </div>

--- a/src/implementations/react/src/adapters/GlobalNav/SideNav/__snapshots__/LinkAdapter.test.js.snap
+++ b/src/implementations/react/src/adapters/GlobalNav/SideNav/__snapshots__/LinkAdapter.test.js.snap
@@ -13,6 +13,7 @@ exports[`<LinkAdapter> renders 1`] = `
     <div class=\\"hig__global-nav__sidenav__groups\\">
       <!--GROUP-->
     </div>
+    <!--SLOT-->
     <div class=\\"hig__global-nav__sidenav__links\\">
       <a class=\\"hig__global-nav__sidenav__links__link\\" href=\\"#\\">link</a><!--LINK-->
     </div>
@@ -43,6 +44,7 @@ exports[`<LinkAdapter> renders with initial props 1`] = `
     <div class=\\"hig__global-nav__sidenav__groups\\">
       <!--GROUP-->
     </div>
+    <!--SLOT-->
     <div class=\\"hig__global-nav__sidenav__links\\">
       <a class=\\"hig__global-nav__sidenav__links__link\\" href=\\"https://a-website.com\\">A title</a><!--LINK-->
     </div>
@@ -73,6 +75,7 @@ exports[`<LinkAdapter> renders with updated props 1`] = `
     <div class=\\"hig__global-nav__sidenav__groups\\">
       <!--GROUP-->
     </div>
+    <!--SLOT-->
     <div class=\\"hig__global-nav__sidenav__links\\">
       <a class=\\"hig__global-nav__sidenav__links__link\\" href=\\"https://a-website.com\\">A title</a><!--LINK-->
     </div>

--- a/src/implementations/react/src/adapters/GlobalNav/SideNav/__snapshots__/ModuleCollapseAdapter.test.js.snap
+++ b/src/implementations/react/src/adapters/GlobalNav/SideNav/__snapshots__/ModuleCollapseAdapter.test.js.snap
@@ -26,6 +26,7 @@ exports[`<ModuleCollapseAdapter> renders 1`] = `
 </div><!--MODULE-->
 </div><!--GROUP-->
     </div>
+    <!--SLOT-->
     <div class=\\"hig__global-nav__sidenav__links\\">
       <!--LINK-->
     </div>
@@ -69,6 +70,7 @@ exports[`<ModuleCollapseAdapter> renders with updated props 1`] = `
 </div><!--MODULE-->
 </div><!--GROUP-->
     </div>
+    <!--SLOT-->
     <div class=\\"hig__global-nav__sidenav__links\\">
       <!--LINK-->
     </div>

--- a/src/implementations/react/src/adapters/GlobalNav/SideNav/__snapshots__/SearchAdapter.test.js.snap
+++ b/src/implementations/react/src/adapters/GlobalNav/SideNav/__snapshots__/SearchAdapter.test.js.snap
@@ -13,6 +13,7 @@ exports[`<SearchAdapter> renders 1`] = `
     <div class=\\"hig__global-nav__sidenav__groups\\">
       <!--GROUP-->
     </div>
+    <!--SLOT-->
     <div class=\\"hig__global-nav__sidenav__links\\">
       <!--LINK-->
     </div>
@@ -47,6 +48,7 @@ exports[`<SearchAdapter> renders with initial props 1`] = `
     <div class=\\"hig__global-nav__sidenav__groups\\">
       <!--GROUP-->
     </div>
+    <!--SLOT-->
     <div class=\\"hig__global-nav__sidenav__links\\">
       <!--LINK-->
     </div>
@@ -81,6 +83,7 @@ exports[`<SearchAdapter> renders with updated props 1`] = `
     <div class=\\"hig__global-nav__sidenav__groups\\">
       <!--GROUP-->
     </div>
+    <!--SLOT-->
     <div class=\\"hig__global-nav__sidenav__links\\">
       <!--LINK-->
     </div>

--- a/src/implementations/react/src/adapters/GlobalNav/SideNav/__snapshots__/SideNavAdapter.test.js.snap
+++ b/src/implementations/react/src/adapters/GlobalNav/SideNav/__snapshots__/SideNavAdapter.test.js.snap
@@ -1,56 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<SideNav> <SideNav> with search renders children correctly 1`] = `
-"<div class=\\"hig__global-nav\\">
-    <div class=\\"hig__global-nav__sidenav\\">
-  <div class=\\"hig__global-nav__sidenav__scroll hig__global-nav__sidenav__scroll--search\\">
-    <h3 class=\\"hig__global-nav__sidenav__super-header\\">
-      <a class=\\"hig__global-nav__sidenav__super-header-link\\"></a>
-    </h3>
-    <h4 class=\\"hig__global-nav__sidenav__header\\">
-      <a class=\\"hig__global-nav__sidenav__header-link\\"></a>
-    </h4>
-    <div class=\\"hig__global-nav__sidenav__groups\\">
-      <div class=\\"hig__global-nav__side-nav__section__group\\">
-    <div class=\\"hig__global-nav__side-nav__section__group__module\\">
-  <div class=\\"hig__global-nav__side-nav__section__group__module__row\\">
-    <a class=\\"hig__global-nav__side-nav__section__group__module__link\\" href=\\"#\\">
-      <div class=\\"hig__global-nav__side-nav__section__group__module__link__icon\\"><div class=\\"hig__icon\\"><svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\" xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" title=\\"assets\\"><title>hig-light/globalnav/sidenav/icon/assets</title><g fill=\\"#221F20\\" fill-rule=\\"evenodd\\"><path d=\\"M10.1898101,0.916614844 L9.67284723,8.01491201 L9.15588441,0.916614844 C9.15588441,0.916614844 7.37499587,-0.81644658 2.12744709,0.48294645 L2.12744709,12.0829042 C2.12744709,12.0829042 6.89296297,11.6014087 8.33744951,12.3725539 C8.33744951,12.3725539 8.29284669,12.9427177 9.66048741,12.950241 L9.67284723,12.950241 L9.68574443,12.950241 C11.0528478,12.9427177 11.0082449,12.3725539 11.0082449,12.3725539 C12.4527315,11.6014087 17.2182474,12.0829042 17.2182474,12.0829042 L17.2182474,0.48294645 C11.9706986,-0.81644658 10.1898101,0.916614844 10.1898101,0.916614844\\" transform=\\"translate(2.327 4.245)\\"></path><path d=\\"M0.91156344,2.55923464 L0.885231654,13.9028606 L0.455862327,13.4729539 L7.29245378,13.4192155 C7.34887904,13.421365 7.39186971,13.4697296 7.38972017,13.52508 C7.38649587,13.5777436 7.3435052,13.6196595 7.29245378,13.6218091 L0.455862327,14.3333047 C0.229623921,14.3440523 0.0372406687,14.1694027 0.0270303844,13.9442391 L0.0259556176,13.925968 L0.0259556176,13.9028606 L0.000161215016,2.55923464 C-0.000376168371,2.3082766 0.203292135,2.10353353 0.453712794,2.10245876 C0.705745602,2.101384 0.911026056,2.30612707 0.91156344,2.55708511 L0.91156344,2.55923464 Z\\" transform=\\"translate(2.327 4.245)\\"></path><path d=\\"M19.3458019,2.55923464 L19.3200075,13.9028606 L19.3200075,13.9248933 C19.3183954,14.1516691 19.1351477,14.3343794 18.9089092,14.3343794 L18.8895634,14.3333047 L12.0535094,13.6218091 C11.9970841,13.6196595 11.9540934,13.571295 11.956243,13.5159445 C11.9594673,13.463281 12.002458,13.421365 12.0535094,13.4192155 L18.8895634,13.4729539 L18.4607315,13.9028606 L18.4343997,2.55923464 C18.4333249,2.3082766 18.6375306,2.10353353 18.8879513,2.10245876 C19.1405215,2.101384 19.3452646,2.30612707 19.3458019,2.55708511 L19.3458019,2.55923464 Z\\" transform=\\"translate(2.327 4.245)\\"></path></g></svg></div></div>
-      <div class=\\"hig__global-nav__side-nav__section__group__module__link__title\\">Document Workflow</div>
-    </a>
-    <!--MODULE-COLLAPSE-->
-  </div>
-  <div class=\\"hig__global-nav__side-nav__section__group__module__submodules \\">
-    <a class=\\"hig__global-nav__side-nav__section__group__module__submodule\\" href=\\"\\">
-  Document
-</a><a class=\\"hig__global-nav__side-nav__section__group__module__submodule\\" href=\\"\\">
-  Workflow
-</a><!--SUBMODULE-->
-  </div>
-</div><!--MODULE-->
-</div><!--GROUP-->
-    </div>
-    <div class=\\"hig__global-nav__sidenav__links\\">
-      <!--LINK-->
-    </div>
-    <div class=\\"hig__global-nav__sidenav__copyright\\">© 2017 Autodesk, Inc.</div>
-  </div>
-  <div class=\\"hig__global-nav__side-nav__search\\">
-    <div class=\\"hig__global-nav__side-nav__search__icon\\"><div class=\\"hig__icon\\"><svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\" xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" title=\\"search-small\\"><title>hig/icon/search-small</title><path d=\\"M15.8702459,15.1631391 L18.9748737,18.267767 C19.1701359,18.4630291 19.1701359,18.7796116 18.9748737,18.9748737 C18.7796116,19.1701359 18.4630291,19.1701359 18.267767,18.9748737 L15.2403215,15.9474283 C14.0545271,17.2108151 12.3694256,18 10.5,18 C6.91014913,18 4,15.0898509 4,11.5 C4,7.91014913 6.91014913,5 10.5,5 C14.0898509,5 17,7.91014913 17,11.5 C17,12.8587306 16.5831026,14.1200897 15.8702459,15.1631391 Z M16,11.5 C16,8.46243388 13.5375661,6 10.5,6 C7.46243388,6 5,8.46243388 5,11.5 C5,14.5375661 7.46243388,17 10.5,17 C13.5375661,17 16,14.5375661 16,11.5 Z\\" fill=\\"#353636\\" fill-rule=\\"evenodd\\"></path></svg></div></div>
-    <div class=\\"hig__global-nav__side-nav__search__inputholder\\"><input class=\\"hig__global-nav__side-nav__search__inputholder__input\\" type=\\"text\\" placeholder=\\"Search\\" value=\\"\\"></div>
-    <div class=\\"hig__global-nav__side-nav__search__clear\\"><div class=\\"hig__icon\\"><svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\" xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" title=\\"close-small\\"><title>hig/icon/close-small</title><g fill=\\"none\\" fill-rule=\\"evenodd\\"><circle stroke=\\"#353636\\" cx=\\"12\\" cy=\\"12\\" r=\\"8\\"></circle><polygon fill=\\"#353636\\" transform=\\"rotate(45 12 12)\\" points=\\"16.5 11.4518414 12.5847458 11.4518414 12.5847458 7.5 11.4152542 7.5 11.4152542 11.4518414 7.5 11.4518414 7.5 12.5226629 11.4152542 12.5226629 11.4152542 16.5 12.5847458 16.5 12.5847458 12.5226629 16.5 12.5226629\\"></polygon></g></svg></div></div>
-</div><!--SEARCH-->
-</div><!--SIDENAV-->
-    <div class=\\"hig__global-nav__container\\">
-        <!--TOPNAV-->
-        <!--SUBNAV-->
-        <div class=\\"hig__global-nav__slot\\">
-            <!--SLOT-->
-        </div>
-    </div>
-</div>"
-`;
-
 exports[`<SideNav> renders when configured with defaults 1`] = `
 "<div class=\\"hig__global-nav\\">
     <div class=\\"hig__global-nav__sidenav\\">
@@ -64,6 +13,7 @@ exports[`<SideNav> renders when configured with defaults 1`] = `
     <div class=\\"hig__global-nav__sidenav__groups\\">
       <!--GROUP-->
     </div>
+    <!--SLOT-->
     <div class=\\"hig__global-nav__sidenav__links\\">
       <!--LINK-->
     </div>
@@ -94,6 +44,7 @@ exports[`<SideNav> renders when configured with updated props 1`] = `
     <div class=\\"hig__global-nav__sidenav__groups\\">
       <!--GROUP-->
     </div>
+    <!--SLOT-->
     <div class=\\"hig__global-nav__sidenav__links\\">
       <!--LINK-->
     </div>
@@ -124,12 +75,117 @@ exports[`<SideNav> renders without defaults 1`] = `
     <div class=\\"hig__global-nav__sidenav__groups\\">
       <!--GROUP-->
     </div>
+    <!--SLOT-->
     <div class=\\"hig__global-nav__sidenav__links\\">
       <!--LINK-->
     </div>
     <div class=\\"hig__global-nav__sidenav__copyright\\">© 2017 Autodesk, Inc.</div>
   </div>
   <!--SEARCH-->
+</div><!--SIDENAV-->
+    <div class=\\"hig__global-nav__container\\">
+        <!--TOPNAV-->
+        <!--SUBNAV-->
+        <div class=\\"hig__global-nav__slot\\">
+            <!--SLOT-->
+        </div>
+    </div>
+</div>"
+`;
+
+exports[`<SideNav> with search renders children correctly 1`] = `
+"<div class=\\"hig__global-nav\\">
+    <div class=\\"hig__global-nav__sidenav\\">
+  <div class=\\"hig__global-nav__sidenav__scroll hig__global-nav__sidenav__scroll--search\\">
+    <h3 class=\\"hig__global-nav__sidenav__super-header\\">
+      <a class=\\"hig__global-nav__sidenav__super-header-link\\"></a>
+    </h3>
+    <h4 class=\\"hig__global-nav__sidenav__header\\">
+      <a class=\\"hig__global-nav__sidenav__header-link\\"></a>
+    </h4>
+    <div class=\\"hig__global-nav__sidenav__groups\\">
+      <div class=\\"hig__global-nav__side-nav__section__group\\">
+    <div class=\\"hig__global-nav__side-nav__section__group__module\\">
+  <div class=\\"hig__global-nav__side-nav__section__group__module__row\\">
+    <a class=\\"hig__global-nav__side-nav__section__group__module__link\\" href=\\"#\\">
+      <div class=\\"hig__global-nav__side-nav__section__group__module__link__icon\\"><div class=\\"hig__icon\\"><svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\" xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" title=\\"assets\\"><title>hig-light/globalnav/sidenav/icon/assets</title><g fill=\\"#221F20\\" fill-rule=\\"evenodd\\"><path d=\\"M10.1898101,0.916614844 L9.67284723,8.01491201 L9.15588441,0.916614844 C9.15588441,0.916614844 7.37499587,-0.81644658 2.12744709,0.48294645 L2.12744709,12.0829042 C2.12744709,12.0829042 6.89296297,11.6014087 8.33744951,12.3725539 C8.33744951,12.3725539 8.29284669,12.9427177 9.66048741,12.950241 L9.67284723,12.950241 L9.68574443,12.950241 C11.0528478,12.9427177 11.0082449,12.3725539 11.0082449,12.3725539 C12.4527315,11.6014087 17.2182474,12.0829042 17.2182474,12.0829042 L17.2182474,0.48294645 C11.9706986,-0.81644658 10.1898101,0.916614844 10.1898101,0.916614844\\" transform=\\"translate(2.327 4.245)\\"></path><path d=\\"M0.91156344,2.55923464 L0.885231654,13.9028606 L0.455862327,13.4729539 L7.29245378,13.4192155 C7.34887904,13.421365 7.39186971,13.4697296 7.38972017,13.52508 C7.38649587,13.5777436 7.3435052,13.6196595 7.29245378,13.6218091 L0.455862327,14.3333047 C0.229623921,14.3440523 0.0372406687,14.1694027 0.0270303844,13.9442391 L0.0259556176,13.925968 L0.0259556176,13.9028606 L0.000161215016,2.55923464 C-0.000376168371,2.3082766 0.203292135,2.10353353 0.453712794,2.10245876 C0.705745602,2.101384 0.911026056,2.30612707 0.91156344,2.55708511 L0.91156344,2.55923464 Z\\" transform=\\"translate(2.327 4.245)\\"></path><path d=\\"M19.3458019,2.55923464 L19.3200075,13.9028606 L19.3200075,13.9248933 C19.3183954,14.1516691 19.1351477,14.3343794 18.9089092,14.3343794 L18.8895634,14.3333047 L12.0535094,13.6218091 C11.9970841,13.6196595 11.9540934,13.571295 11.956243,13.5159445 C11.9594673,13.463281 12.002458,13.421365 12.0535094,13.4192155 L18.8895634,13.4729539 L18.4607315,13.9028606 L18.4343997,2.55923464 C18.4333249,2.3082766 18.6375306,2.10353353 18.8879513,2.10245876 C19.1405215,2.101384 19.3452646,2.30612707 19.3458019,2.55708511 L19.3458019,2.55923464 Z\\" transform=\\"translate(2.327 4.245)\\"></path></g></svg></div></div>
+      <div class=\\"hig__global-nav__side-nav__section__group__module__link__title\\">Document Workflow</div>
+    </a>
+    <!--MODULE-COLLAPSE-->
+  </div>
+  <div class=\\"hig__global-nav__side-nav__section__group__module__submodules \\">
+    <a class=\\"hig__global-nav__side-nav__section__group__module__submodule\\" href=\\"\\">
+  Document
+</a><a class=\\"hig__global-nav__side-nav__section__group__module__submodule\\" href=\\"\\">
+  Workflow
+</a><!--SUBMODULE-->
+  </div>
+</div><!--MODULE-->
+</div><!--GROUP-->
+    </div>
+    <!--SLOT-->
+    <div class=\\"hig__global-nav__sidenav__links\\">
+      <!--LINK-->
+    </div>
+    <div class=\\"hig__global-nav__sidenav__copyright\\">© 2017 Autodesk, Inc.</div>
+  </div>
+  <div class=\\"hig__global-nav__side-nav__search\\">
+    <div class=\\"hig__global-nav__side-nav__search__icon\\"><div class=\\"hig__icon\\"><svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\" xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" title=\\"search-small\\"><title>hig/icon/search-small</title><path d=\\"M15.8702459,15.1631391 L18.9748737,18.267767 C19.1701359,18.4630291 19.1701359,18.7796116 18.9748737,18.9748737 C18.7796116,19.1701359 18.4630291,19.1701359 18.267767,18.9748737 L15.2403215,15.9474283 C14.0545271,17.2108151 12.3694256,18 10.5,18 C6.91014913,18 4,15.0898509 4,11.5 C4,7.91014913 6.91014913,5 10.5,5 C14.0898509,5 17,7.91014913 17,11.5 C17,12.8587306 16.5831026,14.1200897 15.8702459,15.1631391 Z M16,11.5 C16,8.46243388 13.5375661,6 10.5,6 C7.46243388,6 5,8.46243388 5,11.5 C5,14.5375661 7.46243388,17 10.5,17 C13.5375661,17 16,14.5375661 16,11.5 Z\\" fill=\\"#353636\\" fill-rule=\\"evenodd\\"></path></svg></div></div>
+    <div class=\\"hig__global-nav__side-nav__search__inputholder\\"><input class=\\"hig__global-nav__side-nav__search__inputholder__input\\" type=\\"text\\" placeholder=\\"Search\\" value=\\"\\"></div>
+    <div class=\\"hig__global-nav__side-nav__search__clear\\"><div class=\\"hig__icon\\"><svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\" xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" title=\\"close-small\\"><title>hig/icon/close-small</title><g fill=\\"none\\" fill-rule=\\"evenodd\\"><circle stroke=\\"#353636\\" cx=\\"12\\" cy=\\"12\\" r=\\"8\\"></circle><polygon fill=\\"#353636\\" transform=\\"rotate(45 12 12)\\" points=\\"16.5 11.4518414 12.5847458 11.4518414 12.5847458 7.5 11.4152542 7.5 11.4152542 11.4518414 7.5 11.4518414 7.5 12.5226629 11.4152542 12.5226629 11.4152542 16.5 12.5847458 16.5 12.5847458 12.5226629 16.5 12.5226629\\"></polygon></g></svg></div></div>
+</div><!--SEARCH-->
+</div><!--SIDENAV-->
+    <div class=\\"hig__global-nav__container\\">
+        <!--TOPNAV-->
+        <!--SUBNAV-->
+        <div class=\\"hig__global-nav__slot\\">
+            <!--SLOT-->
+        </div>
+    </div>
+</div>"
+`;
+
+exports[`<SideNav> with slot content renders children correctly 1`] = `
+"<div class=\\"hig__global-nav\\">
+    <div class=\\"hig__global-nav__sidenav\\">
+  <div class=\\"hig__global-nav__sidenav__scroll hig__global-nav__sidenav__scroll--search\\">
+    <h3 class=\\"hig__global-nav__sidenav__super-header\\">
+      <a class=\\"hig__global-nav__sidenav__super-header-link\\"></a>
+    </h3>
+    <h4 class=\\"hig__global-nav__sidenav__header\\">
+      <a class=\\"hig__global-nav__sidenav__header-link\\"></a>
+    </h4>
+    <div class=\\"hig__global-nav__sidenav__groups\\">
+      <div class=\\"hig__global-nav__side-nav__section__group\\">
+    <div class=\\"hig__global-nav__side-nav__section__group__module\\">
+  <div class=\\"hig__global-nav__side-nav__section__group__module__row\\">
+    <a class=\\"hig__global-nav__side-nav__section__group__module__link\\" href=\\"#\\">
+      <div class=\\"hig__global-nav__side-nav__section__group__module__link__icon\\"><div class=\\"hig__icon\\"><svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\" xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" title=\\"assets\\"><title>hig-light/globalnav/sidenav/icon/assets</title><g fill=\\"#221F20\\" fill-rule=\\"evenodd\\"><path d=\\"M10.1898101,0.916614844 L9.67284723,8.01491201 L9.15588441,0.916614844 C9.15588441,0.916614844 7.37499587,-0.81644658 2.12744709,0.48294645 L2.12744709,12.0829042 C2.12744709,12.0829042 6.89296297,11.6014087 8.33744951,12.3725539 C8.33744951,12.3725539 8.29284669,12.9427177 9.66048741,12.950241 L9.67284723,12.950241 L9.68574443,12.950241 C11.0528478,12.9427177 11.0082449,12.3725539 11.0082449,12.3725539 C12.4527315,11.6014087 17.2182474,12.0829042 17.2182474,12.0829042 L17.2182474,0.48294645 C11.9706986,-0.81644658 10.1898101,0.916614844 10.1898101,0.916614844\\" transform=\\"translate(2.327 4.245)\\"></path><path d=\\"M0.91156344,2.55923464 L0.885231654,13.9028606 L0.455862327,13.4729539 L7.29245378,13.4192155 C7.34887904,13.421365 7.39186971,13.4697296 7.38972017,13.52508 C7.38649587,13.5777436 7.3435052,13.6196595 7.29245378,13.6218091 L0.455862327,14.3333047 C0.229623921,14.3440523 0.0372406687,14.1694027 0.0270303844,13.9442391 L0.0259556176,13.925968 L0.0259556176,13.9028606 L0.000161215016,2.55923464 C-0.000376168371,2.3082766 0.203292135,2.10353353 0.453712794,2.10245876 C0.705745602,2.101384 0.911026056,2.30612707 0.91156344,2.55708511 L0.91156344,2.55923464 Z\\" transform=\\"translate(2.327 4.245)\\"></path><path d=\\"M19.3458019,2.55923464 L19.3200075,13.9028606 L19.3200075,13.9248933 C19.3183954,14.1516691 19.1351477,14.3343794 18.9089092,14.3343794 L18.8895634,14.3333047 L12.0535094,13.6218091 C11.9970841,13.6196595 11.9540934,13.571295 11.956243,13.5159445 C11.9594673,13.463281 12.002458,13.421365 12.0535094,13.4192155 L18.8895634,13.4729539 L18.4607315,13.9028606 L18.4343997,2.55923464 C18.4333249,2.3082766 18.6375306,2.10353353 18.8879513,2.10245876 C19.1405215,2.101384 19.3452646,2.30612707 19.3458019,2.55708511 L19.3458019,2.55923464 Z\\" transform=\\"translate(2.327 4.245)\\"></path></g></svg></div></div>
+      <div class=\\"hig__global-nav__side-nav__section__group__module__link__title\\">title</div>
+    </a>
+    <!--MODULE-COLLAPSE-->
+  </div>
+  <div class=\\"hig__global-nav__side-nav__section__group__module__submodules \\">
+    <a class=\\"hig__global-nav__side-nav__section__group__module__submodule\\" href=\\"\\">
+  
+</a><a class=\\"hig__global-nav__side-nav__section__group__module__submodule\\" href=\\"\\">
+  
+</a><!--SUBMODULE-->
+  </div>
+</div><!--MODULE-->
+</div><!--GROUP-->
+    </div>
+    <div class=\\"hig__side-nav__slot\\"><div><h1>Hello, world!</h1></div></div><!--SLOT-->
+    <div class=\\"hig__global-nav__sidenav__links\\">
+      <!--LINK-->
+    </div>
+    <div class=\\"hig__global-nav__sidenav__copyright\\">© 2017 Autodesk, Inc.</div>
+  </div>
+  <div class=\\"hig__global-nav__side-nav__search\\">
+    <div class=\\"hig__global-nav__side-nav__search__icon\\"><div class=\\"hig__icon\\"><svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\" xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" title=\\"search-small\\"><title>hig/icon/search-small</title><path d=\\"M15.8702459,15.1631391 L18.9748737,18.267767 C19.1701359,18.4630291 19.1701359,18.7796116 18.9748737,18.9748737 C18.7796116,19.1701359 18.4630291,19.1701359 18.267767,18.9748737 L15.2403215,15.9474283 C14.0545271,17.2108151 12.3694256,18 10.5,18 C6.91014913,18 4,15.0898509 4,11.5 C4,7.91014913 6.91014913,5 10.5,5 C14.0898509,5 17,7.91014913 17,11.5 C17,12.8587306 16.5831026,14.1200897 15.8702459,15.1631391 Z M16,11.5 C16,8.46243388 13.5375661,6 10.5,6 C7.46243388,6 5,8.46243388 5,11.5 C5,14.5375661 7.46243388,17 10.5,17 C13.5375661,17 16,14.5375661 16,11.5 Z\\" fill=\\"#353636\\" fill-rule=\\"evenodd\\"></path></svg></div></div>
+    <div class=\\"hig__global-nav__side-nav__search__inputholder\\"><input class=\\"hig__global-nav__side-nav__search__inputholder__input\\" type=\\"text\\" placeholder=\\"Search\\" value=\\"\\"></div>
+    <div class=\\"hig__global-nav__side-nav__search__clear\\"><div class=\\"hig__icon\\"><svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\" xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" title=\\"close-small\\"><title>hig/icon/close-small</title><g fill=\\"none\\" fill-rule=\\"evenodd\\"><circle stroke=\\"#353636\\" cx=\\"12\\" cy=\\"12\\" r=\\"8\\"></circle><polygon fill=\\"#353636\\" transform=\\"rotate(45 12 12)\\" points=\\"16.5 11.4518414 12.5847458 11.4518414 12.5847458 7.5 11.4152542 7.5 11.4152542 11.4518414 7.5 11.4518414 7.5 12.5226629 11.4152542 12.5226629 11.4152542 16.5 12.5847458 16.5 12.5847458 12.5226629 16.5 12.5226629\\"></polygon></g></svg></div></div>
+</div><!--SEARCH-->
 </div><!--SIDENAV-->
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->

--- a/src/implementations/react/src/adapters/GlobalNav/SideNav/__snapshots__/SubmoduleAdapter.test.js.snap
+++ b/src/implementations/react/src/adapters/GlobalNav/SideNav/__snapshots__/SubmoduleAdapter.test.js.snap
@@ -28,6 +28,7 @@ exports[`<SubmoduleAdapter> renders 1`] = `
 </div><!--MODULE-->
 </div><!--GROUP-->
     </div>
+    <!--SLOT-->
     <div class=\\"hig__global-nav__sidenav__links\\">
       <!--LINK-->
     </div>
@@ -73,6 +74,7 @@ exports[`<SubmoduleAdapter> renders with initial props 1`] = `
 </div><!--MODULE-->
 </div><!--GROUP-->
     </div>
+    <!--SLOT-->
     <div class=\\"hig__global-nav__sidenav__links\\">
       <!--LINK-->
     </div>
@@ -116,6 +118,7 @@ exports[`<SubmoduleAdapter> renders with updated props 1`] = `
 </div><!--MODULE-->
 </div><!--GROUP-->
     </div>
+    <!--SLOT-->
     <div class=\\"hig__global-nav__sidenav__links\\">
       <!--LINK-->
     </div>

--- a/src/implementations/react/src/adapters/GlobalNav/__snapshots__/GlobalNavAdapter.test.js.snap
+++ b/src/implementations/react/src/adapters/GlobalNav/__snapshots__/GlobalNavAdapter.test.js.snap
@@ -39,6 +39,7 @@ exports[`<GlobalNavAdapter> sideNavOpen prop can render the SideNav as a child 1
     <div class=\\"hig__global-nav__sidenav__groups\\">
       <!--GROUP-->
     </div>
+    <!--SLOT-->
     <div class=\\"hig__global-nav__sidenav__links\\">
       <!--LINK-->
     </div>

--- a/src/implementations/react/src/adapters/SlotAdapter.js
+++ b/src/implementations/react/src/adapters/SlotAdapter.js
@@ -1,0 +1,5 @@
+import createSlotComponent from './createSlotComponent';
+
+const Slot = createSlotComponent();
+
+export default Slot;

--- a/src/implementations/react/src/adapters/SpacerAdapter.js
+++ b/src/implementations/react/src/adapters/SpacerAdapter.js
@@ -4,7 +4,7 @@ import * as PropTypes from 'prop-types';
 import HIGElement from '../elements/HIGElement';
 import HIGChildValidator from '../elements/HIGChildValidator';
 import createComponent from './createComponent';
-import Slot from '../elements/components/GlobalNav/Slot';
+import Slot from './SlotAdapter';
 
 class SpacerAdapter extends HIGElement {
   constructor(initialProps) {

--- a/src/implementations/react/src/adapters/SpacerAdapter.test.js
+++ b/src/implementations/react/src/adapters/SpacerAdapter.test.js
@@ -2,7 +2,7 @@ import {mount} from 'enzyme';
 import * as HIG from 'hig-vanilla';
 import React from 'react';
 
-import Slot from '../elements/components/GlobalNav/Slot';
+import Slot from './SlotAdapter';
 import Spacer from './SpacerAdapter'
 
 const Context = props => {

--- a/src/implementations/react/src/elements/components/GlobalNav/GlobalNav.js
+++ b/src/implementations/react/src/elements/components/GlobalNav/GlobalNav.js
@@ -5,7 +5,7 @@ import GlobalNavAdapter from '../../../adapters/GlobalNav/GlobalNavAdapter';
 import TopNavAdapter from '../../../adapters/GlobalNav/TopNav/TopNavAdapter';
 import SubNavAdapter from '../../../adapters/GlobalNav/SubNav/SubNavAdapter';
 import SideNav from './SideNav';
-import Slot from './Slot';
+import Slot from '../../../adapters/SlotAdapter';
 import Tabs from './SubNav/Tabs';
 import ProjectAccountSwitcher from './TopNav/ProjectAccountSwitcher';
 
@@ -19,7 +19,7 @@ class GlobalNav extends Component {
       onHeaderClick: PropTypes.func,
       onSuperHeaderClick: PropTypes.func,
       superHeaderLabel: PropTypes.string,
-      superHeaderLink: PropTypes.string,
+      superHeaderLink: PropTypes.string
     }),
     onModuleChange: PropTypes.func.isRequired,
     modules: PropTypes.arrayOf(
@@ -44,14 +44,14 @@ class GlobalNav extends Component {
       activeProjectId: PropTypes.any,
       activeAccountId: PropTypes.any,
     }),
-
     showSubNav: PropTypes.bool
   }
 
   static defaultProps = {
     modules: [],
     submodules: [],
-    topNav: {}
+    topNav: {},
+    sideNav: {}
   }
 
   constructor(props) {

--- a/src/implementations/react/src/elements/components/GlobalNav/SideNav/SideNav.js
+++ b/src/implementations/react/src/elements/components/GlobalNav/SideNav/SideNav.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
+import HIGChildValidator from "../../../HIGChildValidator";
 import SideNavAdapter from '../../../../adapters/GlobalNav/SideNav/SideNavAdapter';
 import Submodule from './Submodule';
 import Group from '../../../../adapters/GlobalNav/SideNav/GroupAdapter';
@@ -7,6 +8,7 @@ import Module from './Module';
 import ModuleCollapse from './ModuleCollapse';
 import Link from '../../../../adapters/GlobalNav/SideNav/LinkAdapter';
 import Search from './Search';
+import Slot from '../../../../adapters/SlotAdapter';
 import WithState from './WithState';
 
 class SideNav extends Component {
@@ -34,6 +36,7 @@ class SideNav extends Component {
     onModuleClick: PropTypes.func.isRequired,
     onSubmoduleClick: PropTypes.func.isRequired,
     searchable: PropTypes.bool,
+    slot: PropTypes.node,
     superHeaderLabel: PropTypes.string,
     superHeaderLink: PropTypes.string
   };
@@ -95,6 +98,9 @@ class SideNav extends Component {
             })}
           </Group>
         ))}
+        {this.props.slot
+          ? <Slot>{this.props.slot}</Slot>
+          : null}
         {this.props.links.map(link => <Link {...link} key={link.title} />)}
         {this.props.searchable
           ? <Search onInput={this.props.setQuery} value={this.props.query} />

--- a/src/implementations/react/src/elements/components/GlobalNav/SideNav/SideNav.js
+++ b/src/implementations/react/src/elements/components/GlobalNav/SideNav/SideNav.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
-import HIGChildValidator from "../../../HIGChildValidator";
 import SideNavAdapter from '../../../../adapters/GlobalNav/SideNav/SideNavAdapter';
 import Submodule from './Submodule';
 import Group from '../../../../adapters/GlobalNav/SideNav/GroupAdapter';

--- a/src/implementations/react/src/elements/components/GlobalNav/Slot.js
+++ b/src/implementations/react/src/elements/components/GlobalNav/Slot.js
@@ -1,5 +1,0 @@
-import createSlotComponent from '../../../adapters/createSlotComponent';
-
-const Slot = createSlotComponent();
-
-export default Slot;

--- a/src/implementations/react/src/elements/components/GlobalNav/index.js
+++ b/src/implementations/react/src/elements/components/GlobalNav/index.js
@@ -2,5 +2,5 @@ export { default } from './GlobalNav';
 export { default as SideNav } from './SideNav';
 export { default as SubNav } from '../../../adapters/GlobalNav/SubNav/SubNavAdapter';
 export { default as TopNav } from './TopNav';
-export { default as Slot } from './Slot';
+export { default as Slot } from '../../../adapters/SlotAdapter';
 export { default as Tabs } from './SubNav/Tabs';

--- a/src/implementations/react/src/hig-react.js
+++ b/src/implementations/react/src/hig-react.js
@@ -18,6 +18,7 @@ export { default as TextArea } from './adapters/FormElements/TextAreaAdapter';
 export { default as TextField } from './adapters/FormElements/TextFieldAdapter';
 export { default as TextLink } from './adapters/TextLinkAdapter';
 export * from './elements/components/Typography';
-export { default as Table } from  './adapters/TableAdapter'
-export { default as SlotHeadCell } from './elements/components/SlotHeadCell'
-export { default as SlotCell } from './elements/components/SlotCell'
+export { default as Table } from  './adapters/TableAdapter';
+export { default as Slot } from './adapters/SlotAdapter';
+export { default as SlotHeadCell } from './elements/components/SlotHeadCell';
+export { default as SlotCell } from './elements/components/SlotCell';

--- a/src/implementations/react/src/playground/index.js
+++ b/src/implementations/react/src/playground/index.js
@@ -83,7 +83,14 @@ class Playground extends React.Component {
         event.preventDefault();
         console.log('Logo clicked');
       },
-      searchable: true
+      searchable: true,
+      slot: (
+        <div>
+          <Button title="Designer Toolkit" link="https://github.com/Autodesk/hig" />
+          <p></p>
+          <Button title="Git Repository" type="secondary" link="https://github.com/Autodesk/hig" target="_blank" />
+        </div>
+      )
     };
 
     return (
@@ -96,12 +103,6 @@ class Playground extends React.Component {
         activeModuleId={this.state.activeModuleId}
         showSubNav={true}
       >
-        <section>
-          <h3>Tabs</h3>
-          <Button title="Add tab before" onClick={this.addTabBefore} />
-          <Button title="Add tab after" onClick={this.addTabAfter} />
-          <Button title="Remove tab" onClick={this.removeTab} />
-        </section>
         <ButtonSection />
         <IconButtonSection />
         <CheckboxSection />

--- a/src/implementations/vanilla/src/components/global-nav/side-nav/side-nav.html
+++ b/src/implementations/vanilla/src/components/global-nav/side-nav/side-nav.html
@@ -9,6 +9,7 @@
     <div class='hig__global-nav__sidenav__groups'>
       <!--GROUP-->
     </div>
+    <!--SLOT-->
     <div class='hig__global-nav__sidenav__links'>
       <!--LINK-->
     </div>

--- a/src/implementations/vanilla/src/components/global-nav/side-nav/side-nav.js
+++ b/src/implementations/vanilla/src/components/global-nav/side-nav/side-nav.js
@@ -39,6 +39,14 @@ class SideNav extends Core {
     }
   }
 
+  addSlot(slotElement) {
+    this._findOrAddElement(
+      'SLOT',
+      'div',
+      '.hig__side-nav__slot',
+    ).appendChild(slotElement);
+  }
+
   onHeaderClick(fn) {
     return this._attachListener('click', '.hig__global-nav__sidenav__header-link', this.el, fn);
   }

--- a/src/implementations/vanilla/src/components/global-nav/side-nav/side-nav.scss
+++ b/src/implementations/vanilla/src/components/global-nav/side-nav/side-nav.scss
@@ -89,3 +89,7 @@ $hig__global-nav__sidenav--width: 280px;
   font-size: 16px;
   margin-bottom: spacing(s);
 }
+
+.hig__side-nav__slot {
+  padding: 32px 8px 32px 16px;
+}

--- a/src/implementations/vanilla/src/index.js
+++ b/src/implementations/vanilla/src/index.js
@@ -16,13 +16,14 @@ Hig.PasswordField = require('./basics/form-elements/password-field/password-fiel
 Hig.RadioButton = require('./basics/form-elements/radio-button/radio-button.js');
 Hig.Range = require('./basics/form-elements/range/range.js');
 Hig.RichText = require('./basics/rich-text/rich-text.js');
-Hig.Table = require('./components/table/table.js')
+Hig.Table = require('./components/table/table.js');
 Hig.TextArea = require('./basics/form-elements/text-area/text-area.js');
 Hig.TextField = require('./basics/form-elements/text-field/text-field.js');
 Hig.TextLink = require('./basics/text-link/text-link.js');
 Hig.Typography = require('./basics/typography/typography.js');
 Hig.Spacer = require('./basics/spacer/spacer.js');
-Hig.sizes = Hig.Spacer.SizeMap;
 Hig.Grid = require('./basics/grid/grid.js');
+
+Hig.sizes = Hig.Spacer.SizeMap;
 
 module.exports = Hig;

--- a/src/interface/interface.json
+++ b/src/interface/interface.json
@@ -930,6 +930,12 @@
                 "{Search} [ReferenceSearch] - (Optional) reference node for insertBefore"
               ]
             },
+            "addSlot": {
+              "desc": "Pass any content into the side nav",
+              "params": [
+                "{HTMLElement} HTMLElement"
+              ]
+            },
             "onHeaderClick": {
               "desc": "Calls the provided callback when user clicks on the header",
               "params": "HIG.abstract.EventObject.params",


### PR DESCRIPTION
Adds a slot to SideNav.

When using the prop-controlled GlobalNav, provide rendered react markup to `props.sideNav.slot`.

```js
const props = {
  sideNav: {
    slot: (
      <Button title="Designer Toolkit" type="secondary" />
      <Button title="Git Repository" />
    )
  }
}

return (<GlobalNav {...props} />);
```

<img width="1267" alt="screen shot 2017-09-08 at 4 24 00 pm" src="https://user-images.githubusercontent.com/178653/30234459-30e800e8-94b2-11e7-983f-df7c66efbb21.png">