### PR TITLE
Chores: Auto-generate docgen info (Proof of concept)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
           working_directory: packages/react
       - run:
           name: Run Tests (React)
-          command: yarn test --coverage --runInBand --colors
+          command: yarn test-ci
           working_directory: packages/react
   packages-deploy:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,8 @@ jobs:
           name: Run Tests (React)
           command: yarn test-ci
           working_directory: packages/react
+      - store_artifacts:
+            path: packages/react/coverage
   packages-deploy:
     <<: *defaults
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Read [DEVELOPING](DEVELOPING.md) for more information about how to develop withi
 	- Ensure changes are tested
 	- Add to the playground for manual testing if needed
 	- Ensure branch meets testing, coverage, and linting standards
-		- `yarn test --coverage`
+		- `yarn test-ci`
 		- `yarn lint`
 
 #### Create a pull request

--- a/packages/react/.babelrc
+++ b/packages/react/.babelrc
@@ -11,5 +11,5 @@
     "react",
     "stage-2"
   ],
-  "plugins": []
+  "plugins": ["react-docgen"]
 }

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -1,0 +1,23 @@
+module.exports = {
+  collectCoverageFrom: [
+    "!src/index.js",
+    "src/**/*.{js,jsx}",
+    "!src/**/*.story.{js,jsx}",
+    "!src/fixtures/**/*",
+    "!src/stories/**/*",
+    "!src/playground/**/*",
+    "!**/node_modules/**"
+  ],
+  coverageThreshold: {
+    "global": {
+      "branches": 60,
+      "functions": 60,
+      "lines": 60,
+      "statements": 60
+    }
+  },
+  modulePaths: ["node_modules", "<rootDir>/src"],
+  moduleFileExtensions: ["js", "jsx", "json"],
+  setupTestFrameworkScriptFile: "<rootDir>/src/setupTests.js",
+  unmockedModulePathPatterns: ["<rootDir>/node_modules"]
+};

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -63,7 +63,8 @@
     "lint-fix": "eslint ./src/** -c ./.eslintrc.js --fix",
     "playground": "react-scripts start",
     "start": "react-scripts start",
-    "test": "jest",
+    "test": "jest --watch",
+    "test-ci": "jest --coverage --runInBand --colors",
     "type-check": "tsc"
   },
   "dependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -26,7 +26,7 @@
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.1",
-    "babel-plugin-react-docgen": "^1.7.0",
+    "babel-plugin-react-docgen": "^1.8.1",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -63,29 +63,10 @@
     "lint-fix": "eslint ./src/** -c ./.eslintrc.js --fix",
     "playground": "react-scripts start",
     "start": "react-scripts start",
-    "test": "react-scripts test --env=jsdom",
+    "test": "jest",
     "type-check": "tsc"
   },
   "dependencies": {
     "hig-vanilla": "^0.1.15"
-  },
-  "jest": {
-    "collectCoverageFrom": [
-      "!src/index.js",
-      "src/**/*.{js,jsx}",
-      "!src/**/*.story.{js,jsx}",
-      "!src/fixtures/**/*",
-      "!src/stories/**/*",
-      "!src/playground/**/*",
-      "!**/node_modules/**"
-    ],
-    "coverageThreshold": {
-      "global": {
-        "branches": 60,
-        "functions": 60,
-        "lines": 60,
-        "statements": 60
-      }
-    }
   }
 }

--- a/packages/react/src/adapters/ActionBar/ActionBarAdapter.js
+++ b/packages/react/src/adapters/ActionBar/ActionBarAdapter.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { ActionBar as VanillaActionBar } from "hig-vanilla";
 
-class ActionBarAdapter extends Component {
+export default class ActionBarAdapter extends Component {
   render() {
     return (
       <div className={VanillaActionBar.className}>{this.props.children}</div>
@@ -11,20 +11,8 @@ class ActionBarAdapter extends Component {
 }
 
 ActionBarAdapter.propTypes = {
+  /**
+   * Content for the ActionBar. Typically ActionBarGroup or ActionBarSpacer
+   */
   children: PropTypes.node
 };
-
-ActionBarAdapter.__docgenInfo = {
-  props: {
-    children: {
-      description:
-        "Content for the ActionBar. Typically ActionBarGroup or ActionBarSpacer"
-    }
-  }
-};
-
-ActionBarAdapter.defaultProps = {
-  children: null
-};
-
-export default ActionBarAdapter;

--- a/packages/react/src/adapters/ActionBar/ActionBarGroupAdapter.js
+++ b/packages/react/src/adapters/ActionBar/ActionBarGroupAdapter.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { ActionBar as VanillaActionBar } from "hig-vanilla";
 
-class ActionBarGroupAdapter extends Component {
+export default class ActionBarGroupAdapter extends Component {
   render() {
     return (
       <div className={VanillaActionBar.groupClassName}>
@@ -13,15 +13,8 @@ class ActionBarGroupAdapter extends Component {
 }
 
 ActionBarGroupAdapter.propTypes = {
+  /**
+   * Content of the ActionBarGroup. Typically flat IconButtons.
+   */
   children: PropTypes.node
 };
-
-ActionBarGroupAdapter.__docgenInfo = {
-  props: {
-    children: {
-      description: "Content of the ActionBarGroup. Typically flat IconButtons."
-    }
-  }
-};
-
-export default ActionBarGroupAdapter;

--- a/packages/react/src/adapters/AvatarAdapter.js
+++ b/packages/react/src/adapters/AvatarAdapter.js
@@ -1,56 +1,51 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Avatar as VanillaAvatar } from "hig-vanilla";
 import HIGAdapter, { MapsPropToMethod } from "./HIGAdapter";
 
-function AvatarAdapter(props) {
-  return (
-    <HIGAdapter {...props} displayName="Avatar" HIGConstructor={VanillaAvatar}>
-      {adapterProps => (
-        <div>
-          <MapsPropToMethod
-            setter="setName"
-            value={props.name}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            setter="setSize"
-            value={props.size}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            setter="setImage"
-            value={props.image}
-            {...adapterProps}
-          />
-        </div>
-      )}
-    </HIGAdapter>
-  );
+export default class AvatarAdapter extends Component {
+  render() {
+    return (
+      <HIGAdapter
+        {...this.props}
+        displayName="Avatar"
+        HIGConstructor={VanillaAvatar}
+      >
+        {adapterProps => (
+          <div>
+            <MapsPropToMethod
+              setter="setName"
+              value={this.props.name}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              setter="setSize"
+              value={this.props.size}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              setter="setImage"
+              value={this.props.image}
+              {...adapterProps}
+            />
+          </div>
+        )}
+      </HIGAdapter>
+    );
+  }
 }
 
 AvatarAdapter.propTypes = {
+  /**
+   * The name for the avatar
+   */
   name: PropTypes.string.isRequired,
+  /**
+   * small, medium, large or extralarge
+   */
   size: PropTypes.oneOf(VanillaAvatar.AvailableSizes).isRequired,
+  /**
+   * Url to a profile image
+   */
   image: PropTypes.string
 };
-
-AvatarAdapter.__docgenInfo = {
-  props: {
-    name: {
-      description: "the name for the avatar"
-    },
-    size: {
-      description: "small, medium, large or extralarge"
-    },
-    image: {
-      description: "url to a profile image"
-    }
-  }
-};
-
-AvatarAdapter.defaultProps = {
-  image: undefined
-};
-
-export default AvatarAdapter;

--- a/packages/react/src/adapters/ButtonAdapter.js
+++ b/packages/react/src/adapters/ButtonAdapter.js
@@ -1,125 +1,136 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Button as VanillaButton } from "hig-vanilla";
 import HIGAdapter, { MapsPropToMethod, MapsEventListener } from "./HIGAdapter";
 
-function ButtonAdapter(props) {
-  return (
-    <HIGAdapter displayName="Button" HIGConstructor={VanillaButton} {...props}>
-      {adapterProps => (
-        <div>
-          <MapsPropToMethod
-            value={props.icon}
-            setter="setIcon"
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            value={props.link}
-            setter="setLink"
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            value={props.target}
-            setter="setTarget"
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            value={props.title}
-            setter="setTitle"
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            value={props.type}
-            setter="setType"
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            value={props.size}
-            setter="setSize"
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            value={props.width}
-            setter="setWidth"
-            {...adapterProps}
-          />
-          <MapsPropToMethod value={props.disabled} {...adapterProps}>
-            {(instance, value) =>
-              value ? instance.disable() : instance.enable()
-            }
-          </MapsPropToMethod>
-          <MapsEventListener
-            listener="onBlur"
-            handler={props.onBlur}
-            {...adapterProps}
-          />
-          <MapsEventListener
-            listener="onClick"
-            handler={props.onClick}
-            {...adapterProps}
-          />
-          <MapsEventListener
-            listener="onFocus"
-            handler={props.onFocus}
-            {...adapterProps}
-          />
-          <MapsEventListener
-            listener="onHover"
-            handler={props.onHover}
-            {...adapterProps}
-          />
-        </div>
-      )}
-    </HIGAdapter>
-  );
+export default class ButtonAdapter extends Component {
+  render() {
+    return (
+      <HIGAdapter
+        displayName="Button"
+        HIGConstructor={VanillaButton}
+        {...this.props}
+      >
+        {adapterProps => (
+          <div>
+            <MapsPropToMethod
+              value={this.props.icon}
+              setter="setIcon"
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              value={this.props.link}
+              setter="setLink"
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              value={this.props.target}
+              setter="setTarget"
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              value={this.props.title}
+              setter="setTitle"
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              value={this.props.type}
+              setter="setType"
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              value={this.props.size}
+              setter="setSize"
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              value={this.props.width}
+              setter="setWidth"
+              {...adapterProps}
+            />
+            <MapsPropToMethod value={this.props.disabled} {...adapterProps}>
+              {(instance, value) =>
+                value ? instance.disable() : instance.enable()
+              }
+            </MapsPropToMethod>
+            <MapsEventListener
+              listener="onBlur"
+              handler={this.props.onBlur}
+              {...adapterProps}
+            />
+            <MapsEventListener
+              listener="onClick"
+              handler={this.props.onClick}
+              {...adapterProps}
+            />
+            <MapsEventListener
+              listener="onFocus"
+              handler={this.props.onFocus}
+              {...adapterProps}
+            />
+            <MapsEventListener
+              listener="onHover"
+              handler={this.props.onHover}
+              {...adapterProps}
+            />
+          </div>
+        )}
+      </HIGAdapter>
+    );
+  }
 }
 
 ButtonAdapter.propTypes = {
+  /**
+   * Prevents user action on the button
+   */
   disabled: PropTypes.bool,
+  /**
+   * Sets the link of a button
+   */
   link: PropTypes.string,
+  /**
+   * Triggers blur when focus is moved away from icon
+   */
   onBlur: PropTypes.func,
+  /**
+   * Triggers when you click the button
+   */
   onClick: PropTypes.func,
+  /**
+   * Triggers when focus is moved to button
+   */
   onFocus: PropTypes.func,
+  /**
+   * Triggers when you hover over the button
+   */
   onHover: PropTypes.func,
+  /**
+   * Specifies size of button
+   */
   size: PropTypes.oneOf(VanillaButton.AvailableSizes),
+  /**
+   * Specifies where to display the linked URL
+   */
   target: PropTypes.oneOf(["_self", "_blank", "_parent", "_top"]),
+  /**
+   * Sets the title of a button
+   */
   title: PropTypes.string.isRequired,
+  /**
+   * Specifies type of button
+   */
   type: PropTypes.oneOf(VanillaButton.AvailableTypes),
+  /**
+   * Specifies width of button (grow or shrink)
+   */
   width: PropTypes.oneOf(VanillaButton.AvailableWidths),
+  /**
+   * An icon name or svg string
+   */
   icon: PropTypes.string
 };
 
 ButtonAdapter.defaultProps = {
-  disabled: false,
-  link: undefined,
-  onBlur: undefined,
-  onClick: undefined,
-  onFocus: undefined,
-  onHover: undefined,
-  size: undefined,
-  target: undefined,
-  type: undefined,
-  width: undefined,
-  icon: undefined
+  disabled: false
 };
-
-ButtonAdapter.__docgenInfo = {
-  props: {
-    disabled: { description: "prevents user action on the button" },
-    icon: { description: "an icon name or svg string" },
-    link: { description: "sets the link of a button" },
-    onBlur: {
-      description: "triggers blur when focuss is moved away from icon"
-    },
-    onClick: { description: "triggers when you click the button" },
-    onFocus: { description: "triggers focus is moved to button" },
-    onHover: { description: "triggers when you hover over the button" },
-    size: { description: "specifies size of button" },
-    target: { description: "specifies where to display the linked URL" },
-    title: { description: "sets the title of a button" },
-    type: { description: "specifies type of button" },
-    width: { description: "specifies width of button (grow or shrink)" }
-  }
-};
-
-export default ButtonAdapter;

--- a/packages/react/src/adapters/ContainerViewAdapter.js
+++ b/packages/react/src/adapters/ContainerViewAdapter.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 import { ContainerView as ContainerViewVanilla } from "hig-vanilla";
 
-class ContainerViewAdapter extends Component {
+export default class ContainerViewAdapter extends Component {
   render() {
     return (
       <div className={ContainerViewVanilla.className}>
@@ -14,15 +14,8 @@ class ContainerViewAdapter extends Component {
 }
 
 ContainerViewAdapter.propTypes = {
+  /**
+   * The content insdie of the content View
+   */
   children: PropTypes.node
 };
-
-ContainerViewAdapter.__docgenInfo = {
-  props: {
-    children: {
-      description: "the content insdie of the content View"
-    }
-  }
-};
-
-export default ContainerViewAdapter;

--- a/packages/react/src/adapters/ContainerViewContentAdapter.js
+++ b/packages/react/src/adapters/ContainerViewContentAdapter.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { ContainerViewContent as ContainerViewContentVanilla } from "hig-vanilla";
 
-class ContainerViewContentAdapter extends Component {
+export default class ContainerViewContentAdapter extends Component {
   render() {
     return (
       <div className={ContainerViewContentVanilla.className}>
@@ -13,14 +13,8 @@ class ContainerViewContentAdapter extends Component {
 }
 
 ContainerViewContentAdapter.propTypes = {
+  /**
+   * The content inside of the content View
+   */
   children: PropTypes.node
 };
-
-ContainerViewContentAdapter.__docgenInfo = {
-  props: {
-    children: {
-      description: "the content insdie of the content View"
-    }
-  }
-};
-export default ContainerViewContentAdapter;

--- a/packages/react/src/adapters/ContainerViewLeftAdapter.js
+++ b/packages/react/src/adapters/ContainerViewLeftAdapter.js
@@ -1,48 +1,40 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { ContainerViewLeft as ContainerViewLeftVanilla } from "hig-vanilla";
 import HIGAdapter, { MapsPropToMethod, MountsAnyChild } from "./HIGAdapter";
 
-function ContainerViewLeftAdapter(props) {
-  return (
-    <HIGAdapter
-      {...props}
-      displayName="ContainerViewLeft"
-      HIGConstructor={ContainerViewLeftVanilla}
-    >
-      {adapterProps => (
-        <div>
-          <MapsPropToMethod value={props.open} {...adapterProps}>
-            {(instance, value) => (value ? instance.open() : instance.close())}
-          </MapsPropToMethod>
-          <MountsAnyChild mounter="addSlot" {...adapterProps}>
-            {props.children}
-          </MountsAnyChild>
-        </div>
-      )}
-    </HIGAdapter>
-  );
+export default class ContainerViewLeftAdapter extends Component {
+  render() {
+    return (
+      <HIGAdapter
+        {...this.props}
+        displayName="ContainerViewLeft"
+        HIGConstructor={ContainerViewLeftVanilla}
+      >
+        {adapterProps => (
+          <div>
+            <MapsPropToMethod value={this.props.open} {...adapterProps}>
+              {(instance, value) =>
+                value ? instance.open() : instance.close()
+              }
+            </MapsPropToMethod>
+            <MountsAnyChild mounter="addSlot" {...adapterProps}>
+              {this.props.children}
+            </MountsAnyChild>
+          </div>
+        )}
+      </HIGAdapter>
+    );
+  }
 }
 
 ContainerViewLeftAdapter.propTypes = {
+  /**
+   * Sets whether container is open
+   */
   open: PropTypes.bool,
+  /**
+   * Content that is inside the container
+   */
   children: PropTypes.node
 };
-
-ContainerViewLeftAdapter.defaultProps = {
-  open: undefined,
-  children: undefined
-};
-
-ContainerViewLeftAdapter.__docgenInfo = {
-  props: {
-    open: {
-      description: "{bool} sets whether container is open"
-    },
-    children: {
-      description: "content that is inside the container"
-    }
-  }
-};
-
-export default ContainerViewLeftAdapter;

--- a/packages/react/src/adapters/ContainerViewRightAdapter.js
+++ b/packages/react/src/adapters/ContainerViewRightAdapter.js
@@ -1,48 +1,40 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { ContainerViewRight as ContainerViewRightVanilla } from "hig-vanilla";
 import HIGAdapter, { MapsPropToMethod, MountsAnyChild } from "./HIGAdapter";
 
-function ContainerViewRightAdapter(props) {
-  return (
-    <HIGAdapter
-      {...props}
-      displayName="ContainerViewRight"
-      HIGConstructor={ContainerViewRightVanilla}
-    >
-      {adapterProps => (
-        <div>
-          <MapsPropToMethod value={props.open} {...adapterProps}>
-            {(instance, value) => (value ? instance.open() : instance.close())}
-          </MapsPropToMethod>
-          <MountsAnyChild mounter="addSlot" {...adapterProps}>
-            {props.children}
-          </MountsAnyChild>
-        </div>
-      )}
-    </HIGAdapter>
-  );
+export default class ContainerViewRightAdapter extends Component {
+  render() {
+    return (
+      <HIGAdapter
+        {...this.props}
+        displayName="ContainerViewRight"
+        HIGConstructor={ContainerViewRightVanilla}
+      >
+        {adapterProps => (
+          <div>
+            <MapsPropToMethod value={this.props.open} {...adapterProps}>
+              {(instance, value) =>
+                value ? instance.open() : instance.close()
+              }
+            </MapsPropToMethod>
+            <MountsAnyChild mounter="addSlot" {...adapterProps}>
+              {this.props.children}
+            </MountsAnyChild>
+          </div>
+        )}
+      </HIGAdapter>
+    );
+  }
 }
 
 ContainerViewRightAdapter.propTypes = {
+  /**
+   * Sets whether container is open
+   */
   open: PropTypes.bool,
+  /**
+   * Content that is inside the container
+   */
   children: PropTypes.node
 };
-
-ContainerViewRightAdapter.defaultProps = {
-  open: undefined,
-  children: undefined
-};
-
-ContainerViewRightAdapter.__docgenInfo = {
-  props: {
-    open: {
-      description: "{bool} sets whether container is open"
-    },
-    children: {
-      description: "content that is inside the container"
-    }
-  }
-};
-
-export default ContainerViewRightAdapter;

--- a/packages/react/src/adapters/FormElements/CheckboxAdapter.js
+++ b/packages/react/src/adapters/FormElements/CheckboxAdapter.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Checkbox as VanillaCheckbox } from "hig-vanilla";
 import HIGAdapter, {
@@ -7,155 +7,136 @@ import HIGAdapter, {
   ControlsProp
 } from "../HIGAdapter";
 
-function CheckboxAdapter(props) {
-  return (
-    <HIGAdapter
-      {...props}
-      displayName="Checkbox"
-      HIGConstructor={VanillaCheckbox}
-    >
-      {adapterProps => (
-        <div>
-          <ControlsProp
-            eventTargetPropName="indeterminate"
-            handler={props.onChange}
-            listener="onChange"
-            value={props.indeterminate}
-            defaultValue={
-              props.defaultIndeterminate !== undefined
-                ? props.defaultIndeterminate
-                : false
-            }
-            {...adapterProps}
-          >
-            {(instance, value) =>
-              value ? instance.indeterminate() : instance.determinate()
-            }
-          </ControlsProp>
+export default class CheckboxAdapter extends Component {
+  render() {
+    return (
+      <HIGAdapter
+        {...this.props}
+        displayName="Checkbox"
+        HIGConstructor={VanillaCheckbox}
+      >
+        {adapterProps => (
+          <div>
+            <ControlsProp
+              eventTargetPropName="indeterminate"
+              handler={this.props.onChange}
+              listener="onChange"
+              value={this.props.indeterminate}
+              defaultValue={
+                this.props.defaultIndeterminate !== undefined
+                  ? this.props.defaultIndeterminate
+                  : false
+              }
+              {...adapterProps}
+            >
+              {(instance, value) =>
+                value ? instance.indeterminate() : instance.determinate()
+              }
+            </ControlsProp>
 
-          <ControlsProp
-            eventTargetPropName="checked"
-            handler={props.onChange}
-            listener="onChange"
-            value={props.checked}
-            defaultValue={
-              props.defaultChecked !== undefined ? props.defaultChecked : false
-            }
-            {...adapterProps}
-          >
-            {(instance, value) =>
-              value ? instance.check() : instance.uncheck()
-            }
-          </ControlsProp>
+            <ControlsProp
+              eventTargetPropName="checked"
+              handler={this.props.onChange}
+              listener="onChange"
+              value={this.props.checked}
+              defaultValue={
+                this.props.defaultChecked !== undefined
+                  ? this.props.defaultChecked
+                  : false
+              }
+              {...adapterProps}
+            >
+              {(instance, value) =>
+                value ? instance.check() : instance.uncheck()
+              }
+            </ControlsProp>
 
-          <MapsEventListener
-            listener="onFocus"
-            handler={props.onFocus}
-            {...adapterProps}
-          />
-          <MapsEventListener
-            listener="onHover"
-            handler={props.onFocus}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            setter="setLabel"
-            value={props.label}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            setter="setName"
-            value={props.name}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            setter="setValue"
-            value={props.value}
-            {...adapterProps}
-          />
-          <MapsPropToMethod value={props.disabled} {...adapterProps}>
-            {(instance, value) =>
-              value ? instance.disable() : instance.enable()
-            }
-          </MapsPropToMethod>
+            <MapsEventListener
+              listener="onFocus"
+              handler={this.props.onFocus}
+              {...adapterProps}
+            />
+            <MapsEventListener
+              listener="onHover"
+              handler={this.props.onFocus}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              setter="setLabel"
+              value={this.props.label}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              setter="setName"
+              value={this.props.name}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              setter="setValue"
+              value={this.props.value}
+              {...adapterProps}
+            />
+            <MapsPropToMethod value={this.props.disabled} {...adapterProps}>
+              {(instance, value) =>
+                value ? instance.disable() : instance.enable()
+              }
+            </MapsPropToMethod>
 
-          <MapsPropToMethod value={props.required} {...adapterProps}>
-            {(instance, value) =>
-              value ? instance.required(value) : instance.noLongerRequired()
-            }
-          </MapsPropToMethod>
-        </div>
-      )}
-    </HIGAdapter>
-  );
+            <MapsPropToMethod value={this.props.required} {...adapterProps}>
+              {(instance, value) =>
+                value ? instance.required(value) : instance.noLongerRequired()
+              }
+            </MapsPropToMethod>
+          </div>
+        )}
+      </HIGAdapter>
+    );
+  }
 }
 
 CheckboxAdapter.propTypes = {
+  /**
+   * Checks the checkbox
+   */
   checked: PropTypes.bool,
+  /**
+   * Initially checks the checkbox, but allows user action to change it
+   */
   defaultChecked: PropTypes.bool,
+  /**
+   * Prevents user actions on the checkbox
+   */
   disabled: PropTypes.bool,
+  /**
+   * Sets indeterminate state for checkbox
+   */
   indeterminate: PropTypes.bool,
+  /**
+   * Text identifying the field
+   */
   label: PropTypes.string,
+  /**
+   * The name of the checkbox as submitted with a form
+   */
   name: PropTypes.string,
+  /**
+   * Called when user moves focus from the field
+   */
   onBlur: PropTypes.func,
+  /**
+   * Called when user changes the value of the field
+   */
   onChange: PropTypes.func,
+  /**
+   * Called when user puts focus on the field
+   */
   onFocus: PropTypes.func,
+  /**
+   * Marks the field as required, text shown to explain requirement
+   */
   required: PropTypes.string,
+  /**
+   * Value submitted with a form if checked
+   */
   value: PropTypes.string
 };
-
-CheckboxAdapter.defaultProps = {
-  checked: undefined,
-  defaultChecked: undefined,
-  disabled: undefined,
-  indeterminate: undefined,
-  label: undefined,
-  name: undefined,
-  onBlur: undefined,
-  onChange: undefined,
-  onFocus: undefined,
-  required: undefined,
-  value: undefined
-};
-
-CheckboxAdapter.__docgenInfo = {
-  props: {
-    checked: {
-      description: "checks the checkbox"
-    },
-    defaultChecked: {
-      description:
-        "initially checks the checkbox, but allows user action to change it"
-    },
-    disabled: {
-      description: "prevents user actions on the checkbox"
-    },
-    indeterminate: {
-      description: "sets indeterminate state for checkbox"
-    },
-    label: {
-      description: "text identifying the field"
-    },
-    name: {
-      description: "the name of the checkbox as submitted with a form"
-    },
-    onBlur: {
-      description: "called when user moves focus from the field"
-    },
-    onChange: {
-      description: "called when user changes the value of the field"
-    },
-    onFocus: {
-      description: "called when user puts focus on the field"
-    },
-    required: {
-      description:
-        "marks the field as required, text shown to explain requirment"
-    },
-    value: {
-      description: "value submitted with a form if checked"
-    }
-  }
-};
-
-export default CheckboxAdapter;

--- a/packages/react/src/adapters/FormElements/OptionAdapter.js
+++ b/packages/react/src/adapters/FormElements/OptionAdapter.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Option as VanillaOption } from "hig-vanilla";
 import HIGAdapter, {
@@ -7,88 +7,79 @@ import HIGAdapter, {
   MountedByHIGParentList
 } from "../HIGAdapter";
 
-function OptionAdapter(props) {
-  return (
-    <HIGAdapter {...props} displayName="Option" HIGConstructor={VanillaOption}>
-      {adapterProps => (
-        <div>
-          <MapsPropToMethod
-            value={props.label}
-            setter="setLabel"
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            value={props.value}
-            setter="setValue"
-            {...adapterProps}
-          />
-          <MapsPropToMethod value={props.selected} {...adapterProps}>
-            {(instance, value) =>
-              value ? instance.select() : instance.deselect()
-            }
-          </MapsPropToMethod>
+export default class OptionAdapter extends Component {
+  render() {
+    return (
+      <HIGAdapter
+        {...this.props}
+        displayName="Option"
+        HIGConstructor={VanillaOption}
+      >
+        {adapterProps => (
+          <div>
+            <MapsPropToMethod
+              value={this.props.label}
+              setter="setLabel"
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              value={this.props.value}
+              setter="setValue"
+              {...adapterProps}
+            />
+            <MapsPropToMethod value={this.props.selected} {...adapterProps}>
+              {(instance, value) =>
+                value ? instance.select() : instance.deselect()
+              }
+            </MapsPropToMethod>
 
-          <MapsPropToMethod value={props.checked} {...adapterProps}>
-            {(instance, value) =>
-              value ? instance.check() : instance.uncheck()
-            }
-          </MapsPropToMethod>
-          <MapsPropToMethod value={props.focused} {...adapterProps}>
-            {(instance, value) =>
-              value ? instance.focus() : instance.unfocus()
-            }
-          </MapsPropToMethod>
-          <MapsEventListener
-            listener="onHover"
-            handler={props.onHover}
-            {...adapterProps}
-          />
-          <MapsEventListener
-            listener="onClick"
-            handler={props.onClick}
-            {...adapterProps}
-          />
-          <MountedByHIGParentList mounter="addOption" {...adapterProps} />
-        </div>
-      )}
-    </HIGAdapter>
-  );
+            <MapsPropToMethod value={this.props.checked} {...adapterProps}>
+              {(instance, value) =>
+                value ? instance.check() : instance.uncheck()
+              }
+            </MapsPropToMethod>
+            <MapsPropToMethod value={this.props.focused} {...adapterProps}>
+              {(instance, value) =>
+                value ? instance.focus() : instance.unfocus()
+              }
+            </MapsPropToMethod>
+            <MapsEventListener
+              listener="onHover"
+              handler={this.props.onHover}
+              {...adapterProps}
+            />
+            <MapsEventListener
+              listener="onClick"
+              handler={this.props.onClick}
+              {...adapterProps}
+            />
+            <MountedByHIGParentList mounter="addOption" {...adapterProps} />
+          </div>
+        )}
+      </HIGAdapter>
+    );
+  }
 }
 
 OptionAdapter.propTypes = {
+  /**
+   * Called when user moves mouse over the option
+   */
   onHover: PropTypes.func,
+  /**
+   * Called when the user clicks the option
+   */
   onClick: PropTypes.func,
+  /**
+   * Text displayed on the option
+   */
   label: PropTypes.string,
+  /**
+   * Indicates the option is currently selected
+   */
   selected: PropTypes.bool,
+  /**
+   * Data represented by the option
+   */
   value: PropTypes.string
 };
-
-OptionAdapter.defaultProps = {
-  onHover: undefined,
-  onClick: undefined,
-  label: undefined,
-  selected: undefined,
-  value: undefined
-};
-
-OptionAdapter.__docgenInfo = {
-  props: {
-    onHover: {
-      description: "called when user moves mouse over the option"
-    },
-    onClick: {
-      description: "called when the user clicks the option"
-    },
-    label: {
-      description: "text displayed on the option"
-    },
-    selected: {
-      description: "indicates the option is currently selected"
-    },
-    value: {
-      description: "data represented by the option"
-    }
-  }
-};
-
-export default OptionAdapter;

--- a/packages/react/src/adapters/FormElements/RadioButtonAdapter.js
+++ b/packages/react/src/adapters/FormElements/RadioButtonAdapter.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { RadioButton as VanillaRadioButton } from "hig-vanilla";
 import HIGAdapter, {
@@ -7,129 +7,109 @@ import HIGAdapter, {
   ControlsProp
 } from "../HIGAdapter";
 
-function RadioButtonAdapter(props) {
-  return (
-    <HIGAdapter
-      {...props}
-      displayName="RadioButton"
-      HIGConstructor={VanillaRadioButton}
-    >
-      {adapterProps => (
-        <div>
-          <ControlsProp
-            eventTargetPropName="checked"
-            handler={props.onChange}
-            listener="onChange"
-            value={props.checked}
-            defaultValue={props.defaultChecked}
-            {...adapterProps}
-          >
-            {(instance, value) =>
-              value ? instance.check() : instance.uncheck()
-            }
-          </ControlsProp>
-          <MapsEventListener
-            listener="onFocus"
-            handler={props.onFocus}
-            {...adapterProps}
-          />
-          <MapsEventListener
-            listener="onHover"
-            handler={props.onFocus}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            setter="setLabel"
-            value={props.label}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            setter="setName"
-            value={props.name}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            setter="setValue"
-            value={props.value}
-            {...adapterProps}
-          />
-          <MapsPropToMethod value={props.disabled} {...adapterProps}>
-            {(instance, value) =>
-              value ? instance.disable() : instance.enable()
-            }
-          </MapsPropToMethod>
-          <MapsPropToMethod value={props.required} {...adapterProps}>
-            {(instance, value) =>
-              value ? instance.required(value) : instance.noLongerRequired()
-            }
-          </MapsPropToMethod>
-        </div>
-      )}
-    </HIGAdapter>
-  );
+export default class RadioButtonAdapter extends Component {
+  render() {
+    return (
+      <HIGAdapter
+        {...this.props}
+        displayName="RadioButton"
+        HIGConstructor={VanillaRadioButton}
+      >
+        {adapterProps => (
+          <div>
+            <ControlsProp
+              eventTargetPropName="checked"
+              handler={this.props.onChange}
+              listener="onChange"
+              value={this.props.checked}
+              defaultValue={this.props.defaultChecked}
+              {...adapterProps}
+            >
+              {(instance, value) =>
+                value ? instance.check() : instance.uncheck()
+              }
+            </ControlsProp>
+            <MapsEventListener
+              listener="onFocus"
+              handler={this.props.onFocus}
+              {...adapterProps}
+            />
+            <MapsEventListener
+              listener="onHover"
+              handler={this.props.onFocus}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              setter="setLabel"
+              value={this.props.label}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              setter="setName"
+              value={this.props.name}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              setter="setValue"
+              value={this.props.value}
+              {...adapterProps}
+            />
+            <MapsPropToMethod value={this.props.disabled} {...adapterProps}>
+              {(instance, value) =>
+                value ? instance.disable() : instance.enable()
+              }
+            </MapsPropToMethod>
+            <MapsPropToMethod value={this.props.required} {...adapterProps}>
+              {(instance, value) =>
+                value ? instance.required(value) : instance.noLongerRequired()
+              }
+            </MapsPropToMethod>
+          </div>
+        )}
+      </HIGAdapter>
+    );
+  }
 }
 
 RadioButtonAdapter.propTypes = {
+  /**
+   * Checks the checkbox
+   */
   checked: PropTypes.bool,
+  /**
+   * Initially checks the checkbox, but allows user action to change it
+   */
   defaultChecked: PropTypes.bool,
+  /**
+   * Prevents user actions on the checkbox
+   */
   disabled: PropTypes.bool,
+  /**
+   * Text identifying the field
+   */
   label: PropTypes.string,
+  /**
+   * The name of the checkbox as submitted with a form
+   */
   name: PropTypes.string,
+  /**
+   * Called when user moves focus from the field
+   */
   onBlur: PropTypes.func,
+  /**
+   * Called when user changes the value of the field
+   */
   onChange: PropTypes.func,
+  /**
+   * Called when user puts focus on the field
+   */
   onFocus: PropTypes.func,
+  /**
+   * Marks the field as required, text shown to explain requirment
+   */
   required: PropTypes.string,
+  /**
+   * Value submitted with a form if checked
+   */
   value: PropTypes.string
 };
-
-RadioButtonAdapter.defaultProps = {
-  checked: undefined,
-  defaultChecked: undefined,
-  disabled: undefined,
-  label: undefined,
-  name: undefined,
-  onBlur: undefined,
-  onChange: undefined,
-  onFocus: undefined,
-  required: undefined,
-  value: undefined
-};
-
-RadioButtonAdapter.__docgenInfo = {
-  props: {
-    checked: {
-      description: "checks the checkbox"
-    },
-    defaultChecked: {
-      description:
-        "initially checks the checkbox, but allows user action to change it"
-    },
-    disabled: {
-      description: "prevents user actions on the checkbox"
-    },
-    label: {
-      description: "text identifying the field"
-    },
-    name: {
-      description: "the name of the checkbox as submitted with a form"
-    },
-    onBlur: {
-      description: "called when user moves focus from the field"
-    },
-    onChange: {
-      description: "called when user changes the value of the field"
-    },
-    onFocus: {
-      description: "called when user puts focus on the field"
-    },
-    required: {
-      description:
-        "marks the field as required, text shown to explain requirment"
-    },
-    value: {
-      description: "value submitted with a form if checked"
-    }
-  }
-};
-
-export default RadioButtonAdapter;

--- a/packages/react/src/adapters/FormElements/RangeAdapter.js
+++ b/packages/react/src/adapters/FormElements/RangeAdapter.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Range as VanillaRange } from "hig-vanilla";
 import HIGAdapter, {
@@ -7,139 +7,124 @@ import HIGAdapter, {
   ControlsProp
 } from "../HIGAdapter";
 
-function RangeAdapter(props) {
-  return (
-    <HIGAdapter {...props} displayName="Range" HIGConstructor={VanillaRange}>
-      {adapterProps => (
-        <div>
-          <ControlsProp
-            handler={props.onInput}
-            listener="onInput"
-            setter="setValue"
-            value={props.value}
-            defaultValue={props.defaultValue}
-            {...adapterProps}
-          />
-          <MapsEventListener
-            listener="onBlur"
-            handler={props.onBlur}
-            {...adapterProps}
-          />
-          <MapsEventListener
-            listener="onChange"
-            handler={props.onChange}
-            {...adapterProps}
-          />
-          <MapsEventListener
-            listener="onFocus"
-            handler={props.onFocus}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            setter="setInstructions"
-            value={props.instructions}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            setter="setLabel"
-            value={props.label}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            setter="setMin"
-            value={props.min}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            setter="setMax"
-            value={props.max}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            setter="setStep"
-            value={props.step}
-            {...adapterProps}
-          />
-          <MapsPropToMethod value={props.disabled} {...adapterProps}>
-            {(instance, value) =>
-              value ? instance.disable() : instance.enable()
-            }
-          </MapsPropToMethod>
-          <MapsPropToMethod value={props.required} {...adapterProps}>
-            {(instance, value) =>
-              value ? instance.required(value) : instance.noLongerRequired()
-            }
-          </MapsPropToMethod>
-        </div>
-      )}
-    </HIGAdapter>
-  );
+export default class RangeAdapter extends Component {
+  render() {
+    return (
+      <HIGAdapter
+        {...this.props}
+        displayName="Range"
+        HIGConstructor={VanillaRange}
+      >
+        {adapterProps => (
+          <div>
+            <ControlsProp
+              handler={this.props.onInput}
+              listener="onInput"
+              setter="setValue"
+              value={this.props.value}
+              defaultValue={this.props.defaultValue}
+              {...adapterProps}
+            />
+            <MapsEventListener
+              listener="onBlur"
+              handler={this.props.onBlur}
+              {...adapterProps}
+            />
+            <MapsEventListener
+              listener="onChange"
+              handler={this.props.onChange}
+              {...adapterProps}
+            />
+            <MapsEventListener
+              listener="onFocus"
+              handler={this.props.onFocus}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              setter="setInstructions"
+              value={this.props.instructions}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              setter="setLabel"
+              value={this.props.label}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              setter="setMin"
+              value={this.props.min}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              setter="setMax"
+              value={this.props.max}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              setter="setStep"
+              value={this.props.step}
+              {...adapterProps}
+            />
+            <MapsPropToMethod value={this.props.disabled} {...adapterProps}>
+              {(instance, value) =>
+                value ? instance.disable() : instance.enable()
+              }
+            </MapsPropToMethod>
+            <MapsPropToMethod value={this.props.required} {...adapterProps}>
+              {(instance, value) =>
+                value ? instance.required(value) : instance.noLongerRequired()
+              }
+            </MapsPropToMethod>
+          </div>
+        )}
+      </HIGAdapter>
+    );
+  }
 }
 
 RangeAdapter.propTypes = {
+  /**
+   * Initial value of the field, user action will override
+   */
   defaultValue: PropTypes.string,
+  /**
+   * Prevents user actions on the field
+   */
   disabled: PropTypes.bool,
+  /**
+   * Instructional text for the field
+   */
   instructions: PropTypes.string,
+  /**
+   * Text describing what the field represents
+   */
   label: PropTypes.string,
+  /**
+   * Name of the field when submitted with a form
+   */
   name: PropTypes.string,
+  /**
+   * Called when user moves focus from the field
+   */
   onBlur: PropTypes.func,
+  /**
+   * Called after user changes the value of the field
+   */
   onChange: PropTypes.func,
+  /**
+   * Called when user puts focus onto the field
+   */
   onFocus: PropTypes.func,
+  /**
+   * Called as user changes the value of the field
+   */
   onInput: PropTypes.func,
+  /**
+   * Text describing why the field is required
+   */
   required: PropTypes.string,
+  /**
+   * Value of the field
+   */
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 };
-
-RangeAdapter.defaultProps = {
-  defaultValue: undefined,
-  disabled: undefined,
-  instructions: undefined,
-  label: undefined,
-  name: undefined,
-  onBlur: undefined,
-  onChange: undefined,
-  onFocus: undefined,
-  onInput: undefined,
-  required: undefined,
-  value: undefined
-};
-
-RangeAdapter.__docgenInfo = {
-  props: {
-    defaultValue: {
-      description: "initial value of the field, user raction will override"
-    },
-    disabled: {
-      description: "prevents user actions on the field"
-    },
-    instructions: {
-      description: "instructional text for the field"
-    },
-    label: {
-      description: "text describing what the field represents"
-    },
-    name: {
-      description: "name of the field when submitted with a form"
-    },
-    onBlur: {
-      description: "called when user moves focus from the field"
-    },
-    onChange: {
-      description: "called after user changes the value of the field"
-    },
-    onFocus: {
-      description: "called when user puts focus onto the field"
-    },
-    onInput: {
-      description: "called as user changes the value of the field"
-    },
-    required: {
-      description: "text describing why the field is required"
-    },
-    value: {
-      description: "value of the field"
-    }
-  }
-};
-
-export default RangeAdapter;

--- a/packages/react/src/adapters/FormElements/RangeAdapter.test.js
+++ b/packages/react/src/adapters/FormElements/RangeAdapter.test.js
@@ -1,0 +1,35 @@
+import React from "react";
+import { mount } from "enzyme";
+import { Range as VanillaRange } from "hig-vanilla";
+import RangeAdapter from "./RangeAdapter";
+
+describe("RangeAdapter", () => {
+  it("implements the hig interface", () => {
+    expect(spiedInstance => {
+      mount(
+        <RangeAdapter
+          higInstance={spiedInstance}
+          min={0}
+          max={100}
+          step={2}
+          label="Range"
+          instructions="It's a range"
+          disabled
+          required="This is definitely required"
+          onChange={jest.fn()}
+          onFocus={jest.fn()}
+          onBlur={jest.fn()}
+          onInput={jest.fn()}
+        />
+      );
+
+      mount(
+        <RangeAdapter
+          higInstance={spiedInstance}
+          disabled={false}
+          required=""
+        />
+      );
+    }).toImplementHIGInterfaceOf(VanillaRange);
+  });
+});

--- a/packages/react/src/adapters/FormElements/TextAreaAdapter.js
+++ b/packages/react/src/adapters/FormElements/TextAreaAdapter.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { TextArea as VanillaTextArea } from "hig-vanilla";
 import HIGAdapter, {
@@ -7,143 +7,123 @@ import HIGAdapter, {
   ControlsProp
 } from "../HIGAdapter";
 
-function TextAreaAdapter(props) {
-  return (
-    <HIGAdapter
-      {...props}
-      displayName="TextArea"
-      HIGConstructor={VanillaTextArea}
-    >
-      {adapterProps => (
-        <div>
-          <ControlsProp
-            handler={props.onInput}
-            listener="onInput"
-            setter="setValue"
-            value={props.value}
-            defaultValue={props.defaultValue}
-            {...adapterProps}
-          />
-          <MapsEventListener
-            listener="onBlur"
-            handler={props.onBlur}
-            {...adapterProps}
-          />
-          <MapsEventListener
-            listener="onChange"
-            handler={props.onChange}
-            {...adapterProps}
-          />
-          <MapsEventListener
-            listener="onFocus"
-            handler={props.onFocus}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            setter="setInstructions"
-            value={props.instructions}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            setter="setPlaceholder"
-            value={props.placeholder}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            setter="setLabel"
-            value={props.label}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            setter="setName"
-            value={props.name}
-            {...adapterProps}
-          />
-          <MapsPropToMethod value={props.disabled} {...adapterProps}>
-            {(instance, value) =>
-              value ? instance.disable() : instance.enable()
-            }
-          </MapsPropToMethod>
-          <MapsPropToMethod value={props.required} {...adapterProps}>
-            {(instance, value) =>
-              value ? instance.required(value) : instance.noLongerRequired()
-            }
-          </MapsPropToMethod>
-        </div>
-      )}
-    </HIGAdapter>
-  );
+export default class TextAreaAdapter extends Component {
+  render() {
+    return (
+      <HIGAdapter
+        {...this.props}
+        displayName="TextArea"
+        HIGConstructor={VanillaTextArea}
+      >
+        {adapterProps => (
+          <div>
+            <ControlsProp
+              handler={this.props.onInput}
+              listener="onInput"
+              setter="setValue"
+              value={this.props.value}
+              defaultValue={this.props.defaultValue}
+              {...adapterProps}
+            />
+            <MapsEventListener
+              listener="onBlur"
+              handler={this.props.onBlur}
+              {...adapterProps}
+            />
+            <MapsEventListener
+              listener="onChange"
+              handler={this.props.onChange}
+              {...adapterProps}
+            />
+            <MapsEventListener
+              listener="onFocus"
+              handler={this.props.onFocus}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              setter="setInstructions"
+              value={this.props.instructions}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              setter="setPlaceholder"
+              value={this.props.placeholder}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              setter="setLabel"
+              value={this.props.label}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              setter="setName"
+              value={this.props.name}
+              {...adapterProps}
+            />
+            <MapsPropToMethod value={this.props.disabled} {...adapterProps}>
+              {(instance, value) =>
+                value ? instance.disable() : instance.enable()
+              }
+            </MapsPropToMethod>
+            <MapsPropToMethod value={this.props.required} {...adapterProps}>
+              {(instance, value) =>
+                value ? instance.required(value) : instance.noLongerRequired()
+              }
+            </MapsPropToMethod>
+          </div>
+        )}
+      </HIGAdapter>
+    );
+  }
 }
 
 TextAreaAdapter.propTypes = {
+  /**
+   * Initial value of the field, user actions will override
+   */
   defaultValue: PropTypes.string,
+  /**
+   * Prevents user actions on the field
+   */
   disabled: PropTypes.bool,
+  /**
+   * Instructional text for the field
+   */
   instructions: PropTypes.string,
+  /**
+   * Text describing what the field represents
+   */
   label: PropTypes.string,
+  /**
+   * Name of the field when submitted with a form
+   */
   name: PropTypes.string,
+  /**
+   * Called when user moves focus from the field
+   */
   onBlur: PropTypes.func,
+  /**
+   * Called after user changes the value of the field
+   */
   onChange: PropTypes.func,
+  /**
+   * Called when user puts focus onto the field
+   */
   onFocus: PropTypes.func,
+  /**
+   * Called as user changes the value of the field
+   */
   onInput: PropTypes.func,
+  /**
+   * Example of what the user should type into the field
+   */
   placeholder: PropTypes.string,
+  /**
+   * Text describing why the field is required
+   */
   required: PropTypes.string,
+  /**
+   * Value of the field
+   */
   value: PropTypes.string
 };
-
-TextAreaAdapter.defaultProps = {
-  defaultValue: undefined,
-  disabled: undefined,
-  instructions: undefined,
-  label: undefined,
-  name: undefined,
-  onBlur: undefined,
-  onChange: undefined,
-  onFocus: undefined,
-  onInput: undefined,
-  placeholder: undefined,
-  required: undefined,
-  value: undefined
-};
-
-TextAreaAdapter.__docgenInfo = {
-  props: {
-    defaultValue: {
-      description: "initial value of the field, user actions will override"
-    },
-    disabled: {
-      description: "prevents user actions on the field"
-    },
-    instructions: {
-      description: "instructional text for the field"
-    },
-    label: {
-      description: "text describing what the field represents"
-    },
-    name: {
-      description: "name of the field when submitted with a form"
-    },
-    onBlur: {
-      description: "called when user moves focus from the field"
-    },
-    onChange: {
-      description: "called after user changes the value of the field"
-    },
-    onFocus: {
-      description: "called when user puts focus onto the field"
-    },
-    onInput: {
-      description: "called as user changes the value of the field"
-    },
-    placeholder: {
-      description: "example of what the user should type into the field"
-    },
-    required: {
-      description: "text describing why the field is required"
-    },
-    value: {
-      description: "value of the field"
-    }
-  }
-};
-
-export default TextAreaAdapter;

--- a/packages/react/src/adapters/FormElements/TextFieldAdapter.js
+++ b/packages/react/src/adapters/FormElements/TextFieldAdapter.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { TextField as VanillaTextField } from "hig-vanilla";
 import HIGAdapter, {
@@ -7,174 +7,153 @@ import HIGAdapter, {
   ControlsProp
 } from "../HIGAdapter";
 
-function TextFieldAdapter(props) {
-  return (
-    <HIGAdapter
-      {...props}
-      displayName="TextField"
-      HIGConstructor={VanillaTextField}
-    >
-      {adapterProps => (
-        <div>
-          <ControlsProp
-            handler={props.onInput}
-            listener="onInput"
-            setter="setValue"
-            value={props.value}
-            defaultValue={props.defaultValue}
-            {...adapterProps}
-          />
-          <MapsEventListener
-            listener="onBlur"
-            handler={props.onBlur}
-            {...adapterProps}
-          />
-          <MapsEventListener
-            listener="onChange"
-            handler={props.onChange}
-            {...adapterProps}
-          />
-          <MapsEventListener
-            listener="onClearButtonClick"
-            handler={props.onClearButtonClick}
-            {...adapterProps}
-          />
-          <MapsEventListener
-            listener="onFocus"
-            handler={props.onFocus}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            setter="setInstructions"
-            value={props.instructions}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            setter="setPlaceholder"
-            value={props.placeholder}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            setter="setLabel"
-            value={props.label}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            setter="setName"
-            value={props.name}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            setter="setIcon"
-            value={props.icon}
-            {...adapterProps}
-          />
-          <MapsPropToMethod value={props.disabled} {...adapterProps}>
-            {(instance, value) =>
-              value ? instance.disable() : instance.enable()
-            }
-          </MapsPropToMethod>
-          <MapsPropToMethod value={props.required} {...adapterProps}>
-            {(instance, value) =>
-              value ? instance.required(value) : instance.noLongerRequired()
-            }
-          </MapsPropToMethod>
-          <MapsPropToMethod value={props.showClearButton} {...adapterProps}>
-            {(instance, value) =>
-              value ? instance.showClearButton() : instance.hideClearButton()
-            }
-          </MapsPropToMethod>
-        </div>
-      )}
-    </HIGAdapter>
-  );
+export default class TextFieldAdapter extends Component {
+  render() {
+    return (
+      <HIGAdapter
+        {...this.props}
+        displayName="TextField"
+        HIGConstructor={VanillaTextField}
+      >
+        {adapterProps => (
+          <div>
+            <ControlsProp
+              handler={this.props.onInput}
+              listener="onInput"
+              setter="setValue"
+              value={this.props.value}
+              defaultValue={this.props.defaultValue}
+              {...adapterProps}
+            />
+            <MapsEventListener
+              listener="onBlur"
+              handler={this.props.onBlur}
+              {...adapterProps}
+            />
+            <MapsEventListener
+              listener="onChange"
+              handler={this.props.onChange}
+              {...adapterProps}
+            />
+            <MapsEventListener
+              listener="onClearButtonClick"
+              handler={this.props.onClearButtonClick}
+              {...adapterProps}
+            />
+            <MapsEventListener
+              listener="onFocus"
+              handler={this.props.onFocus}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              setter="setInstructions"
+              value={this.props.instructions}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              setter="setPlaceholder"
+              value={this.props.placeholder}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              setter="setLabel"
+              value={this.props.label}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              setter="setName"
+              value={this.props.name}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              setter="setIcon"
+              value={this.props.icon}
+              {...adapterProps}
+            />
+            <MapsPropToMethod value={this.props.disabled} {...adapterProps}>
+              {(instance, value) =>
+                value ? instance.disable() : instance.enable()
+              }
+            </MapsPropToMethod>
+            <MapsPropToMethod value={this.props.required} {...adapterProps}>
+              {(instance, value) =>
+                value ? instance.required(value) : instance.noLongerRequired()
+              }
+            </MapsPropToMethod>
+            <MapsPropToMethod
+              value={this.props.showClearButton}
+              {...adapterProps}
+            >
+              {(instance, value) =>
+                value ? instance.showClearButton() : instance.hideClearButton()
+              }
+            </MapsPropToMethod>
+          </div>
+        )}
+      </HIGAdapter>
+    );
+  }
 }
 
 TextFieldAdapter.propTypes = {
+  /**
+   * Initial value of the field, user actions will override
+   */
   defaultValue: PropTypes.string,
+  /**
+   * Prevents user actions on the field
+   */
   disabled: PropTypes.bool,
+  /**
+   * Icon for the field, either the name of an included icon, or an svg string of a custom icon
+   */
   icon: PropTypes.string,
+  /**
+   * Instructional text for the field
+   */
   instructions: PropTypes.string,
+  /**
+   * Text describing what the field represents
+   */
   label: PropTypes.string,
+  /**
+   * Name of the field when submitted with a form
+   */
   name: PropTypes.string,
+  /**
+   * Called when user moves focus from the field
+   */
   onBlur: PropTypes.func,
+  /**
+   * Called after user changes the value of the field
+   */
   onChange: PropTypes.func,
+  /**
+   * Called when user clicks the clear button
+   */
   onClearButtonClick: PropTypes.func,
+  /**
+   * Called when user puts focus onto the field
+   */
   onFocus: PropTypes.func,
+  /**
+   * Called as user changes the value of the field
+   */
   onInput: PropTypes.func,
+  /**
+   * Example of what the user should type into the field
+   */
   placeholder: PropTypes.string,
+  /**
+   * Text describing why the field is required
+   */
   required: PropTypes.string,
+  /**
+   * When true, causes the clear button to appear
+   */
   showClearButton: PropTypes.bool,
+  /**
+   * Value of the field
+   */
   value: PropTypes.string
 };
-
-TextFieldAdapter.defaultProps = {
-  defaultValue: undefined,
-  disabled: undefined,
-  icon: undefined,
-  instructions: undefined,
-  label: undefined,
-  name: undefined,
-  onBlur: undefined,
-  onChange: undefined,
-  onClearButtonClick: undefined,
-  onFocus: undefined,
-  onInput: undefined,
-  placeholder: undefined,
-  required: undefined,
-  showClearButton: undefined,
-  value: undefined
-};
-
-TextFieldAdapter.__docgenInfo = {
-  props: {
-    defaultValue: {
-      description: "initial value of the field, user actions will override"
-    },
-    disabled: {
-      description: "prevents user actions on the field"
-    },
-    icon: {
-      description:
-        "icon for the field, either the name of an included icon, or an svg string of a custom icon"
-    },
-    instructions: {
-      description: "instructional text for the field"
-    },
-    label: {
-      description: "text describing what the field represents"
-    },
-    name: {
-      description: "name of the field when submitted with a form"
-    },
-    onBlur: {
-      description: "called when user moves focus from the field"
-    },
-    onChange: {
-      description: "called after user changes the value of the field"
-    },
-    onClearButtonClick: {
-      description: "called when user clicks the clear button"
-    },
-    onFocus: {
-      description: "called when user puts focus onto the field"
-    },
-    onInput: {
-      description: "called as user changes the value of the field"
-    },
-    placeholder: {
-      description: "example of what the user should type into the field"
-    },
-    required: {
-      description: "text describing why the field is required"
-    },
-    showClearButton: {
-      description: "when true causes the clear button to appear"
-    },
-    value: {
-      description: "value of the field"
-    }
-  }
-};
-
-export default TextFieldAdapter;

--- a/packages/react/src/adapters/GlobalNav/TopNav/NotificationAdapter.js
+++ b/packages/react/src/adapters/GlobalNav/TopNav/NotificationAdapter.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Notification as VanillaNotification } from "hig-vanilla";
 
@@ -9,75 +9,69 @@ import HIGAdapter, {
   MapsEventListener
 } from "../../HIGAdapter";
 
-function NotificationAdapter(props) {
-  return (
-    <HIGAdapter
-      displayName="NotificationAdapter"
-      HIGConstructor={VanillaNotification}
-      {...props}
-    >
-      {adapterProps => (
-        <div>
-          <MountedByHIGParent mounter="addNotification" {...adapterProps} />
-          <MapsPropToMethod
-            value={props.timestamp}
-            setter="setCreatedAt"
-            {...adapterProps}
-          />
-          <MapsEventListener
-            listener="onClick"
-            handler={props.onClick}
-            {...adapterProps}
-          />
-          <MapsEventListener
-            listener="onFeaturedClick"
-            handler={props.onFeaturedClick}
-            {...adapterProps}
-          />
-          <MapsPropToMethod value={props.unread} {...adapterProps}>
-            {(instance, value) =>
-              value ? instance.markUnread() : instance.markRead()
-            }
-          </MapsPropToMethod>
-          <MapsPropToMethod value={props.featured} {...adapterProps}>
-            {(instance, value) =>
-              value ? instance.setFeatured() : instance.removeFeatured()
-            }
-          </MapsPropToMethod>
-          <MountsAnyChild mounter="setContent" {...adapterProps}>
-            {props.children}
-          </MountsAnyChild>
-        </div>
-      )}
-    </HIGAdapter>
-  );
+export default class NotificationAdapter extends Component {
+  render() {
+    return (
+      <HIGAdapter
+        displayName="NotificationAdapter"
+        HIGConstructor={VanillaNotification}
+        {...this.props}
+      >
+        {adapterProps => (
+          <div>
+            <MountedByHIGParent mounter="addNotification" {...adapterProps} />
+            <MapsPropToMethod
+              value={this.props.timestamp}
+              setter="setCreatedAt"
+              {...adapterProps}
+            />
+            <MapsEventListener
+              listener="onClick"
+              handler={this.props.onClick}
+              {...adapterProps}
+            />
+            <MapsEventListener
+              listener="onFeaturedClick"
+              handler={this.props.onFeaturedClick}
+              {...adapterProps}
+            />
+            <MapsPropToMethod value={this.props.unread} {...adapterProps}>
+              {(instance, value) =>
+                value ? instance.markUnread() : instance.markRead()
+              }
+            </MapsPropToMethod>
+            <MapsPropToMethod value={this.props.featured} {...adapterProps}>
+              {(instance, value) =>
+                value ? instance.setFeatured() : instance.removeFeatured()
+              }
+            </MapsPropToMethod>
+            <MountsAnyChild mounter="setContent" {...adapterProps}>
+              {this.props.children}
+            </MountsAnyChild>
+          </div>
+        )}
+      </HIGAdapter>
+    );
+  }
 }
 
 NotificationAdapter.propTypes = {
+  /**
+   * Calls the provided callback when user clicks on the noticatiosn icon in the top nav
+   */
   onClick: PropTypes.func,
   onDismissed: PropTypes.func,
+  /**
+   * {Boolean} to show specify whether notificaiton is read
+   */
   unread: PropTypes.bool,
   featured: PropTypes.bool,
+  /**
+   * Content for notification
+   */
   children: PropTypes.node,
+  /**
+   * Timestamp for notification
+   */
   timestamp: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]) // ISO date string
 };
-
-NotificationAdapter.__docgenInfo = {
-  props: {
-    unread: {
-      description: "{Boolean} to show specify whether notificaiton is read"
-    },
-    children: {
-      description: "content for notification"
-    },
-    timestamp: {
-      description: "timstamp for notification"
-    },
-    onClick: {
-      description:
-        "Calls the provided callback when user clicks on the noticatiosn icon in the top nav"
-    }
-  }
-};
-
-export default NotificationAdapter;

--- a/packages/react/src/adapters/GridAdapter.js
+++ b/packages/react/src/adapters/GridAdapter.js
@@ -1,34 +1,29 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Grid as VanillaGrid } from "hig-vanilla";
 import HIGAdapter, { MountsHIGChildList } from "./HIGAdapter";
 
-function GridAdapter(props) {
-  return (
-    <HIGAdapter {...props} displayName="Grid" HIGConstructor={VanillaGrid}>
-      {adapterProps => (
-        <MountsHIGChildList {...adapterProps}>
-          {props.children}
-        </MountsHIGChildList>
-      )}
-    </HIGAdapter>
-  );
+export default class GridAdapter extends Component {
+  render() {
+    return (
+      <HIGAdapter
+        {...this.props}
+        displayName="Grid"
+        HIGConstructor={VanillaGrid}
+      >
+        {adapterProps => (
+          <MountsHIGChildList {...adapterProps}>
+            {this.props.children}
+          </MountsHIGChildList>
+        )}
+      </HIGAdapter>
+    );
+  }
 }
 
 GridAdapter.propTypes = {
+  /**
+   * Support adding GridItems
+   */
   children: PropTypes.node
 };
-
-GridAdapter.defaultProps = {
-  children: undefined
-};
-
-GridAdapter.__docgenInfo = {
-  props: {
-    children: {
-      description: "support adding GridItems"
-    }
-  }
-};
-
-export default GridAdapter;

--- a/packages/react/src/adapters/GridItemAdapter.js
+++ b/packages/react/src/adapters/GridItemAdapter.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Grid as VanillaGrid } from "hig-vanilla";
 import HIGAdapter, {
@@ -7,52 +7,66 @@ import HIGAdapter, {
   MountsAnyChild
 } from "./HIGAdapter";
 
-function GridItemAdapter(props) {
-  return (
-    <HIGAdapter
-      {...props}
-      displayName="GridItem"
-      HIGConstructor={VanillaGrid._partials.GridItem}
-    >
-      {adapterProps => (
-        <div>
-          <MountedByHIGParentList mounter="addGridItem" {...adapterProps} />
-          <MapsPropToMethod
-            setter="setFraction"
-            value={props.fraction}
-            {...adapterProps}
-          />
-          {props.children ? (
-            <MountsAnyChild mounter="addSlot" {...adapterProps}>
-              {props.children}
-            </MountsAnyChild>
-          ) : null}
-        </div>
-      )}
-    </HIGAdapter>
-  );
+export default class GridItemAdapter extends Component {
+  render() {
+    return (
+      <HIGAdapter
+        {...this.props}
+        displayName="GridItem"
+        HIGConstructor={VanillaGrid._partials.GridItem}
+      >
+        {adapterProps => (
+          <div>
+            <MountedByHIGParentList mounter="addGridItem" {...adapterProps} />
+            <MapsPropToMethod
+              setter="setFraction"
+              value={this.props.fraction}
+              {...adapterProps}
+            />
+            {this.props.children ? (
+              <MountsAnyChild mounter="addSlot" {...adapterProps}>
+                {this.props.children}
+              </MountsAnyChild>
+            ) : null}
+          </div>
+        )}
+      </HIGAdapter>
+    );
+  }
 }
 
 GridItemAdapter.propTypes = {
+  /**
+   * Fraction in english, with 1, 2, 4, 8, 12 as nominators
+   * So our possible values are:
+   *   'one-whole'
+   *   'one-half'
+   *   'one-quarter'
+   *   'two-quarter'
+   *   'three-quarter'
+   *   'one-eighth'
+   *   'two-eighths'
+   *   'three-eighths'
+   *   'four-eighths'
+   *   'five-eights'
+   *   'six-eighths'
+   *   'seven-eighths'
+   *   'one-twelfth'
+   *   'two-twelfths'
+   *   'three-twelfths'
+   *   'four-twelfths'
+   *   'five-twelfths'
+   *   'six-twelfths'
+   *   'seven-twelfths'
+   *   'eight-twelfths'
+   *   'nine-twelfths'
+   *   'ten-twelfths'
+   *   'eleven-twelfths'
+   */
   fraction: PropTypes.oneOf(VanillaGrid._partials.GridItem.AvailableFractions)
     .isRequired,
+  /**
+   * Content for the grid item
+   */
   children: PropTypes.node
 };
-
-GridItemAdapter.defaultProps = {
-  children: undefined
-};
-
-GridItemAdapter.__docgenInfo = {
-  props: {
-    fraction: {
-      description:
-        "fraction in english, with 1, 2, 4, 8, 12 as nominators, so our possible values are: 'one-whole', 'one-half', 'one-quarter', 'two-quarter', 'three-quarter', 'one-eighth', 'two-eighths', 'three-eighths', 'four-eighths', 'five-eights', 'six-eighths', 'seven-eighths', 'one-twelfth', 'two-twelfths', 'three-twelfths', 'four-twelfths', 'five-twelfths', 'six-twelfths', 'seven-twelfths', 'eight-twelfths', 'nine-twelfths', 'ten-twelfths', 'eleven-twelfths'" // eslint-disable-line max-len
-    },
-    children: {
-      description: "Content for the grid item"
-    }
-  }
-};
-
-export default GridItemAdapter;

--- a/packages/react/src/adapters/IconAdapter.js
+++ b/packages/react/src/adapters/IconAdapter.js
@@ -1,32 +1,31 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Icon as VanillaIcon } from "hig-vanilla";
 import HIGAdapter, { MapsPropToMethod } from "./HIGAdapter";
 
-function IconAdapter(props) {
-  return (
-    <HIGAdapter {...props} displayName="Icon" HIGConstructor={VanillaIcon}>
-      {adapterProps => (
-        <MapsPropToMethod
-          setter="setNameOrSVG"
-          value={props.nameOrSVG}
-          {...adapterProps}
-        />
-      )}
-    </HIGAdapter>
-  );
+export default class IconAdapter extends Component {
+  render() {
+    return (
+      <HIGAdapter
+        {...this.props}
+        displayName="Icon"
+        HIGConstructor={VanillaIcon}
+      >
+        {adapterProps => (
+          <MapsPropToMethod
+            setter="setNameOrSVG"
+            value={this.props.nameOrSVG}
+            {...adapterProps}
+          />
+        )}
+      </HIGAdapter>
+    );
+  }
 }
 
 IconAdapter.propTypes = {
+  /**
+   * Name of an included icon, or svg string of a custom icon
+   */
   nameOrSVG: PropTypes.string.isRequired
 };
-
-IconAdapter.__docgenInfo = {
-  props: {
-    nameOrSVG: {
-      description: "name of an included icon, or svg string of a custom icon"
-    }
-  }
-};
-
-export default IconAdapter;

--- a/packages/react/src/adapters/IconButtonAdapter.js
+++ b/packages/react/src/adapters/IconButtonAdapter.js
@@ -1,122 +1,107 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { IconButton as VanillaIconButton } from "hig-vanilla";
 
 import HIGAdapter, { MapsPropToMethod, MapsEventListener } from "./HIGAdapter";
 
-function IconButtonAdapter(props) {
-  return (
-    <HIGAdapter
-      displayName="IconButton"
-      HIGConstructor={VanillaIconButton}
-      {...props}
-    >
-      {adapterProps => (
-        <div>
-          <MapsPropToMethod
-            value={props.title}
-            setter="setTitle"
-            {...adapterProps}
-          />
-          <MapsEventListener
-            listener="onClick"
-            handler={props.onClick}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            value={props.link}
-            setter="setLink"
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            value={props.icon}
-            setter="setIcon"
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            value={props.type}
-            setter="setType"
-            {...adapterProps}
-          />
-          <MapsPropToMethod value={props.disabled} {...adapterProps}>
-            {(instance, value) =>
-              value ? instance.disable() : instance.enable()
-            }
-          </MapsPropToMethod>
+export default class IconButtonAdapter extends Component {
+  render() {
+    return (
+      <HIGAdapter
+        displayName="IconButton"
+        HIGConstructor={VanillaIconButton}
+        {...this.props}
+      >
+        {adapterProps => (
+          <div>
+            <MapsPropToMethod
+              value={this.props.title}
+              setter="setTitle"
+              {...adapterProps}
+            />
+            <MapsEventListener
+              listener="onClick"
+              handler={this.props.onClick}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              value={this.props.link}
+              setter="setLink"
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              value={this.props.icon}
+              setter="setIcon"
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              value={this.props.type}
+              setter="setType"
+              {...adapterProps}
+            />
+            <MapsPropToMethod value={this.props.disabled} {...adapterProps}>
+              {(instance, value) =>
+                value ? instance.disable() : instance.enable()
+              }
+            </MapsPropToMethod>
 
-          <MapsEventListener
-            listener="onHover"
-            handler={props.onHover}
-            {...adapterProps}
-          />
-          <MapsEventListener
-            listener="onFocus"
-            handler={props.onFocus}
-            {...adapterProps}
-          />
-          <MapsEventListener
-            listener="onBlur"
-            handler={props.onBlur}
-            {...adapterProps}
-          />
-        </div>
-      )}
-    </HIGAdapter>
-  );
+            <MapsEventListener
+              listener="onHover"
+              handler={this.props.onHover}
+              {...adapterProps}
+            />
+            <MapsEventListener
+              listener="onFocus"
+              handler={this.props.onFocus}
+              {...adapterProps}
+            />
+            <MapsEventListener
+              listener="onBlur"
+              handler={this.props.onBlur}
+              {...adapterProps}
+            />
+          </div>
+        )}
+      </HIGAdapter>
+    );
+  }
 }
 
 IconButtonAdapter.propTypes = {
+  /**
+   * Title of the button for accessibility purposes
+   */
   title: PropTypes.string.isRequired,
+  /**
+   * Url button will navigate to when clicked
+   */
   link: PropTypes.string,
+  /**
+   * Name of an included icon, or svg string of a custom icon
+   */
   icon: PropTypes.string.isRequired,
+  /**
+   * Prevents user actions on the button
+   */
   disabled: PropTypes.bool,
+  /**
+   * Called when user moves focus away from the button
+   */
   onBlur: PropTypes.func,
+  /**
+   * Called when user clicks the button
+   */
   onClick: PropTypes.func,
+  /**
+   * Called when user moves focus onto the button
+   */
   onFocus: PropTypes.func,
+  /**
+   * Called when user moves the mouse over the button
+   */
   onHover: PropTypes.func,
+  /**
+   * 'primary' or 'flat'; the style of the button
+   */
   type: PropTypes.oneOf(VanillaIconButton.AvailableTypes)
 };
-
-IconButtonAdapter.defaultProps = {
-  link: undefined,
-  disabled: false,
-  onBlur: undefined,
-  onClick: undefined,
-  onFocus: undefined,
-  onHover: undefined,
-  type: undefined
-};
-
-IconButtonAdapter.__docgenInfo = {
-  props: {
-    title: {
-      description: "title of the button for accessibility purposes"
-    },
-    link: {
-      description: "url button will navigate to when clicked"
-    },
-    icon: {
-      description: "name of an included icon, or svg string of a custom icon"
-    },
-    disabled: {
-      description: "prevents user actions on the button"
-    },
-    onBlur: {
-      description: "called when user moves focus away from the button"
-    },
-    onClick: {
-      description: "called when user clicks the button"
-    },
-    onFocus: {
-      description: "called when user moves focus onto the button"
-    },
-    onHover: {
-      description: "called when user moves the mouse over the button"
-    },
-    type: {
-      description: "'primary' or 'flat'; the style of the button"
-    }
-  }
-};
-
-export default IconButtonAdapter;

--- a/packages/react/src/adapters/ImageAdapter.js
+++ b/packages/react/src/adapters/ImageAdapter.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Image as VanillaImage } from "hig-vanilla";
 
-class ImageAdapter extends Component {
+export default class ImageAdapter extends Component {
   render() {
     return (
       <img
@@ -15,14 +15,8 @@ class ImageAdapter extends Component {
 }
 
 ImageAdapter.propTypes = {
+  /**
+   * Path to image
+   */
   src: PropTypes.string
 };
-
-ImageAdapter.__docgenInfo = {
-  props: {
-    src: {
-      description: "path to image"
-    }
-  }
-};
-export default ImageAdapter;

--- a/packages/react/src/adapters/ModalAdapter.js
+++ b/packages/react/src/adapters/ModalAdapter.js
@@ -9,7 +9,7 @@ import HIGAdapter, {
 } from "./HIGAdapter";
 import { Button } from "../hig-react";
 
-class ModalAdapter extends Component {
+export default class ModalAdapter extends Component {
   constructor(props) {
     super(props);
     this.buttons = [];
@@ -82,58 +82,40 @@ class ModalAdapter extends Component {
 }
 
 ModalAdapter.propTypes = {
+  /**
+   * Text or html string content of the modal
+   */
   body: PropTypes.string,
+  /**
+   * An array of props supported by the Button component
+   */
   buttons: PropTypes.arrayOf(PropTypes.shape(Button.propTypes)),
+  /**
+   * Supports adding any dom content to the body of the modal
+   */
   children: PropTypes.node,
+  /**
+   * Triggers when you click the close button
+   */
   onCloseClick: PropTypes.func,
+  /**
+   * Triggers when you click the overlay behind the modal
+   */
   onOverlayClick: PropTypes.func,
+  /**
+   * Modal is visible when true
+   */
   open: PropTypes.bool,
+  /**
+   * Style of the modal shell
+   */
   style: PropTypes.oneOf(VanillaModal.AvailableStyles),
+  /**
+   * Title of the modal
+   */
   title: PropTypes.string
-};
-
-ModalAdapter.defaultProps = {
-  body: undefined,
-  buttons: undefined,
-  children: undefined,
-  onCloseClick: undefined,
-  onOverlayClick: undefined,
-  open: undefined,
-  style: undefined,
-  title: undefined
-};
-
-ModalAdapter.__docgenInfo = {
-  props: {
-    body: {
-      description: "text or html string content of the modal"
-    },
-    buttons: {
-      description: "an array of props supported by the Button component"
-    },
-    style: {
-      description: "style of the modal shell"
-    },
-    onCloseClick: {
-      description: "triggers when you click the close button"
-    },
-    onOverlayClick: {
-      description: "triggers when you click the overlay behind the modal"
-    },
-    open: {
-      description: "modal is visible when true"
-    },
-    title: {
-      description: "title of the modal"
-    },
-    children: {
-      description: "supports add any dom content to the body of the modal"
-    }
-  }
 };
 
 ModalAdapter.defaultProps = {
   buttons: []
 };
-
-export default ModalAdapter;

--- a/packages/react/src/adapters/ProgressBarAdapter.js
+++ b/packages/react/src/adapters/ProgressBarAdapter.js
@@ -1,37 +1,31 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { ProgressBar } from "hig-vanilla";
 import HIGAdapter, { MapsPropToMethod } from "./HIGAdapter";
 
-function ProgressBarAdapter(props) {
-  return (
-    <HIGAdapter
-      {...props}
-      displayName="ProgressBar"
-      HIGConstructor={ProgressBar}
-    >
-      {higProps => (
-        <MapsPropToMethod
-          value={props.percentComplete}
-          setter="setPercentComplete"
-          {...higProps}
-        />
-      )}
-    </HIGAdapter>
-  );
+export default class ProgressBarAdapter extends Component {
+  render() {
+    return (
+      <HIGAdapter
+        {...this.props}
+        displayName="ProgressBar"
+        HIGConstructor={ProgressBar}
+      >
+        {higProps => (
+          <MapsPropToMethod
+            value={this.props.percentComplete}
+            setter="setPercentComplete"
+            {...higProps}
+          />
+        )}
+      </HIGAdapter>
+    );
+  }
 }
 
 ProgressBarAdapter.propTypes = {
+  /**
+   * An integer from 0 to 100 representing the percent the delayed operation has completed
+   */
   percentComplete: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 };
-
-ProgressBarAdapter.__docgenInfo = {
-  props: {
-    percentComplete: {
-      description:
-        "An integer from 0 to 100 representing the percent the delayed operation has completed"
-    }
-  }
-};
-
-export default ProgressBarAdapter;

--- a/packages/react/src/adapters/ProgressRingAdapter.js
+++ b/packages/react/src/adapters/ProgressRingAdapter.js
@@ -1,49 +1,42 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { ProgressRing } from "hig-vanilla";
 import HIGAdapter, { MapsPropToMethod } from "./HIGAdapter";
 
-function ProgressRingAdapter(props) {
-  return (
-    <HIGAdapter
-      {...props}
-      displayName="ProgressRing"
-      HIGConstructor={ProgressRing}
-    >
-      {higProps => (
-        <div>
-          <MapsPropToMethod
-            value={props.percentComplete}
-            setter="setPercentComplete"
-            {...higProps}
-          />
-          <MapsPropToMethod value={props.size} setter="setSize" {...higProps} />
-        </div>
-      )}
-    </HIGAdapter>
-  );
+export default class ProgressRingAdapter extends Component {
+  render() {
+    return (
+      <HIGAdapter
+        {...this.props}
+        displayName="ProgressRing"
+        HIGConstructor={ProgressRing}
+      >
+        {higProps => (
+          <div>
+            <MapsPropToMethod
+              value={this.props.percentComplete}
+              setter="setPercentComplete"
+              {...higProps}
+            />
+            <MapsPropToMethod
+              value={this.props.size}
+              setter="setSize"
+              {...higProps}
+            />
+          </div>
+        )}
+      </HIGAdapter>
+    );
+  }
 }
 
 ProgressRingAdapter.propTypes = {
+  /**
+   * An integer from 0 to 100 representing the percent the delayed operation has completed
+   */
   percentComplete: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /**
+   * {xs, s, m, l} the size of the progress indicator
+   */
   size: PropTypes.oneOf(ProgressRing.AvailableSizes)
 };
-
-ProgressRingAdapter.defaultProps = {
-  percentComplete: undefined,
-  size: undefined
-};
-
-ProgressRingAdapter.__docgenInfo = {
-  props: {
-    percentComplete: {
-      description:
-        "An integer from 0 to 100 representing the percent the delayed operation has completed"
-    },
-    size: {
-      description: "{xs, s, m, l} the size of the progress indicator"
-    }
-  }
-};
-
-export default ProgressRingAdapter;

--- a/packages/react/src/adapters/SectionLabelAdapter.js
+++ b/packages/react/src/adapters/SectionLabelAdapter.js
@@ -1,46 +1,41 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 
 import { SectionLabel as VanillaSectionLabel } from "hig-vanilla";
 import HIGAdapter, { MapsPropToMethod, MountsAnyChild } from "./HIGAdapter";
 
-function SectionLabelAdapter(props) {
-  return (
-    <HIGAdapter
-      displayName="SectionLabel"
-      HIGConstructor={VanillaSectionLabel}
-      {...props}
-    >
-      {adapterProps => (
-        <div>
-          <MapsPropToMethod
-            value={props.label}
-            setter="setLabel"
-            {...adapterProps}
-          />
-          <MountsAnyChild mounter="addSlot" {...adapterProps}>
-            {props.children}
-          </MountsAnyChild>
-        </div>
-      )}
-    </HIGAdapter>
-  );
+export default class SectionLabelAdapter extends Component {
+  render() {
+    return (
+      <HIGAdapter
+        displayName="SectionLabel"
+        HIGConstructor={VanillaSectionLabel}
+        {...this.props}
+      >
+        {adapterProps => (
+          <div>
+            <MapsPropToMethod
+              value={this.props.label}
+              setter="setLabel"
+              {...adapterProps}
+            />
+            <MountsAnyChild mounter="addSlot" {...adapterProps}>
+              {this.props.children}
+            </MountsAnyChild>
+          </div>
+        )}
+      </HIGAdapter>
+    );
+  }
 }
 
 SectionLabelAdapter.propTypes = {
+  /**
+   * Label text
+   */
   label: PropTypes.string.isRequired,
+  /**
+   * Content inside the container
+   */
   children: PropTypes.node
 };
-
-SectionLabelAdapter.__docgenInfo = {
-  props: {
-    label: {
-      description: "{string} label text"
-    },
-    children: {
-      description: "content inside the container"
-    }
-  }
-};
-
-export default SectionLabelAdapter;

--- a/packages/react/src/adapters/SpacerAdapter.js
+++ b/packages/react/src/adapters/SpacerAdapter.js
@@ -1,61 +1,58 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Spacer as VanillaSpacer } from "hig-vanilla";
 import HIGAdapter, { MapsPropToMethod, MountsAnyChild } from "./HIGAdapter";
 
-function SpacerAdapter(props) {
-  return (
-    <HIGAdapter {...props} displayName="Spacer" HIGConstructor={VanillaSpacer}>
-      {adapterProps => (
-        <div>
-          <MapsPropToMethod
-            value={props.inset}
-            setter="setInset"
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            value={props.type}
-            setter="setType"
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            value={props.width}
-            setter="setWidth"
-            {...adapterProps}
-          />
-          <MountsAnyChild mounter="addSlot" {...adapterProps}>
-            {props.children}
-          </MountsAnyChild>
-        </div>
-      )}
-    </HIGAdapter>
-  );
+export default class SpacerAdapter extends Component {
+  render() {
+    return (
+      <HIGAdapter
+        {...this.props}
+        displayName="Spacer"
+        HIGConstructor={VanillaSpacer}
+      >
+        {adapterProps => (
+          <div>
+            <MapsPropToMethod
+              value={this.props.inset}
+              setter="setInset"
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              value={this.props.type}
+              setter="setType"
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              value={this.props.width}
+              setter="setWidth"
+              {...adapterProps}
+            />
+            <MountsAnyChild mounter="addSlot" {...adapterProps}>
+              {this.props.children}
+            </MountsAnyChild>
+          </div>
+        )}
+      </HIGAdapter>
+    );
+  }
 }
 
 SpacerAdapter.propTypes = {
+  /**
+   * Inset width of the spacer
+   */
   inset: PropTypes.oneOf(VanillaSpacer.AvailableSizes),
+  /**
+   * Type of the spacer ('stack' or 'inline')
+   */
   type: PropTypes.oneOf(VanillaSpacer.AvailableTypes),
+  /**
+   * Width of the spacer (vertical if type is 'stack', horizontal if type is 'inline'
+   */
   width: PropTypes.oneOf(VanillaSpacer.AvailableSizes),
+  /**
+   * Content to render within the spacer
+   */
   children: PropTypes.node
 };
-
-SpacerAdapter.defaultProps = {
-  inset: undefined,
-  type: undefined,
-  width: undefined,
-  children: undefined
-};
-
-SpacerAdapter.__docgenInfo = {
-  props: {
-    inset: { description: "inset width of the spacer" },
-    type: { description: "type of the spacer ('stack' or 'inline')" },
-    width: {
-      description:
-        "width of the spacer (vertical if type is 'stack', horizontal if type is 'inline'"
-    },
-    children: { description: "content to render within the spacer" }
-  }
-};
-
-export default SpacerAdapter;

--- a/packages/react/src/adapters/Table/SlotCellAdapter.js
+++ b/packages/react/src/adapters/Table/SlotCellAdapter.js
@@ -1,44 +1,35 @@
-import React from "react";
+import React, { Component } from "react";
 import { Table as VanillaTable } from "hig-vanilla";
-import * as PropTypes from "prop-types";
+import PropTypes from "prop-types";
 import HIGAdapter, {
   MountsAnyChild,
   MountedByHIGParentList
 } from "../HIGAdapter";
 
-function SlotCellAdapter(props) {
-  return (
-    <HIGAdapter
-      {...props}
-      displayName="Slot"
-      HIGConstructor={VanillaTable._partials.TableRow._partials.SlotCell}
-    >
-      {adapterProps => (
-        <div>
-          <MountedByHIGParentList mounter="addCell" {...adapterProps} />
-          <MountsAnyChild mounter="addSlot" {...adapterProps}>
-            {props.children}
-          </MountsAnyChild>
-        </div>
-      )}
-    </HIGAdapter>
-  );
+export default class SlotCellAdapter extends Component {
+  render() {
+    return (
+      <HIGAdapter
+        {...this.props}
+        displayName="Slot"
+        HIGConstructor={VanillaTable._partials.TableRow._partials.SlotCell}
+      >
+        {adapterProps => (
+          <div>
+            <MountedByHIGParentList mounter="addCell" {...adapterProps} />
+            <MountsAnyChild mounter="addSlot" {...adapterProps}>
+              {this.props.children}
+            </MountsAnyChild>
+          </div>
+        )}
+      </HIGAdapter>
+    );
+  }
 }
 
 SlotCellAdapter.propTypes = {
+  /**
+   * Content for slot cell
+   */
   children: PropTypes.node
 };
-
-SlotCellAdapter.defaultProps = {
-  children: undefined
-};
-
-SlotCellAdapter.__docgenInfo = {
-  props: {
-    children: {
-      description: "content for slot cell"
-    }
-  }
-};
-
-export default SlotCellAdapter;

--- a/packages/react/src/adapters/Table/SlotHeadCellAdapter.js
+++ b/packages/react/src/adapters/Table/SlotHeadCellAdapter.js
@@ -1,55 +1,45 @@
-import React from "react";
+import React, { Component } from "react";
 import { Table as VanillaTable } from "hig-vanilla";
-import * as PropTypes from "prop-types";
+import PropTypes from "prop-types";
 import HIGAdapter, {
   MapsPropToMethod,
   MountsAnyChild,
   MountedByHIGParentList
 } from "../HIGAdapter";
 
-function SlotHeadCellAdapter(props) {
-  return (
-    <HIGAdapter
-      {...props}
-      displayName="Slot"
-      HIGConstructor={VanillaTable._partials.TableHead._partials.SlotHeadCell}
-    >
-      {adapterProps => (
-        <div>
-          <MapsPropToMethod
-            value={props.width}
-            setter="setWidth"
-            {...adapterProps}
-          />
-          <MountedByHIGParentList mounter="addCell" {...adapterProps} />
-          <MountsAnyChild mounter="addSlot" {...adapterProps}>
-            {props.children}
-          </MountsAnyChild>
-        </div>
-      )}
-    </HIGAdapter>
-  );
+export default class SlotHeadCellAdapter extends Component {
+  render() {
+    return (
+      <HIGAdapter
+        {...this.props}
+        displayName="Slot"
+        HIGConstructor={VanillaTable._partials.TableHead._partials.SlotHeadCell}
+      >
+        {adapterProps => (
+          <div>
+            <MapsPropToMethod
+              value={this.props.width}
+              setter="setWidth"
+              {...adapterProps}
+            />
+            <MountedByHIGParentList mounter="addCell" {...adapterProps} />
+            <MountsAnyChild mounter="addSlot" {...adapterProps}>
+              {this.props.children}
+            </MountsAnyChild>
+          </div>
+        )}
+      </HIGAdapter>
+    );
+  }
 }
 
 SlotHeadCellAdapter.propTypes = {
+  /**
+   * Content for slot cell
+   */
   children: PropTypes.node,
+  /**
+   * Sets {String} width of the cell
+   */
   width: PropTypes.string
 };
-
-SlotHeadCellAdapter.defaultProps = {
-  children: undefined,
-  width: undefined
-};
-
-SlotHeadCellAdapter.__docgenInfo = {
-  props: {
-    children: {
-      description: "content for slot cell"
-    },
-    width: {
-      description: "sets {String} width of the cell"
-    }
-  }
-};
-
-export default SlotHeadCellAdapter;

--- a/packages/react/src/adapters/Table/TableRowAdapter.js
+++ b/packages/react/src/adapters/Table/TableRowAdapter.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Table as VanillaTable } from "hig-vanilla";
-import * as PropTypes from "prop-types";
+import PropTypes from "prop-types";
 
 import HIGAdapter, {
   MapsPropToMethod,

--- a/packages/react/src/adapters/Table/TextCellContentAdapter.js
+++ b/packages/react/src/adapters/Table/TextCellContentAdapter.js
@@ -1,63 +1,52 @@
-import React from "react";
+import React, { Component } from "react";
 import { TextCellContent as VanillaTextCellContent } from "hig-vanilla";
 import PropTypes from "prop-types";
 
 import HIGAdapter, { MapsPropToMethod } from "../HIGAdapter";
 
-function TextCellContentAdapter(props) {
-  return (
-    <HIGAdapter
-      displayName="TextCellContent"
-      HIGConstructor={VanillaTextCellContent}
-      {...props}
-    >
-      {adapterProps => (
-        <div>
-          <MapsPropToMethod
-            value={props.text}
-            setter="setText"
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            value={props.detail}
-            setter="setDetail"
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            value={props.alignment}
-            setter="setAlignment"
-            {...adapterProps}
-          />
-        </div>
-      )}
-    </HIGAdapter>
-  );
+export default class TextCellContentAdapter extends Component {
+  render() {
+    return (
+      <HIGAdapter
+        displayName="TextCellContent"
+        HIGConstructor={VanillaTextCellContent}
+        {...this.props}
+      >
+        {adapterProps => (
+          <div>
+            <MapsPropToMethod
+              value={this.props.text}
+              setter="setText"
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              value={this.props.detail}
+              setter="setDetail"
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              value={this.props.alignment}
+              setter="setAlignment"
+              {...adapterProps}
+            />
+          </div>
+        )}
+      </HIGAdapter>
+    );
+  }
 }
 
 TextCellContentAdapter.propTypes = {
+  /**
+   * Sets {String} text in cell
+   */
   text: PropTypes.string,
+  /**
+   * Sets {String} supporting text for cell in body of table
+   */
   detail: PropTypes.string,
+  /**
+   * Sets {String} text-position of cell
+   */
   alignment: PropTypes.oneOf(VanillaTextCellContent.AvailableAlignments)
 };
-
-TextCellContentAdapter.defaultProps = {
-  text: undefined,
-  detail: undefined,
-  alignment: undefined
-};
-
-TextCellContentAdapter.__docgenInfo = {
-  props: {
-    text: {
-      description: "sets {String} text in cell"
-    },
-    alignment: {
-      description: "sets {String} text-position of cell"
-    },
-    detail: {
-      description: "sets {String} supporting text for cell in body of table"
-    }
-  }
-};
-
-export default TextCellContentAdapter;

--- a/packages/react/src/adapters/Tabs/index.js
+++ b/packages/react/src/adapters/Tabs/index.js
@@ -1,2 +1,0 @@
-export { default } from "./TabsAdapter";
-export { default as Tab } from "./TabAdapter";

--- a/packages/react/src/adapters/TextLinkAdapter.js
+++ b/packages/react/src/adapters/TextLinkAdapter.js
@@ -1,71 +1,60 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { TextLink as VanillaTextLink } from "hig-vanilla";
 import HIGAdapter, { MapsPropToMethod, MapsEventListener } from "./HIGAdapter";
 
-function TextLinkAdapter(props) {
-  return (
-    <HIGAdapter
-      {...props}
-      displayName="TextLink"
-      HIGConstructor={VanillaTextLink}
-    >
-      {adapterProps => (
-        <div>
-          <MapsEventListener
-            listener="onClick"
-            handler={props.onClick}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            setter="setHref"
-            value={props.href}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            setter="setType"
-            value={props.type}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            setter="setText"
-            value={props.text}
-            {...adapterProps}
-          />
-        </div>
-      )}
-    </HIGAdapter>
-  );
+export default class TextLinkAdapter extends Component {
+  render() {
+    return (
+      <HIGAdapter
+        {...this.props}
+        displayName="TextLink"
+        HIGConstructor={VanillaTextLink}
+      >
+        {adapterProps => (
+          <div>
+            <MapsEventListener
+              listener="onClick"
+              handler={this.props.onClick}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              setter="setHref"
+              value={this.props.href}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              setter="setType"
+              value={this.props.type}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              setter="setText"
+              value={this.props.text}
+              {...adapterProps}
+            />
+          </div>
+        )}
+      </HIGAdapter>
+    );
+  }
 }
 
 TextLinkAdapter.propTypes = {
+  /**
+   * Sets the link url or path
+   */
   href: PropTypes.string,
+  /**
+   * Triggers when you click the link
+   */
   onClick: PropTypes.func,
+  /**
+   * Sets the text and alt-text of the link
+   */
   text: PropTypes.string.isRequired,
+  /**
+   * Specifies type of link
+   */
   type: PropTypes.oneOf(VanillaTextLink.AvailableTypes)
 };
-
-TextLinkAdapter.defaultProps = {
-  href: undefined,
-  onClick: undefined,
-  type: undefined
-};
-
-TextLinkAdapter.__docgenInfo = {
-  props: {
-    text: {
-      description: "sets the text and alt-text of the link"
-    },
-    href: {
-      description: "sets the link url or path"
-    },
-    type: {
-      description: "specifies type of link"
-    },
-    onClick: {
-      description: "triggers when you click the link"
-    }
-  }
-};
-
-export default TextLinkAdapter;

--- a/packages/react/src/adapters/TimestampAdapter.js
+++ b/packages/react/src/adapters/TimestampAdapter.js
@@ -1,36 +1,33 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Timestamp as VanillaTimestamp } from "hig-vanilla";
 import HIGAdapter, { MapsPropToMethod } from "./HIGAdapter";
 
-function TimestampAdapter(props) {
-  return (
-    <HIGAdapter
-      displayName="Timestamp"
-      HIGConstructor={VanillaTimestamp}
-      {...props}
-    >
-      {adapterProps => (
-        <div>
-          <MapsPropToMethod
-            value={props.time}
-            setter="setTimestamp"
-            {...adapterProps}
-          />
-        </div>
-      )}
-    </HIGAdapter>
-  );
+export default class TimestampAdapter extends Component {
+  render() {
+    return (
+      <HIGAdapter
+        displayName="Timestamp"
+        HIGConstructor={VanillaTimestamp}
+        {...this.props}
+      >
+        {adapterProps => (
+          <div>
+            <MapsPropToMethod
+              value={this.props.time}
+              setter="setTimestamp"
+              {...adapterProps}
+            />
+          </div>
+        )}
+      </HIGAdapter>
+    );
+  }
 }
 
 TimestampAdapter.propTypes = {
+  /**
+   * {String} string timestamp
+   */
   timestamp: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)])
 };
-
-TimestampAdapter.__docgenInfo = {
-  props: {
-    timestamp: { description: "{String} string timestamp" }
-  }
-};
-
-export default TimestampAdapter;

--- a/packages/react/src/adapters/TypographyAdapter.js
+++ b/packages/react/src/adapters/TypographyAdapter.js
@@ -1,48 +1,42 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Typography as VanillaTypography } from "hig-vanilla";
 import HIGAdapter, { MapsPropToMethod } from "./HIGAdapter";
 
-function TypographyAdapter(props) {
-  return (
-    <HIGAdapter
-      {...props}
-      displayName="Typography"
-      HIGConstructor={VanillaTypography}
-    >
-      {adapterProps => (
-        <div>
-          <MapsPropToMethod
-            setter="setType"
-            value={props.type}
-            {...adapterProps}
-          />
-          <MapsPropToMethod
-            setter="setText"
-            value={props.text}
-            {...adapterProps}
-          />
-        </div>
-      )}
-    </HIGAdapter>
-  );
+export default class TypographyAdapter extends Component {
+  render() {
+    return (
+      <HIGAdapter
+        {...this.props}
+        displayName="Typography"
+        HIGConstructor={VanillaTypography}
+      >
+        {adapterProps => (
+          <div>
+            <MapsPropToMethod
+              setter="setType"
+              value={this.props.type}
+              {...adapterProps}
+            />
+            <MapsPropToMethod
+              setter="setText"
+              value={this.props.text}
+              {...adapterProps}
+            />
+          </div>
+        )}
+      </HIGAdapter>
+    );
+  }
 }
 
 TypographyAdapter.propTypes = {
+  /**
+   * {String - 'stack', 'inline'} type of the typography
+   */
   type: PropTypes.string.isRequired,
+  /**
+   * {String - styled or unstyled text to show inside the typography
+   */
   text: PropTypes.string.isRequired
 };
-
-TypographyAdapter.__docgenInfo = {
-  props: {
-    type: {
-      description: "{String - 'stack', 'inline'} type of the typography"
-    },
-    text: {
-      description:
-        "{String - styled or unstyled text to show inside the typography "
-    }
-  }
-};
-
-export default TypographyAdapter;

--- a/packages/react/src/elements/components/Container.js
+++ b/packages/react/src/elements/components/Container.js
@@ -1,24 +1,15 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 
-function Container({ children }) {
-  return <div className="hig__container">{children}</div>;
+export default class Container extends Component {
+  render() {
+    return <div className="hig__container">{this.props.children}</div>;
+  }
 }
 
 Container.propTypes = {
+  /**
+   * React-generated markup to render within
+   */
   children: PropTypes.node
 };
-
-Container.defaultProps = {
-  children: null
-};
-
-Container.__docgenInfo = {
-  props: {
-    children: {
-      description: "react-generated markup to render within"
-    }
-  }
-};
-
-export default Container;

--- a/packages/react/src/elements/components/ExpandingFilterSection.js
+++ b/packages/react/src/elements/components/ExpandingFilterSection.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { ExpandingFilterSection as VanillaExpandingFilterSection } from "hig-vanilla";
 import ExpandingFilterSectionAdapter from "../../adapters/ExpandingFilterSectionAdapter";
 
-class ExpandingFilterSection extends Component {
+export default class ExpandingFilterSection extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -28,23 +28,16 @@ class ExpandingFilterSection extends Component {
 }
 
 ExpandingFilterSection.propTypes = {
+  /**
+   * Content to be shown when section is open
+   */
   children: PropTypes.node,
+  /**
+   * Short text describing the content
+   */
   label: PropTypes.string,
+  /**
+   * {s, m} size of the expanding filter section label
+   */
   size: PropTypes.oneOf(VanillaExpandingFilterSection.AvailableSizes)
 };
-
-ExpandingFilterSection.__docgenInfo = {
-  props: {
-    children: {
-      description: "Content to be shown when section is open"
-    },
-    label: {
-      description: "Short text describing the content"
-    },
-    size: {
-      description: "{s, m} size of the expanding fitler section label"
-    }
-  }
-};
-
-export default ExpandingFilterSection;

--- a/packages/react/src/elements/components/Flyout.js
+++ b/packages/react/src/elements/components/Flyout.js
@@ -1,9 +1,9 @@
-import * as PropTypes from "prop-types";
+import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { Flyout as VanillaFlyout } from "hig-vanilla";
 import FlyoutAdapter from "../../adapters/FlyoutAdapter";
 
-class Flyout extends Component {
+export default class Flyout extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -38,21 +38,20 @@ class Flyout extends Component {
 }
 
 Flyout.propTypes = {
+  /**
+   * Where the flyout will be anchored relative to target
+   */
   anchorPoint: PropTypes.oneOf(VanillaFlyout.AvailableAnchorPoints),
+  /**
+   * Target component to open the flyout
+   */
   children: PropTypes.node,
+  /**
+   * Content for the flyout
+   */
   content: PropTypes.node,
+  /**
+   * Max height of the flyout content, in pixels
+   */
   maxHeight: PropTypes.number
 };
-
-Flyout.__docgenInfo = {
-  props: {
-    anchorPoint: {
-      description: "where the flyout will be anchored relative to target"
-    },
-    children: { description: "target component to open the flyout" },
-    content: { description: "content for the flyout" },
-    maxHeight: { description: "max height of the flyout content, in pixels" }
-  }
-};
-
-export default Flyout;

--- a/packages/react/src/elements/components/Flyout.js
+++ b/packages/react/src/elements/components/Flyout.js
@@ -4,24 +4,6 @@ import { Flyout as VanillaFlyout } from "hig-vanilla";
 import FlyoutAdapter from "../../adapters/FlyoutAdapter";
 
 class Flyout extends Component {
-  static propTypes = {
-    anchorPoint: PropTypes.oneOf(VanillaFlyout.AvailableAnchorPoints),
-    children: PropTypes.node,
-    content: PropTypes.node,
-    maxHeight: PropTypes.number
-  };
-
-  static __docgenInfo = {
-    props: {
-      anchorPoint: {
-        description: "where the flyout will be anchored relative to target"
-      },
-      children: { description: "target component to open the flyout" },
-      content: { description: "content for the flyout" },
-      maxHeight: { description: "max height of the flyout content, in pixels" }
-    }
-  };
-
   constructor(props) {
     super(props);
     this.state = {
@@ -54,5 +36,23 @@ class Flyout extends Component {
     );
   }
 }
+
+Flyout.propTypes = {
+  anchorPoint: PropTypes.oneOf(VanillaFlyout.AvailableAnchorPoints),
+  children: PropTypes.node,
+  content: PropTypes.node,
+  maxHeight: PropTypes.number
+};
+
+Flyout.__docgenInfo = {
+  props: {
+    anchorPoint: {
+      description: "where the flyout will be anchored relative to target"
+    },
+    children: { description: "target component to open the flyout" },
+    content: { description: "content for the flyout" },
+    maxHeight: { description: "max height of the flyout content, in pixels" }
+  }
+};
 
 export default Flyout;

--- a/packages/react/src/elements/components/FormElements/Dropdown.js
+++ b/packages/react/src/elements/components/FormElements/Dropdown.js
@@ -1,10 +1,10 @@
 import React, { Component } from "react";
-import * as PropTypes from "prop-types";
+import PropTypes from "prop-types";
 
 import DropdownAdapter from "../../../adapters/FormElements/DropdownAdapter";
 import Option from "./Option";
 
-class Dropdown extends Component {
+export default class Dropdown extends Component {
   static defaultProps = {
     options: [],
     onChange: () => {}
@@ -83,68 +83,57 @@ class Dropdown extends Component {
 }
 
 Dropdown.propTypes = {
+  /**
+   * {string} label for the the dropdown
+   */
   label: PropTypes.string,
+  /**
+   * {string} instructions for the dropdown
+   */
   instructions: PropTypes.string,
+  /**
+   * {string} placeholder for the dropdown
+   */
   placeholder: PropTypes.string,
+  /**
+   * {bool} makes the dropdown disabled
+   */
   disabled: PropTypes.bool,
+  /**
+   * {string} makes the field required
+   */
   required: PropTypes.string,
+  /**
+   * {string} option that is selected on construction
+   */
   value: PropTypes.string,
+  /**
+   * {string} default selected option
+   */
   defaultValue: PropTypes.string,
+  /**
+   * {Array} array with objects, objects have a 'label' and a 'value'
+   */
   options: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string,
       value: PropTypes.string
     })
   ),
+  /**
+   * Calls the provided callback when option is changed
+   */
   onChange: PropTypes.func,
+  /**
+   * Calls the provided callback when focus moves away from the dropdown
+   */
   onBlur: PropTypes.func,
+  /**
+   * Calls the provided callback when the user focuses on the dropdown
+   */
   onFocus: PropTypes.func,
+  /**
+   * Calls the provided callback when the user presses a key while the dropdown has focus
+   */
   onKeypress: PropTypes.func
 };
-
-Dropdown.__docgenInfo = {
-  props: {
-    label: {
-      description: "{string} label for the the dropdown"
-    },
-    instructions: {
-      description: "{string} instructions for the dropdown"
-    },
-    placeholder: {
-      description: "{string} placeholder for the dropdown"
-    },
-    disabled: {
-      description: "{bool} makes the dropdown disabled"
-    },
-    required: {
-      description: "{string} makes the field required"
-    },
-    value: {
-      description: "{string} option that is selected on construction"
-    },
-    defaultValue: {
-      description: "{string} default selected option"
-    },
-    options: {
-      description:
-        "{Array} array with objects, objects have a 'label' and a 'value'"
-    },
-    onChange: {
-      description: "Calls the provided callback when option is changed"
-    },
-    onBlur: {
-      description:
-        "Calls the provided callback when focus moves away from the dropdown"
-    },
-    onFocus: {
-      description:
-        "Calls the provided callback when the user focuses on the dropdown"
-    },
-    onKeypress: {
-      description:
-        "Calls the provided callback when the user presses a key while the dropdown has focus"
-    }
-  }
-};
-
-export default Dropdown;

--- a/packages/react/src/elements/components/FormElements/Option.js
+++ b/packages/react/src/elements/components/FormElements/Option.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import * as PropTypes from "prop-types";
+import PropTypes from "prop-types";
 import OptionAdapter from "../../../adapters/FormElements/OptionAdapter";
 
 class Option extends Component {

--- a/packages/react/src/elements/components/FormElements/PasswordField.js
+++ b/packages/react/src/elements/components/FormElements/PasswordField.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import PasswordFieldAdapter from "../../../adapters/FormElements/PasswordFieldAdapter";
 
-class PasswordField extends Component {
+export default class PasswordField extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -52,17 +52,53 @@ class PasswordField extends Component {
 }
 
 PasswordField.propTypes = {
+  /**
+   * Disable the field, preventing user interaction
+   */
   disabled: PropTypes.bool,
+  /**
+   * Initial value of the field
+   */
   initialValue: PropTypes.string,
+  /**
+   * A short description or suggestion
+   */
   instructions: PropTypes.string,
+  /**
+   * Describes what the field controls
+   */
   label: PropTypes.string,
+  /**
+   * Set on the element's name attribute
+   */
   name: PropTypes.string,
+  /**
+   * Called when user moves focus away from the field
+   */
   onBlur: PropTypes.func,
+  /**
+   * Called when user enters a new value and moves focus away from the field
+   */
   onChange: PropTypes.func,
+  /**
+   * Called when user moves focus onto the field
+   */
   onFocus: PropTypes.func,
+  /**
+   * Called when user enters a new value
+   */
   onInput: PropTypes.func,
+  /**
+   * Data entry suggestions or formatting examples
+   */
   placeholder: PropTypes.string,
+  /**
+   * Indicates a field must be filled before the form may be completed
+   */
   required: PropTypes.string,
+  /**
+   * Controlled value of the field
+   */
   value: PropTypes.string
 };
 
@@ -72,30 +108,3 @@ PasswordField.defaultProps = {
   onChange: () => {},
   onInput: () => {}
 };
-
-PasswordField.__docgenInfo = {
-  props: {
-    disabled: { description: "disable the field, preventing user interaction" },
-    initialValue: { description: "initial value of the field" },
-    instructions: { description: "a short description or suggestion" },
-    label: { description: "describes what the field controls" },
-    name: { description: "set on the element's name attribute" },
-    onBlur: { description: "called when user moves focus away from the field" },
-    onChange: {
-      description:
-        "called when user enters a new value and moves focus away from the field"
-    },
-    onFocus: { description: "called when user moves focus onto the field" },
-    onInput: { description: "called when user enters a new value" },
-    placeholder: {
-      description: "data entry suggestions or formatting examples"
-    },
-    required: {
-      description:
-        "indicates a field must be filled before the form may be completed"
-    },
-    value: { description: "controlled value of the field" }
-  }
-};
-
-export default PasswordField;

--- a/packages/react/src/elements/components/GlobalNav/GlobalNav.js
+++ b/packages/react/src/elements/components/GlobalNav/GlobalNav.js
@@ -14,7 +14,7 @@ import ProjectAccountSwitcher from "./TopNav/ProjectAccountSwitcher";
 import Notifications from "./TopNav/Notifications";
 import Notification from "./TopNav/Notification";
 
-class GlobalNav extends Component {
+export default class GlobalNav extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -163,25 +163,55 @@ class GlobalNav extends Component {
 }
 
 GlobalNav.propTypes = {
+  /**
+   * Id of the active module or submodule
+   */
   activeModuleId: PropTypes.string,
+  /**
+   * Page content
+   */
   children: PropTypes.node,
+  /**
+   * Called when the user clicks on the 'hamburger' button in order to toggle the menu
+   */
   onHamburgerClick: PropTypes.func,
+  /**
+   * Called when the user selects a module or submodule
+   */
   onModuleChange: PropTypes.func.isRequired,
+  /**
+   * When true, shows the Subnav below the Topnav
+   */
   showSubNav: PropTypes.bool,
+  /**
+   * When true, Sidenav is open
+   */
   sideNavOpen: PropTypes.bool,
+  /**
+   * Initial open state of the side nav, user actions will override
+   */
   sideNavOpenByDefault: PropTypes.bool,
+  /**
+   * A list of modules to appear in the sidenav
+   */
   modules: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,
       title: PropTypes.string.isRequired
     })
   ),
+  /**
+   * A list of submodules to appear in the sidenav
+   */
   submodules: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,
       title: PropTypes.string.isRequired
     })
   ),
+  /**
+   * Options to configure the Topnav
+   */
   topNav: PropTypes.shape({
     logo: PropTypes.string,
     logoLink: PropTypes.string,
@@ -203,6 +233,9 @@ GlobalNav.propTypes = {
       )
     })
   }),
+  /**
+   * Options to configure the Sidenav
+   */
   sideNav: PropTypes.shape({
     copyright: PropTypes.string,
     headerLabel: PropTypes.string,
@@ -216,56 +249,9 @@ GlobalNav.propTypes = {
 };
 
 GlobalNav.defaultProps = {
-  activeModuleId: undefined,
-  children: undefined,
   modules: [],
   submodules: [],
   topNav: {},
   sideNav: {},
-  onHamburgerClick: () => {},
-  showSubNav: false,
-  sideNavOpen: undefined,
-  sideNavOpenByDefault: false
+  onHamburgerClick: () => {}
 };
-
-GlobalNav.__docgenInfo = {
-  props: {
-    activeModuleId: {
-      description: "id of the active module or submodule"
-    },
-    children: {
-      description: "page content"
-    },
-    onHamburgerClick: {
-      description:
-        "called when the user clicks on the 'hamburger' button in order to toggle the menu"
-    },
-    onModuleChange: {
-      description: "called when the user selects a module or submodule"
-    },
-    showSubNav: {
-      description: "when true, shows the Subnav below the Topnav"
-    },
-    sideNavOpen: {
-      description: "when true, Sidenav is open"
-    },
-    sideNavOpenByDefault: {
-      description:
-        "initial open state of the side nav, user actions will override"
-    },
-    modules: {
-      description: "a list of modules to appear in the sidenav"
-    },
-    submodules: {
-      description: "a list of submodules to appear in the sidenav"
-    },
-    topNav: {
-      description: "options to configure the Topnav"
-    },
-    sideNav: {
-      description: "options to configure the Sidenav"
-    }
-  }
-};
-
-export default GlobalNav;

--- a/packages/react/src/elements/components/GlobalNav/SideNav/SideNav.js
+++ b/packages/react/src/elements/components/GlobalNav/SideNav/SideNav.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import * as PropTypes from "prop-types";
+import PropTypes from "prop-types";
 import SideNavAdapter from "../../../../adapters/GlobalNav/SideNav/SideNavAdapter";
 import Submodule from "./Submodule";
 import Group from "../../../../adapters/GlobalNav/SideNav/GroupAdapter";

--- a/packages/react/src/elements/components/GlobalNav/TopNav/Notification.js
+++ b/packages/react/src/elements/components/GlobalNav/TopNav/Notification.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 import NotificationAdapter from "../../../../adapters/GlobalNav/TopNav/NotificationAdapter";
 
-class Notification extends Component {
+export default class Notification extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -31,41 +31,31 @@ class Notification extends Component {
 }
 
 Notification.propTypes = {
+  /**
+   * {Boolean} to show specify whether notification is read
+   */
   unread: PropTypes.bool,
+  /**
+   * Content for notification
+   */
   children: PropTypes.node,
+  /**
+   * Timestamp for notification (ISO date string or date instance)
+   */
   timestamp: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.instanceOf(Date)
-  ]), // ISO date string
+  ]),
+  /**
+   * Calls the provided callback when user clicks on the noticatiosn icon in the top nav
+   */
   onClick: PropTypes.func,
+  /**
+   * Id for the notification
+   */
   id: PropTypes.number.isRequired,
+  /**
+   * {Boolean} specifies a featured notification
+   */
   featured: PropTypes.bool
 };
-
-Notification.defaultProps = {};
-
-Notification.__docgenInfo = {
-  props: {
-    id: {
-      description: "Id for the notification"
-    },
-    unread: {
-      description: "{Boolean} to show specify whether notificaiton is read"
-    },
-    children: {
-      description: "content for notification"
-    },
-    timestamp: {
-      description: "timstamp for notification"
-    },
-    onClick: {
-      description:
-        "Calls the provided callback when user clicks on the noticatiosn icon in the top nav"
-    },
-    featured: {
-      description: "{Boolean} specifies a featured notification"
-    }
-  }
-};
-
-export default Notification;

--- a/packages/react/src/elements/components/GlobalNav/TopNav/Notifications.js
+++ b/packages/react/src/elements/components/GlobalNav/TopNav/Notifications.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import NotificationsAdapter from "../../../../adapters/GlobalNav/TopNav/NotificationsAdapter";
 import Notification from "./Notification";
 
-class Notifications extends Component {
+export default class Notifications extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -131,14 +131,41 @@ class Notifications extends Component {
 }
 
 Notifications.propTypes = {
+  /**
+   * Opens the notifications flyout
+   */
   open: PropTypes.bool,
+  /**
+   * Show the loading indicator
+   */
   loading: PropTypes.bool,
+  /**
+   * Whether to show number of notifications or not
+   */
   showUnreadBadge: PropTypes.bool,
+  /**
+   * Number of unread messages
+   */
   unreadCount: PropTypes.number,
+  /**
+   * Calls the provided callback when user clicks on the notifications icon in the top nav
+   */
   onClick: PropTypes.func,
+  /**
+   * Calls the provided callback when user clicks outside the dropdown
+   */
   onClickOutside: PropTypes.func,
+  /**
+   * Calls the provided callback when the notifications content is scrolled
+   */
   onScroll: PropTypes.func,
+  /**
+   * The title text that renders above the notifications list
+   */
   title: PropTypes.string,
+  /**
+   * An object containing props for a Notification, to be styled as a featured notification
+   */
   featuredNotification: PropTypes.shape(Notification.propTypes)
 };
 
@@ -148,50 +175,3 @@ Notifications.defaultProps = {
   onScroll: () => {},
   title: "Notifications"
 };
-
-Notifications.__docgenInfo = {
-  props: {
-    open: {
-      description: "opens the notifications flyout"
-    },
-    addNotification: {
-      description: "Pass in an instance of a Notification"
-    },
-    setUnseenCount: {
-      description: "Pass a value for number of notifications that are unread"
-    },
-    onClickOutside: {
-      description:
-        "Calls the provided callback when user clicks outside the dropdown"
-    },
-    onClick: {
-      description:
-        "Calls the provided callback when user clicks on the notifications icon in the top nav"
-    },
-    onScroll: {
-      description:
-        "Calls the provided callback when the notifications content is scrolled"
-    },
-    showUnreadBadge: {
-      description: "Boolean on whether to show number of notifications or not"
-    },
-    unreadCount: {
-      description: "number of unreadmessages"
-    },
-    loading: {
-      description: "show the loading indicator"
-    },
-    maxHeight: {
-      description: "the max height of the flyout content, in pixels"
-    },
-    title: {
-      description: "The title text that renders above the notifications list"
-    },
-    featuredNotification: {
-      description:
-        "An object containing props for a Notification, to be styled as a featured notification"
-    }
-  }
-};
-
-export default Notifications;

--- a/packages/react/src/elements/components/GlobalNav/TopNav/Search.js
+++ b/packages/react/src/elements/components/GlobalNav/TopNav/Search.js
@@ -3,25 +3,7 @@ import PropTypes from "prop-types";
 import SearchAdapter from "../../../../adapters/GlobalNav/TopNav/SearchAdapter";
 import Option from "../../FormElements/Option";
 
-class Search extends Component {
-  static propTypes = {
-    placeholder: PropTypes.string,
-    options: PropTypes.arrayOf(
-      PropTypes.shape({
-        label: PropTypes.string,
-        value: PropTypes.string
-      })
-    ),
-    onInput: PropTypes.func,
-    value: PropTypes.string,
-    showOptions: PropTypes.bool,
-    onBlur: PropTypes.func,
-    showClearIcon: PropTypes.bool,
-    onClearIconClick: PropTypes.func,
-    onClickOutside: PropTypes.func,
-    onKeydown: PropTypes.func
-  };
-
+export default class Search extends Component {
   static defaultProps = {
     onInput: () => {},
     value: undefined,
@@ -186,39 +168,48 @@ class Search extends Component {
   }
 }
 
-Search.__docgenInfo = {
-  props: {
-    value: {
-      description: "value of search input"
-    },
-    onInput: {
-      description:
-        "Calls the provided callback when user enters text in Search input"
-    },
-    showOptions: {
-      description: "shows fitered options"
-    },
-    onBlur: {
-      description: "calles the callback on Blur"
-    },
-    onFocus: {
-      description: "calls the callback on Focus"
-    },
-    showClearIcon: {
-      description: "show the clear input icon"
-    },
-    onClearIconClick: {
-      description: "Calls the provided callback when the Clear Icon is clicked"
-    },
-    onClickOutside: {
-      description:
-        "Calls the provided callback when user clicks outside of the Help"
-    },
-    onKeydown: {
-      description:
-        "Calls the provided callback when user pressed key down on Search Input"
-    }
-  }
+Search.propTypes = {
+  placeholder: PropTypes.string,
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string,
+      value: PropTypes.string
+    })
+  ),
+  /**
+   * Calls the provided callback when user enters text in Search input
+   */
+  onInput: PropTypes.func,
+  /**
+   * Value of search input
+   */
+  value: PropTypes.string,
+  /**
+   * Shows filtered options
+   */
+  showOptions: PropTypes.bool,
+  /**
+   * Calls the callback on Blur
+   */
+  onBlur: PropTypes.func,
+  /**
+   * Calls the callback on Focus
+   */
+  onFocus: PropTypes.func,
+  /**
+   * Show the clear input icon
+   */
+  showClearIcon: PropTypes.bool,
+  /**
+   * Calls the provided callback when the Clear Icon is clicked
+   */
+  onClearIconClick: PropTypes.func,
+  /**
+   * Calls the provided callback when user clicks outside of the Help
+   */
+  onClickOutside: PropTypes.func,
+  /**
+   * Calls the provided callback when user pressed key down on Search Input
+   */
+  onKeydown: PropTypes.func
 };
-
-export default Search;

--- a/packages/react/src/elements/components/Modal.js
+++ b/packages/react/src/elements/components/Modal.js
@@ -1,10 +1,10 @@
 import React from "react";
-import * as PropTypes from "prop-types";
+import PropTypes from "prop-types";
 import { Modal as VanillaModal } from "hig-vanilla";
 import ModalAdapter from "../../adapters/ModalAdapter";
 import { Button } from "../../hig-react";
 
-class Modal extends React.Component {
+export default class Modal extends React.Component {
   constructor(props) {
     super(props);
     this.state = { open: false };
@@ -29,43 +29,36 @@ class Modal extends React.Component {
 }
 
 Modal.propTypes = {
+  /**
+   * Text or html string content of the modal
+   */
   body: PropTypes.string,
+  /**
+   * An array of props supported by the Button component
+   */
   buttons: PropTypes.arrayOf(PropTypes.shape(Button.propTypes)),
+  /**
+   * Ssupports adding any dom content to the body of the modal
+   */
   children: PropTypes.node,
+  /**
+   * Triggers when the modal closes
+   */
   onClose: PropTypes.func,
+  /**
+   * Modal is visible when true
+   */
   open: PropTypes.bool,
+  /**
+   * Style of the modal shell
+   */
   style: PropTypes.oneOf(VanillaModal.AvailableStyles),
+  /**
+   * Title of the modal
+   */
   title: PropTypes.string
-};
-
-Modal.__docgenInfo = {
-  props: {
-    body: {
-      description: "text or html string content of the modal"
-    },
-    buttons: {
-      description: "an array of props supported by the Button component"
-    },
-    style: {
-      description: "style of the modal shell"
-    },
-    onClose: {
-      description: "triggers when the modal will close"
-    },
-    open: {
-      description: "modal is visible when true"
-    },
-    title: {
-      description: "title of the modal"
-    },
-    children: {
-      description: "supports add any dom content to the body of the modal"
-    }
-  }
 };
 
 Modal.defaultProps = {
   onClose: () => {}
 };
-
-export default Modal;

--- a/packages/react/src/elements/components/RichText.js
+++ b/packages/react/src/elements/components/RichText.js
@@ -1,41 +1,31 @@
 /* eslint-disable react/no-danger */
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { RichText as VanillaRichText } from "hig-vanilla";
 
-function RichText(props) {
-  return props.children ? (
-    <div className={VanillaRichText.className}>{props.children}</div>
-  ) : (
-    <div
-      className={VanillaRichText.className}
-      dangerouslySetInnerHTML={props.dangerouslySetInnerHTML}
-    />
-  );
+export default class RichText extends Component {
+  render() {
+    return this.props.children ? (
+      <div className={VanillaRichText.className}>{this.props.children}</div>
+    ) : (
+      <div
+        className={VanillaRichText.className}
+        dangerouslySetInnerHTML={this.props.dangerouslySetInnerHTML}
+      />
+    );
+  }
 }
+/* eslint-enable react/no-danger */
 
 RichText.propTypes = {
+  /**
+   * React-generated markup to style with HIG typography rules
+   */
   children: PropTypes.node,
+  /**
+   * HTML string to be rendered and styled with HIG typography rules
+   */
   dangerouslySetInnerHTML: PropTypes.shape({
     __html: PropTypes.string
   })
 };
-
-RichText.defaultProps = {
-  children: null,
-  dangerouslySetInnerHTML: null
-};
-
-RichText.__docgenInfo = {
-  props: {
-    children: {
-      description: "react-generated markup to style with HIG typography rules"
-    },
-    dangerouslySetInnerHTML: {
-      description:
-        "HTML string to be rendered and styled with HIG typography rules"
-    }
-  }
-};
-
-export default RichText;

--- a/packages/react/src/elements/components/ShowMoreLess.js
+++ b/packages/react/src/elements/components/ShowMoreLess.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import TextLinkAdapter from "../../adapters/TextLinkAdapter";
 
-class ShowMoreLess extends Component {
+export default class ShowMoreLess extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -68,23 +68,16 @@ ShowMoreLess.defaultProps = {
 };
 
 ShowMoreLess.propTypes = {
+  /**
+   * {Number} Max height for content container
+   */
   maxHeight: PropTypes.number,
+  /**
+   * {String} content for label in expanded content container
+   */
   showLessLabel: PropTypes.string,
+  /**
+   * {String} content for label in collapsed content container
+   */
   showMoreLabel: PropTypes.string
 };
-
-ShowMoreLess.__docgenInfo = {
-  props: {
-    maxHeight: {
-      description: "{Number} Max height for content container"
-    },
-    showLessLabel: {
-      description: "{String} content for label in expanded content container"
-    },
-    showMoreLabel: {
-      description: "{String} content for label in collapsed content container"
-    }
-  }
-};
-
-export default ShowMoreLess;

--- a/packages/react/src/elements/components/Table/HeaderCheckbox.js
+++ b/packages/react/src/elements/components/Table/HeaderCheckbox.js
@@ -1,5 +1,5 @@
 import React from "react";
-import * as PropTypes from "prop-types";
+import PropTypes from "prop-types";
 import { colors } from "hig-vanilla";
 
 import Checkbox from "../../../adapters/FormElements/CheckboxAdapter";

--- a/packages/react/src/elements/components/Table/HeaderCheckbox.test.js
+++ b/packages/react/src/elements/components/Table/HeaderCheckbox.test.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+import HeaderCheckbox from "./HeaderCheckbox";
+import CheckboxAdapter from "../../../adapters/FormElements/CheckboxAdapter";
+
+describe("<HeaderCheckbox />", () => {
+  describe("selected", () => {
+    it("is passed as the CheckboxAdapter's checked prop", () => {
+      const wrapper = shallow(<HeaderCheckbox selected />);
+      expect(wrapper.find(CheckboxAdapter)).toHaveProp("checked", true);
+    });
+  });
+
+  describe("onSelectAllSelectionChange", () => {
+    it("is passed as the CheckboxAdapter's onChange handler", () => {
+      const spy = jest.fn();
+      const wrapper = shallow(
+        <HeaderCheckbox onSelectAllSelectionChange={spy} />
+      );
+      expect(wrapper.find(CheckboxAdapter)).toHaveProp("onChange", spy);
+    });
+  });
+});

--- a/packages/react/src/elements/components/Table/RowCheckbox.js
+++ b/packages/react/src/elements/components/Table/RowCheckbox.js
@@ -1,5 +1,5 @@
 import React from "react";
-import * as PropTypes from "prop-types";
+import PropTypes from "prop-types";
 import { colors } from "hig-vanilla";
 
 import Checkbox from "../../../adapters/FormElements/CheckboxAdapter";

--- a/packages/react/src/elements/components/Table/SelectableTable.js
+++ b/packages/react/src/elements/components/Table/SelectableTable.js
@@ -1,10 +1,10 @@
 import { Table as VanillaTable } from "hig-vanilla";
-import * as PropTypes from "prop-types";
+import PropTypes from "prop-types";
 import React, { Component } from "react";
 import HeaderCheckbox from "./HeaderCheckbox";
 import RowCheckbox from "./RowCheckbox";
 
-class SelectableTable extends Component {
+export default class SelectableTable extends Component {
   static propTypes = {
     selectable: PropTypes.bool
   };
@@ -92,32 +92,27 @@ class SelectableTable extends Component {
   }
 }
 
-SelectableTable.__docgenInfo = {
-  props: {
-    columns: {
-      description: "provides content for header cells"
-    },
-    data: {
-      description: "provides content table cells"
-    },
-    density: {
-      description: "sets the size of the table"
-    },
-    onRowSelectionChange: {
-      description: "called when user selects or deselects a row"
-    },
-    onSelectAllSelectionChange: {
-      description: "called when user checks or unchecks the select-all checkbox"
-    }
-  }
-};
-
 SelectableTable.propTypes = {
+  /**
+   * Sets the size of the table
+   */
   density: PropTypes.oneOf(VanillaTable.AvailableDensities),
+  /**
+   * Provides content table cells
+   */
   data: PropTypes.arrayOf(PropTypes.object),
+  /**
+   * Called when user selects or deselects a row
+   */
   onRowSelectionChange: PropTypes.func,
   children: PropTypes.func,
+  /**
+   * Called when user checks or unchecks the select-all checkbox
+   */
   onSelectAllSelectionChange: PropTypes.func,
+  /**
+   * Provides content for header cells
+   */
   columns: PropTypes.arrayOf(
     PropTypes.shape({
       Header: PropTypes.string,
@@ -128,5 +123,3 @@ SelectableTable.propTypes = {
     })
   )
 };
-
-export default SelectableTable;

--- a/packages/react/src/elements/components/Table/Table.js
+++ b/packages/react/src/elements/components/Table/Table.js
@@ -1,5 +1,5 @@
 import { Table as VanillaTable } from "hig-vanilla";
-import * as PropTypes from "prop-types";
+import PropTypes from "prop-types";
 import React, { Component } from "react";
 import TableAdapter from "../../../adapters/Table/TableAdapter";
 import TableHeadAdapter from "../../../adapters/Table/TableHeadAdapter";
@@ -51,18 +51,13 @@ function getHeadCell(props) {
   );
 }
 
-class Table extends Component {
+export default class Table extends Component {
   static defaultProps = {
     columns: [],
     data: [],
     selectable: false,
     density: undefined
   };
-
-  constructor(props) {
-    super(props);
-    this.state = {};
-  }
 
   renderTable(columns, data, density) {
     return (
@@ -106,6 +101,9 @@ class Table extends Component {
 }
 
 Table.propTypes = {
+  /**
+   * Provides content for header cells
+   */
   columns: PropTypes.arrayOf(
     PropTypes.shape({
       Header: PropTypes.string,
@@ -115,33 +113,24 @@ Table.propTypes = {
       Cell: PropTypes.any
     })
   ),
+  /**
+   * Provides content table cells
+   */
   data: PropTypes.arrayOf(PropTypes.object),
+  /**
+   * Sets the size of the table
+   */
   density: PropTypes.oneOf(VanillaTable.AvailableDensities),
+  /**
+   * Called when user selects or deselects a row
+   */
+  onRowSelectionChange: PropTypes.func,
+  /**
+   * Called when user checks or unchecks the select-all checkbox
+   */
+  onSelectAllSelectionChange: PropTypes.func,
+  /**
+   * When true, adds checkboxes to each row, and a select-all checkbox to the header
+   */
   selectable: PropTypes.bool
 };
-
-Table.__docgenInfo = {
-  props: {
-    columns: {
-      description: "provides content for header cells"
-    },
-    data: {
-      description: "provides content table cells"
-    },
-    density: {
-      description: "sets the size of the table"
-    },
-    onRowSelectionChange: {
-      description: "called when user selects or deselects a row"
-    },
-    onSelectAllSelectionChange: {
-      description: "called when user checks or unchecks the select-all checkbox"
-    },
-    selectable: {
-      description:
-        "when true adds checkboxes to each row, and a select-all checkbox to the header"
-    }
-  }
-};
-
-export default Table;

--- a/packages/react/src/elements/components/Tabs/PlaceholderTab.js
+++ b/packages/react/src/elements/components/Tabs/PlaceholderTab.js
@@ -1,32 +1,34 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-class Tab extends React.Component {
-  state = {
-    activeTabId: undefined
-  };
+export default class PlaceholderTab extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      activeTabId: undefined
+    };
+  }
 
   render() {
     return null;
   }
 }
 
-Tab.propTypes = {
+PlaceholderTab.propTypes = {
+  /**
+   * Brief text identifying the tab content
+   */
   label: PropTypes.string.isRequired,
+  /**
+   * When true, tabs content will be shown
+   */
   active: PropTypes.bool,
+  /**
+   * Content to display when tab is active
+   */
   children: PropTypes.node.isRequired
 };
 
-Tab.defaultProps = {
+PlaceholderTab.defaultProps = {
   active: false
 };
-
-Tab.__docgenInfo = {
-  props: {
-    label: { description: "brief text identifying the tab content" },
-    active: { description: "when true, tabs content will be shown" },
-    children: { description: "content to display when tab is active" }
-  }
-};
-
-export default Tab;

--- a/packages/react/src/elements/components/Tabs/Tabs.js
+++ b/packages/react/src/elements/components/Tabs/Tabs.js
@@ -1,9 +1,9 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import TabsAdapter from "../../../adapters/Tabs/TabsAdapter";
 import Tab from "./Tab";
 
-class Tabs extends React.Component {
+export default class Tabs extends Component {
   state = {
     activeTabIndex: this.defaultActiveTabIndex()
   };
@@ -58,24 +58,16 @@ class Tabs extends React.Component {
 }
 
 Tabs.propTypes = {
+  /**
+   * Called when user activates a tab
+   */
   onTabChange: PropTypes.func,
+  /**
+   * Accepts Tab components
+   */
   children: PropTypes.node
 };
 
 Tabs.defaultProps = {
-  onTabChange: () => {},
-  children: null
+  onTabChange: () => {}
 };
-
-Tabs.__docgenInfo = {
-  props: {
-    children: {
-      description: "Accepts Tab components"
-    },
-    onTabChange: {
-      description: "Called when user activates a tab"
-    }
-  }
-};
-
-export default Tabs;

--- a/packages/react/src/elements/components/Tooltip.js
+++ b/packages/react/src/elements/components/Tooltip.js
@@ -1,9 +1,9 @@
-import * as PropTypes from "prop-types";
+import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { Tooltip as VanillaTooltip } from "hig-vanilla";
 import TooltipAdapter from "../../adapters/TooltipAdapter";
 
-class Tooltip extends Component {
+export default class Tooltip extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -37,19 +37,16 @@ class Tooltip extends Component {
 }
 
 Tooltip.propTypes = {
+  /**
+   * Where the tooltip will be anchored relative to target
+   */
   anchorPoint: PropTypes.oneOf(VanillaTooltip.AvailableAnchorPoints),
+  /**
+   * Target component to open the tooltip
+   */
   children: PropTypes.node,
+  /**
+   * Content for the tooltip
+   */
   content: PropTypes.string
 };
-
-Tooltip.__docgenInfo = {
-  props: {
-    anchorPoint: {
-      description: "where the tooltip will be anchored relative to target"
-    },
-    children: { description: "target component to open the tooltip" },
-    content: { description: "content for the tooltip" }
-  }
-};
-
-export default Tooltip;

--- a/packages/react/src/elements/components/Tooltip.js
+++ b/packages/react/src/elements/components/Tooltip.js
@@ -4,22 +4,6 @@ import { Tooltip as VanillaTooltip } from "hig-vanilla";
 import TooltipAdapter from "../../adapters/TooltipAdapter";
 
 class Tooltip extends Component {
-  static propTypes = {
-    anchorPoint: PropTypes.oneOf(VanillaTooltip.AvailableAnchorPoints),
-    children: PropTypes.node,
-    content: PropTypes.string
-  };
-
-  static __docgenInfo = {
-    props: {
-      anchorPoint: {
-        description: "where the tooltip will be anchored relative to target"
-      },
-      children: { description: "target component to open the tooltip" },
-      content: { description: "content for the tooltip" }
-    }
-  };
-
   constructor(props) {
     super(props);
     this.state = {
@@ -51,5 +35,21 @@ class Tooltip extends Component {
     );
   }
 }
+
+Tooltip.propTypes = {
+  anchorPoint: PropTypes.oneOf(VanillaTooltip.AvailableAnchorPoints),
+  children: PropTypes.node,
+  content: PropTypes.string
+};
+
+Tooltip.__docgenInfo = {
+  props: {
+    anchorPoint: {
+      description: "where the tooltip will be anchored relative to target"
+    },
+    children: { description: "target component to open the tooltip" },
+    content: { description: "content for the tooltip" }
+  }
+};
 
 export default Tooltip;

--- a/packages/react/src/playground/PlaygroundSection.js
+++ b/packages/react/src/playground/PlaygroundSection.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from "react";
-import * as PropTypes from "prop-types";
+import PropTypes from "prop-types";
 import { Container, H3, Spacer } from "../hig-react";
 
 class PlaygroundSection extends PureComponent {

--- a/packages/react/yarn.lock
+++ b/packages/react/yarn.lock
@@ -611,7 +611,7 @@ babel-plugin-jest-hoist@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz#afedc853bd3f8dc3548ea671fbe69d03cc2c1767"
 
-babel-plugin-react-docgen@^1.7.0:
+babel-plugin-react-docgen@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-react-docgen/-/babel-plugin-react-docgen-1.8.1.tgz#6e08e057f5dcd46b434e7553e971baa604dae377"
   dependencies:

--- a/packages/vanilla/src/basics/form-elements/range/range.js
+++ b/packages/vanilla/src/basics/form-elements/range/range.js
@@ -51,12 +51,18 @@ class Range extends Core {
 
   setMax(maxValue) {
     this._findDOMEl('.hig__range__field', this.el).setAttribute('max', maxValue);
-    this._findDOMEl('.hig__range__field__range-values', this.el).dataset.rangeMax = maxValue;
+    const dataset = this._findDOMEl('.hig__range__field__range-values', this.el).dataset;
+    if (dataset) {
+      dataset.rangeMax = maxValue;
+    }
   }
 
   setMin(minValue) {
     this._findDOMEl('.hig__range__field', this.el).setAttribute('min', minValue);
-    this._findDOMEl('.hig__range__field__range-values', this.el).dataset.rangeMin = minValue;
+    const dataset = this._findDOMEl('.hig__range__field__range-values', this.el).dataset;
+    if (dataset) {
+      dataset.rangeMin = minValue;
+    }
   }
 
   setStep(value) {


### PR DESCRIPTION
# Goals

Rather than manually defining a `__docgenInfo` object for each component, we can have the babel plugin `react-docgen` generate this object for us, as long as we leave comments in the expected locations and format.

Though we'll still have to repeat ourselves by documenting in each component and in `interface.json`, this approach has some benefits by automatically including the prop *type*, not just description.

# Implementation

In order for tests to recognize the generated info, we need to have Jest use **our** babel config, not the one included with `react-scripts`. Part of this PR includes updating `package.json` so that we call `jest` directly and consolidate our Jest config into its own config file.

# Side-Effects

If we remove our docgen definitions, I wonder if our code coverage statistics will drop because  there are fewer lines to cover. I ended up writing tests for previously-untested components to boost our coverage numbers and make CircleCI happy.