### PR TITLE
[Notifications] Retain Notification read state locally

### DIFF
--- a/packages/react/src/elements/components/GlobalNav/TopNav/Notification.js
+++ b/packages/react/src/elements/components/GlobalNav/TopNav/Notification.js
@@ -13,6 +13,7 @@ class Notification extends Component {
   }
 
   onClick = () => {
+    this.setState({ unread: false });
     this.props.onClick(this.props.id);
   };
 
@@ -22,7 +23,7 @@ class Notification extends Component {
         {...this.props}
         onClick={this.onClick}
         id={this.props.id}
-        unread={this.props.unread}
+        unread={this.state.unread}
       >
         {this.props.children}
       </NotificationAdapter>
@@ -50,7 +51,7 @@ Notification.__docgenInfo = {
       description: "Id for the notification"
     },
     unread: {
-      description: "{Boolean} to show specify whether notificaiton is read"
+      description: "{Boolean} initializes whether the notification is read"
     },
     children: {
       description: "content for notification"

--- a/packages/react/src/playground/index.js
+++ b/packages/react/src/playground/index.js
@@ -129,8 +129,7 @@ class Playground extends React.Component {
   transformedNotifications = notifications =>
     notifications.map(notification =>
       Object.assign({}, notification, {
-        onClick: this.onNotificationClick,
-        unread: !this.state.readIds.includes(notification.id)
+        onClick: this.onNotificationClick
       })
     );
 


### PR DESCRIPTION
So far, we've written our playground to be the source of truth for tracking the read state of notifications. We could also extend the Notification component to retain its own read/unread status. 

That way, the Notification can optimistically mark itself as read, and leave the onClick hook in place in case the consumer wants to persist that read state through another mechanism. 