### PR TITLE
[Discussion] Example to add localized strings to test page

### DIFF
--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -49,6 +49,7 @@
     "gemini": "^4.18.1",
     "gemini-sauce": "^1.0.1",
     "http-server": "^0.10.0",
+    "i18next": "^8.1.0",
     "loader-utils": "^1.0.2",
     "mustache": "^2.3.0",
     "node-sass": "^4.5.0",

--- a/packages/vanilla/src/basics/flyout/tests/test-flyout_ja.html
+++ b/packages/vanilla/src/basics/flyout/tests/test-flyout_ja.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang='en' >
+<html lang='ja' >
     <head>
         <meta charset="utf-8"/>
         <link rel="stylesheet" href="../../../../lib/hig.css">
@@ -17,7 +17,7 @@
         <div class='test-container'></div>
         <script>
             var i18next = Hig.i18next;
-            i18next.changeLanguage('en');
+            i18next.changeLanguage('ja');
 
             function createFlyoutContent() {
                 var flyoutContent = document.createElement('div');

--- a/packages/vanilla/src/helpers/js/i18n.js
+++ b/packages/vanilla/src/helpers/js/i18n.js
@@ -1,0 +1,17 @@
+import i18next from 'i18next'
+
+const translations = {};
+
+['en', 'ja'].forEach(lang =>
+  translations[lang] = {
+    translation: require('../../languages/' + lang + '/hig-vanilla-tests.json')
+  }
+);
+
+i18next.init({
+  lng: 'en',
+  debug: true,
+  resources: translations
+});
+
+export default i18next;

--- a/packages/vanilla/src/index.js
+++ b/packages/vanilla/src/index.js
@@ -60,3 +60,5 @@ export { default as Typography } from './basics/typography/typography';
 export { default as breakpoints } from './basics/responsive/responsive';
 export { colors };
 export { sizes };
+
+export { default as i18next } from './helpers/js/i18n.js';

--- a/packages/vanilla/src/languages/en/hig-vanilla-tests.json
+++ b/packages/vanilla/src/languages/en/hig-vanilla-tests.json
@@ -1,0 +1,9 @@
+{
+  "sample" : {
+    "hello_world": "Hello, world!"
+  },
+  "flyout" : {
+    "open_default_btn": "Open default flyout",
+    "open_setter_btn": "Open setter flyout"
+  }
+}

--- a/packages/vanilla/src/languages/ja/hig-vanilla-tests.json
+++ b/packages/vanilla/src/languages/ja/hig-vanilla-tests.json
@@ -1,0 +1,9 @@
+{
+  "sample" : {
+    "hello_world": "ようこそ、世界！"
+  },
+  "flyout" : {
+    "open_default_btn": "既定のフライアウトを開く",
+    "open_setter_btn": "セッターフライアウトを開く"
+  }
+}


### PR DESCRIPTION
**Change:**
1. Add i18next module
2. Extract strings from test html to resource file (English/Japanese)
3. Add a localized test html

**Discussion:**
As we discussed with @recyclerobot the other day, we would like to add localized strings in test pages to make sure HIG elements work with in different languages/locales.

The purpose of this PR is to discuss and find an agreement how to implement **test** pages. We paid attention to some aspects:

- Easy to implement based on the existing test pages
- To follow i18n best practices as much as possible so that these examples could be used as a base for real implementation
- To avoid mixed-language page because this is not real case in general and we may want to apply different CSS (especially font related settings) to verify the rendering result

Some additional comments:
-  Language selection is hardcoded because the setting is normally taken from the user preference.
-  Localized page is a duplication from English page except language settings. Although the duplication is not good practice in general, in the case of static test pages, it is an easy way to do. With React implementation, we would add a language drop down to select language.

Could you review and give us your feedback?

Thanks.