### PR TITLE
Add hig-react deploy task to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,9 +91,23 @@ jobs:
           name: Validate hig-react version
           command: npm run validate
           working_directory: src/implementations/react
+  deploy:
+    <<: *defaults
+    steps:
+      - checkout
+      # Get vanilla node_modules for this revision of vanilla/package.json
+      - restore_cache:
+          key: dependency-cache-vanilla-v1-{{ checksum "package.json" }}
+      # Get React node_modules for this revision of react/package.json
+      - restore_cache:
+          key: dependency-cache-react-v1-{{ checksum "package.json" }}
+      - run:
+          name: Deploy hig-react
+          command: npm publish
+          working_directory: src/implementations/react
 workflows:
   version: 2
-  build-test-and-validate:
+  build-test-validate-and-deploy:
     jobs:
       - build
       - test:
@@ -103,6 +117,15 @@ workflows:
           filters:
             branches:
               ignore: master
+          requires:
+            - build
+            - test
+      - deploy:
+          #filters:
+            #branches:
+            #  only: master
+            #tags:
+            #  only: /v[0-9]+(\.[0-9]+)*/
           requires:
             - build
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,11 +125,11 @@ workflows:
             - build
             - test
       - deploy:
-          #filters:
-            #branches:
-            #  only: master
-            #tags:
-            #  only: /v[0-9]+(\.[0-9]+)*/
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
           requires:
             - build
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,10 @@ jobs:
       - restore_cache:
           key: dependency-cache-react-v1-{{ checksum "package.json" }}
       - run:
+          name: Add auth token
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+          working_directory: src/implementations/react
+      - run:
           name: Deploy hig-react
           command: npm publish
           working_directory: src/implementations/react


### PR DESCRIPTION
Story: https://github.com/Autodesk/hig/issues/314

Adds deploy job to CircleCI tasks

This job will be run only on master

It's also configured to only run when a version tag in the format `v0.18.0` is present. This will need to be confirmed in master