### PR TITLE
Nav fixes

### DIFF
--- a/packages/vanilla/src/components/global-nav/side-nav/group/module/collapse/collapse.scss
+++ b/packages/vanilla/src/components/global-nav/side-nav/group/module/collapse/collapse.scss
@@ -2,15 +2,22 @@
 @import '~helpers/css/mixins/base.scss';
 @import '~helpers/css/mixins/spacing.scss';
 .hig__global-nav__side-nav__section__group__module__collapse {
-  @include vendor-prefix('transform', 'rotate(0deg)');
-  &--collapsed {
-    @include vendor-prefix('transform', 'rotate(-90deg)');
-  }
   &--hide {
     display: none;
   }
+
   &:hover {
     cursor: pointer;
+  }
+
+  .hig__icon {
+    @include vendor-prefix('transform', 'rotate(0deg)');
+  }
+}
+
+.hig__global-nav__side-nav__section__group__module__collapse--collapsed {
+  .hig__icon {
+    @include vendor-prefix('transform', 'rotate(-90deg)');
   }
 }
 

--- a/packages/vanilla/src/components/global-nav/side-nav/group/module/module.scss
+++ b/packages/vanilla/src/components/global-nav/side-nav/group/module/module.scss
@@ -58,7 +58,7 @@
 }
 
 .hig__global-nav__side-nav__section__group__module__submodules {
-  padding-left: 48px;
+  padding-left: 46px;
   &--no-icon {
     padding-left: spacing(m);
   }

--- a/packages/vanilla/src/components/global-nav/top-nav/notifications/_list/_list.html
+++ b/packages/vanilla/src/components/global-nav/top-nav/notifications/_list/_list.html
@@ -1,7 +1,7 @@
 <div>
   <div class="hig__notification__title"></div>
   <div class="hig__notifications__list">
-    <div class="hig__notifications__list-content"><!--NOTIFICATIONS--></div>
+    <div class="hig__notifications__list-content hig__notifications__list-content--loaded"><!--NOTIFICATIONS--></div>
     <div class="hig__notifications__loading-container" />
   </div>
 </div>


### PR DESCRIPTION
1. Default Notifications to "loaded" in case `loading` prop is never used.
3. Align Submodules with the Module title
2. Fix Module Collapse icon positioning when title spans several lines:

![screen shot 2018-01-24 at 3 57 49 pm](https://user-images.githubusercontent.com/1744567/35363548-5b31f96a-011f-11e8-82b3-1a45b17c8629.png)