### PR TITLE
Concurrent CircleCI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
           name: Run Tests (React)
           command: npm run test-ci
           working_directory: src/implementations/react
-  validate:
+  react-validate:
     <<: *defaults
     steps:
       - checkout
@@ -98,7 +98,7 @@ jobs:
           name: Validate hig-react version
           command: npm run validate
           working_directory: src/implementations/react
-  deploy:
+  react-deploy:
     <<: *defaults
     steps:
       - checkout
@@ -128,14 +128,14 @@ workflows:
           requires:
             - vanilla-build
             - react-build
-      - validate:
+      - react-validate:
           filters:
             branches:
               ignore: master
           requires:
             - react-build
             - test
-      - deploy:
+      - react-deploy:
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ defaults: &defaults
 
 version: 2
 jobs:
-  vanilla-build:
+  vanilla-setup:
     <<: *defaults
     steps:
       - checkout
@@ -21,6 +21,13 @@ jobs:
           key: dependency-cache-vanilla-v1-{{ checksum "src/implementations/vanilla/package.json" }}
           paths:
             - src/implementations/vanilla/node_modules
+  vanilla-build:
+    <<: *defaults
+    steps:
+      - checkout
+      # Get vanilla node_modules for this revision of vanilla/package.json
+      - restore_cache:
+          key: dependency-cache-vanilla-v1-{{ checksum "src/implementations/vanilla/package.json" }}
       - run:
           name: Build (Vanilla)
           command: npm run lib
@@ -30,7 +37,7 @@ jobs:
           key: lib-cache-vanilla-v1-{{ .Revision }}
           paths:
             - src/implementations/vanilla/lib
-  react-build:
+  react-setup:
     <<: *defaults
     steps:
       - checkout
@@ -49,6 +56,16 @@ jobs:
           key: dependency-cache-react-v1-{{ checksum "src/implementations/react/package.json" }}
           paths:
             - src/implementations/react/node_modules
+  react-build:
+    <<: *defaults
+    steps:
+      - checkout
+      # Get vanilla node_modules for this revision of vanilla/package.json
+      - restore_cache:
+          key: dependency-cache-vanilla-v1-{{ checksum "src/implementations/vanilla/package.json" }}
+      # Get React node_modules for this revision of react/package.json
+      - restore_cache:
+          key: dependency-cache-react-v1-{{ checksum "src/implementations/react/package.json" }}
       - run:
           name: Build (React)
           command: npm run lib
@@ -130,10 +147,16 @@ workflows:
   version: 2
   build-test-validate-and-deploy:
     jobs:
-      - vanilla-build
+      - vanilla-setup
+      - react-setup:
+          requires:
+            - vanilla-setup
+      - vanilla-build:
+          requires:
+            - vanilla-setup
       - react-build:
           requires:
-            - vanilla-build
+            - react-setup
       - vanilla-test:
           requires:
             - vanilla-build
@@ -145,7 +168,6 @@ workflows:
             branches:
               ignore: master
           requires:
-            - react-build
             - vanilla-test
             - react-test
       - react-deploy:
@@ -155,6 +177,5 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
           requires:
-            - react-build
             - vanilla-test
             - react-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
           key: lib-cache-react-v1-{{ .Revision }}
           paths:
             - src/implementations/react/lib
-  test:
+  vanilla-test:
     <<: *defaults
     steps:
       - checkout
@@ -77,6 +77,16 @@ jobs:
           name: Run Tests (Vanilla)
           command: npm run gemini-ci
           working_directory: src/implementations/vanilla
+  react-test:
+    <<: *defaults
+    steps:
+      - checkout
+      # Get vanilla node_modules for this revision of vanilla/package.json
+      - restore_cache:
+          key: dependency-cache-vanilla-v1-{{ checksum "src/implementations/vanilla/package.json" }}
+      # Get vanilla build files for this commit
+      - restore_cache:
+          key: lib-cache-vanilla-v1-{{ .Revision }}
       # Get React node_modules for this revision of react/package.json
       - restore_cache:
           key: dependency-cache-react-v1-{{ checksum "src/implementations/react/package.json" }}
@@ -124,9 +134,11 @@ workflows:
       - react-build:
           requires:
             - vanilla-build
-      - test:
+      - vanilla-test:
           requires:
             - vanilla-build
+      - react-test:
+          requires:
             - react-build
       - react-validate:
           filters:
@@ -134,7 +146,8 @@ workflows:
               ignore: master
           requires:
             - react-build
-            - test
+            - vanilla-test
+            - react-test
       - react-deploy:
           filters:
             branches:
@@ -143,4 +156,5 @@ workflows:
               only: /v[0-9]+(\.[0-9]+)*/
           requires:
             - react-build
-            - test
+            - vanilla-test
+            - react-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ defaults: &defaults
 
 version: 2
 jobs:
-  build:
+  vanilla-build:
     <<: *defaults
     steps:
       - checkout
@@ -21,6 +21,22 @@ jobs:
           key: dependency-cache-vanilla-v1-{{ checksum "src/implementations/vanilla/package.json" }}
           paths:
             - src/implementations/vanilla/node_modules
+      - run:
+          name: Build (Vanilla)
+          command: npm run lib
+          working_directory: src/implementations/vanilla
+      # Store vanilla build files for this commit
+      - save_cache:
+          key: lib-cache-vanilla-v1-{{ .Revision }}
+          paths:
+            - src/implementations/vanilla/lib
+  react-build:
+    <<: *defaults
+    steps:
+      - checkout
+      # Get vanilla node_modules for this revision of vanilla/package.json
+      - restore_cache:
+          key: dependency-cache-vanilla-v1-{{ checksum "src/implementations/vanilla/package.json" }}
       # Get React node_modules for this revision of react/package.json
       - restore_cache:
           key: dependency-cache-react-v1-{{ checksum "src/implementations/react/package.json" }}
@@ -33,15 +49,6 @@ jobs:
           key: dependency-cache-react-v1-{{ checksum "src/implementations/react/package.json" }}
           paths:
             - src/implementations/react/node_modules
-      - run:
-          name: Build (Vanilla)
-          command: npm run lib
-          working_directory: src/implementations/vanilla
-      # Store vanilla build files for this commit
-      - save_cache:
-          key: lib-cache-vanilla-v1-{{ .Revision }}
-          paths:
-            - src/implementations/vanilla/lib
       - run:
           name: Build (React)
           command: npm run lib
@@ -113,16 +120,20 @@ workflows:
   version: 2
   build-test-validate-and-deploy:
     jobs:
-      - build
+      - vanilla-build
+      - react-build:
+          requires:
+            - vanilla-build
       - test:
           requires:
-            - build
+            - vanilla-build
+            - react-build
       - validate:
           filters:
             branches:
               ignore: master
           requires:
-            - build
+            - react-build
             - test
       - deploy:
           filters:
@@ -131,5 +142,5 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
           requires:
-            - build
+            - react-build
             - test


### PR DESCRIPTION
Includes: https://github.com/Autodesk/hig/pull/332

This will require changing the Github/CircleCI integration accordingly for these checks:

* vanilla-setup
* react-setup
* vanilla-build
* react-build
* **vanilla-test (required)**
* **react-test (required)**
* react-validation (eventually required, see below)
* react-deploy

The *build* checks don't need to be required explicitly, they're required implicitly as a dependency of the other checks

The *react-validation* check can be required once the versioning/deployment workflow has been established