### PR TITLE
[SideNav] Clicking a module only toggles expand/collapse

### DIFF
--- a/packages/react/src/elements/components/GlobalNav/SideNav/SideNav.test.js
+++ b/packages/react/src/elements/components/GlobalNav/SideNav/SideNav.test.js
@@ -89,10 +89,10 @@ describe("<SideNav>", () => {
     });
 
     describe("matching a submodule", () => {
-      it("passes active to the submodule and its parent", () => {
+      it("passes active to the submodule but not its parent", () => {
         const wrapper = mount(<Context activeModuleId="sub-1" />);
         expect(wrapper.find(Submodule).first()).toHaveProp("active", true);
-        expect(wrapper.find(Module).first()).toHaveProp("active", true);
+        expect(wrapper.find(Module).first()).toHaveProp("active", false);
       });
     });
   });

--- a/packages/react/src/elements/components/GlobalNav/SideNav/WithState.js
+++ b/packages/react/src/elements/components/GlobalNav/SideNav/WithState.js
@@ -95,17 +95,9 @@ export default function WithState(WrappedComponent) {
     };
 
     handleModuleClick = id => {
-      const submodules = this.props.submodules.filter(s => s.moduleId === id);
+      this.toggleModuleMinimized(id);
+      this.setActiveModuleId(id);
 
-      if (submodules.length > 0) {
-        if (submodules.length > 5) {
-          this.toggleModuleMinimized(id);
-        }
-
-        this.setActiveModuleId(submodules[0].id);
-      } else {
-        this.setActiveModuleId(id);
-      }
       if (this.props.onModuleClick) {
         this.props.onModuleClick(id);
       }

--- a/packages/react/src/elements/components/GlobalNav/SideNav/model.js
+++ b/packages/react/src/elements/components/GlobalNav/SideNav/model.js
@@ -37,16 +37,13 @@ export function getModuleState(moduleStates, id) {
 export function mergeState({ modules, submodules, ...props }, state) {
   const activeModuleId = props.activeModuleId || state.activeModuleId;
   const activeModule = modules.find(m => m.id === activeModuleId) || {};
-  const activeSubmodule = submodules.find(m => m.id === activeModuleId) || {};
 
   return {
     ...props,
     modules: modules.map(module => {
       const moduleWithState = {
         ...module,
-        active:
-          module.id === activeModule.id ||
-          module.id === activeSubmodule.moduleId,
+        active: module.id === activeModule.id,
         ...getModuleState(state.moduleStates, module.id)
       };
 

--- a/packages/react/src/elements/components/GlobalNav/SideNav/model.test.js
+++ b/packages/react/src/elements/components/GlobalNav/SideNav/model.test.js
@@ -102,21 +102,21 @@ describe("SideNav model", () => {
             state
           );
 
-          expect(result.modules[0].active).toBeTruthy();
+          expect(result.modules[0].active).toBeFalsy();
           expect(result.submodules[0].active).toBeTruthy();
         });
       });
     });
 
     describe("with an active submodule", () => {
-      it("sets active on the submodule and the parent module", () => {
+      it("sets active on the submodule but not the parent module", () => {
         const state = {
           activeModuleId: "A",
           moduleStates: {}
         };
         const result = mergeState(props, state);
 
-        expect(result.modules[0].active).toBeTruthy();
+        expect(result.modules[0].active).toBeFalsy();
         expect(result.submodules[0].active).toBeTruthy();
       });
     });


### PR DESCRIPTION
This change no longer activates the first submodule.

![nav](https://user-images.githubusercontent.com/1744567/35365824-5a458556-012b-11e8-81bd-a42fc21dc98a.gif)
