### PR TITLE
Fix warning in v16

### DIFF
--- a/src/implementations/react/src/elements/components/Flyout.js
+++ b/src/implementations/react/src/elements/components/Flyout.js
@@ -25,12 +25,6 @@ class Flyout extends React.Component {
     }
   };
 
-  static childContextTypes = {
-    parent: PropTypes.shape({
-      appendChild: PropTypes.func
-    })
-  }
-
   setTargetEl = el => {
     this.setState({ target: el });
   };


### PR DESCRIPTION
Remove unused method from Flyout that triggers a warning in the new version of React.