### PR TITLE
Linkable things without links dont have href attr

### DIFF
--- a/packages/vanilla/src/components/button/button.html
+++ b/packages/vanilla/src/components/button/button.html
@@ -1,4 +1,4 @@
-<a tabindex="0" class="hig__button">
+<a {{#link}}href={{link}}{{/link}} tabindex="0" class="hig__button">
   <!--ICON-->
   <span class="hig__button__title"></span>
 </a>

--- a/packages/vanilla/src/components/button/button.js
+++ b/packages/vanilla/src/components/button/button.js
@@ -4,7 +4,6 @@ import Icon from 'basics/icon/icon';
 import './button.scss';
 import Template from './button.html';
 
-
 const AvailableTypes = ['primary', 'secondary', 'flat'];
 const AvailableSizes = ['small', 'standard', 'large'];
 const AvailableWidths = ['shrink', 'grow'];
@@ -44,7 +43,9 @@ class Button extends Core {
   }
 
   setLink(link) {
-    this.el.setAttribute('href', link);
+    link === undefined || link === ''
+      ? this.el.removeAttribte('href')
+      : this.el.setAttribute('href', link);
   }
 
   setType(type) {

--- a/packages/vanilla/src/components/button/button.js
+++ b/packages/vanilla/src/components/button/button.js
@@ -43,7 +43,7 @@ class Button extends Core {
   }
 
   setLink(link) {
-    link === undefined || link === ''
+    !link || link === ''
       ? this.el.removeAttribte('href')
       : this.el.setAttribute('href', link);
   }
@@ -158,7 +158,7 @@ class Button extends Core {
 Button._interface = Interface.components.Button;
 Button._defaults = {
   icon: false,
-  link: false,
+  link: null,
   size: 'standard',
   target: '_self',
   title: 'link',

--- a/packages/vanilla/src/components/global-nav/side-nav/group/module/module.html
+++ b/packages/vanilla/src/components/global-nav/side-nav/group/module/module.html
@@ -1,6 +1,6 @@
 <div class="hig__global-nav__side-nav__section__group__module">
   <div class="hig__global-nav__side-nav__section__group__module__row">
-    <a class="hig__global-nav__side-nav__section__group__module__link">
+    <a class="hig__global-nav__side-nav__section__group__module__link" {{#link}}href={{link}}{{/link}}>
       <div class="hig__global-nav__side-nav__section__group__module__link__icon"></div>
       <div class="hig__global-nav__side-nav__section__group__module__link__title">{{ title }}</div>
       <div class="hig__global-nav__side-nav__section__group__module__link__external-link-icon"></div>

--- a/packages/vanilla/src/components/global-nav/side-nav/group/module/module.js
+++ b/packages/vanilla/src/components/global-nav/side-nav/group/module/module.js
@@ -69,7 +69,7 @@ class Module extends Core {
 
   setLink(link) {
     const anchorEl = this._findDOMEl('a', this.el);
-    link === undefined || link === ''
+    !link || link === ''
       ? anchorEl.removeAttribte('href')
       : anchorEl.setAttribute('href', link);
   }
@@ -156,7 +156,8 @@ Module._interface =
   Interface.components.GlobalNav.partials.SideNav.partials.SideNavFull.partials.Group.partials.Module;
 Module._defaults = {
   icon: '',
-  title: 'title'
+  title: 'title',
+  link: null
 };
 Module._partials = {
   Submodule,

--- a/packages/vanilla/src/components/global-nav/side-nav/group/module/module.js
+++ b/packages/vanilla/src/components/global-nav/side-nav/group/module/module.js
@@ -68,7 +68,10 @@ class Module extends Core {
   }
 
   setLink(link) {
-    this._findDOMEl('a', this.el).setAttribute('href', link);
+    const anchorEl = this._findDOMEl('a', this.el);
+    link === undefined || link === ''
+      ? anchorEl.removeAttribte('href')
+      : anchorEl.setAttribute('href', link);
   }
 
   setTarget(target) {

--- a/packages/vanilla/src/components/global-nav/side-nav/group/module/submodule/submodule.html
+++ b/packages/vanilla/src/components/global-nav/side-nav/group/module/submodule/submodule.html
@@ -1,6 +1,7 @@
 <a
   class='hig__global-nav__side-nav__section__group__module__submodule
          hig__global-nav__side-nav__section__group__module__submodule--hide'
+  {{#link}}href={{link}}{{/link}}
 >
   <div class='hig__global-nav__side-nav__section__group__module__submodule__title'>{{ title }}</div>
   <div class='hig__global-nav__side-nav__section__group__module__submodule__external-link-icon'></div>

--- a/packages/vanilla/src/components/global-nav/side-nav/group/module/submodule/submodule.js
+++ b/packages/vanilla/src/components/global-nav/side-nav/group/module/submodule/submodule.js
@@ -36,7 +36,7 @@ class Submodule extends Core {
   }
 
   setLink(link) {
-    link === undefined || link === ''
+    !link || link === ''
       ? this.el.removeAttribte('href')
       : this.el.setAttribute('href', link);
   }
@@ -95,7 +95,8 @@ class Submodule extends Core {
 Submodule._interface =
   Interface.components.GlobalNav.partials.SideNav.partials.SideNavFull.partials.Group.partials.Module.partials.Submodule;
 Submodule._defaults = {
-  title: ''
+  title: '',
+  link: null
 };
 Submodule._partials = {};
 

--- a/packages/vanilla/src/components/global-nav/side-nav/group/module/submodule/submodule.js
+++ b/packages/vanilla/src/components/global-nav/side-nav/group/module/submodule/submodule.js
@@ -36,7 +36,9 @@ class Submodule extends Core {
   }
 
   setLink(link) {
-    this.el.setAttribute('href', link);
+    link === undefined || link === ''
+      ? this.el.removeAttribte('href')
+      : this.el.setAttribute('href', link);
   }
 
   setTarget(target) {

--- a/packages/vanilla/src/components/global-nav/side-nav/link/link.html
+++ b/packages/vanilla/src/components/global-nav/side-nav/link/link.html
@@ -1,4 +1,4 @@
-<a class='hig__global-nav__sidenav__links__link' href='{{ link }}' rel="getout">
+<a class='hig__global-nav__sidenav__links__link' {{#link}}href="{{ link }}" {{/link}} rel="getout">
   <div class='hig__global-nav__sidenav__links__link__title'>{{ title }}</div>
   <div class='hig__global-nav__sidenav__links__link__external-link-icon'></div>
 </a>

--- a/packages/vanilla/src/components/global-nav/side-nav/link/link.html
+++ b/packages/vanilla/src/components/global-nav/side-nav/link/link.html
@@ -1,4 +1,4 @@
-<a class='hig__global-nav__sidenav__links__link' {{#link}}href="{{ link }}" {{/link}} rel="getout">
+<a class='hig__global-nav__sidenav__links__link' {{#link}}href="{{ link }}"{{/link}}>
   <div class='hig__global-nav__sidenav__links__link__title'>{{ title }}</div>
   <div class='hig__global-nav__sidenav__links__link__external-link-icon'></div>
 </a>

--- a/packages/vanilla/src/components/global-nav/side-nav/link/link.js
+++ b/packages/vanilla/src/components/global-nav/side-nav/link/link.js
@@ -38,7 +38,7 @@ class Link extends Core {
   }
 
   setLink(link) {
-    link === undefined || link === ''
+    !link || link === ''
       ? this.el.removeAttribte('href')
       : this.el.setAttribute('href', link);
   }
@@ -73,7 +73,7 @@ Link._interface =
   Interface.components.GlobalNav.partials.SideNav.partials.SideNavFull.partials.Link;
 Link._defaults = {
   title: 'link',
-  link: false
+  link: null
 };
 
 export default Link;

--- a/packages/vanilla/src/components/global-nav/side-nav/link/link.js
+++ b/packages/vanilla/src/components/global-nav/side-nav/link/link.js
@@ -38,7 +38,9 @@ class Link extends Core {
   }
 
   setLink(link) {
-    this.el.setAttribute('href', link);
+    link === undefined || link === ''
+      ? this.el.removeAttribte('href')
+      : this.el.setAttribute('href', link);
   }
 
   setTarget(target) {
@@ -71,7 +73,7 @@ Link._interface =
   Interface.components.GlobalNav.partials.SideNav.partials.SideNavFull.partials.Link;
 Link._defaults = {
   title: 'link',
-  link: '#'
+  link: false
 };
 
 export default Link;

--- a/packages/vanilla/src/components/global-nav/top-nav/help/option/option.js
+++ b/packages/vanilla/src/components/global-nav/top-nav/help/option/option.js
@@ -19,7 +19,7 @@ class Option extends Core {
   }
 
   setLink(link) {
-    link === undefined || link === ''
+    !link || link === ''
       ? this.el.removeAttribte('href')
       : this.el.setAttribute('href', link);
   }

--- a/packages/vanilla/src/components/global-nav/top-nav/help/option/option.js
+++ b/packages/vanilla/src/components/global-nav/top-nav/help/option/option.js
@@ -19,7 +19,7 @@ class Option extends Core {
   }
 
   setLink(link) {
-    link === undefined
+    link === undefined || link === ''
       ? this.el.removeAttribte('href')
       : this.el.setAttribute('href', link);
   }
@@ -30,7 +30,8 @@ class Option extends Core {
   }
 }
 
-Option._interface = Interface.components.GlobalNav.partials.TopNav.partials.Help.partials.Option;
+Option._interface =
+  Interface.components.GlobalNav.partials.TopNav.partials.Help.partials.Option;
 Option._defaults = {
   name: '',
   link: null

--- a/packages/vanilla/src/components/global-nav/top-nav/shortcut/shortcut.html
+++ b/packages/vanilla/src/components/global-nav/top-nav/shortcut/shortcut.html
@@ -1,1 +1,1 @@
-<a title="{{ title }}" class="hig__global-nav__top-nav__shortcut"></a>
+<a title="{{ title }}" class="hig__global-nav__top-nav__shortcut" {{#link}}href={{link}}{{/link}}></a>

--- a/packages/vanilla/src/components/global-nav/top-nav/shortcut/shortcut.js
+++ b/packages/vanilla/src/components/global-nav/top-nav/shortcut/shortcut.js
@@ -36,7 +36,9 @@ class Shortcut extends Core {
   }
 
   setLink(link) {
-    this.el.setAttribute('href', link);
+    link === undefined || link === ''
+      ? this.el.removeAttribte('href')
+      : this.el.setAttribute('href', link);
   }
 
   _findOrCreateIconComponent(mountElOrSelector, name = 'icon') {

--- a/packages/vanilla/src/components/icon-button/icon-button.js
+++ b/packages/vanilla/src/components/icon-button/icon-button.js
@@ -46,7 +46,7 @@ class IconButton extends Core {
   }
 
   setLink(link) {
-    link === undefined || link === ''
+    !link || link === ''
       ? this.el.removeAttribte('href')
       : this.el.setAttribute('href', link);
   }
@@ -112,8 +112,9 @@ class IconButton extends Core {
 
 IconButton._interface = Interface.components.IconButton;
 IconButton._defaults = {
-  title: 'button',
   icon: false,
+  link: null,
+  title: 'button',
   type: AvailableTypes[0]
 };
 IconButton.AvailableTypes = AvailableTypes;

--- a/packages/vanilla/src/components/icon-button/icon-button.js
+++ b/packages/vanilla/src/components/icon-button/icon-button.js
@@ -46,7 +46,9 @@ class IconButton extends Core {
   }
 
   setLink(link) {
-    this.el.setAttribute('href', link);
+    link === undefined || link === ''
+      ? this.el.removeAttribte('href')
+      : this.el.setAttribute('href', link);
   }
 
   setIcon(icon) {


### PR DESCRIPTION
I went through every component with a `setLink` method and treated them all the same way.
- `setLink` adds and removes the `href` attribute as needed.
- template includes/excludes `href` attribute based on value of `link`.

Completes #636 