### PR TITLE
[SideNav] onNavigation changes and "active" modules

### DIFF
--- a/packages/interface/interface.json
+++ b/packages/interface/interface.json
@@ -1212,6 +1212,9 @@
                         "activate": {
                           "desc": "activates the module"
                         },
+                        "activateChildren": {
+                          "desc": "indicates a module's submodules are active"
+                        },
                         "addSubmodule": {
                           "desc": "Pass in an instance of a Submodule partial",
                           "params": [
@@ -1228,6 +1231,9 @@
                         },
                         "deactivate": {
                           "desc": "deactivates the module"
+                        },
+                        "deactivateChildren": {
+                          "desc": "indicates a module's submodules are not active"
                         },
                         "hide": {
                           "desc": "hide (used for filtering)"

--- a/packages/react/src/adapters/GlobalNav/SideNav/ModuleAdapter.js
+++ b/packages/react/src/adapters/GlobalNav/SideNav/ModuleAdapter.js
@@ -77,6 +77,13 @@ function ModuleAdapter(props) {
               value ? instance.activate() : instance.deactivate()
             }
           </MapsPropToMethod>
+          <MapsPropToMethod value={props.activeChildren} {...adapterProps}>
+            {(instance, value) =>
+              value
+                ? instance.activateChildren()
+                : instance.deactivateChildren()
+            }
+          </MapsPropToMethod>
           <MountsHIGChild {...adapterProps}>{collapse}</MountsHIGChild>
           {submodules.length > 0 ? (
             <MountsHIGChildList {...adapterProps}>
@@ -96,6 +103,7 @@ ModuleAdapter.propTypes = {
   title: PropTypes.string,
   target: PropTypes.string,
   active: PropTypes.bool,
+  activeChildren: PropTypes.bool,
   onClick: PropTypes.func,
   onHover: PropTypes.func
 };
@@ -105,7 +113,8 @@ ModuleAdapter.defaultProps = {
   icon: undefined,
   link: undefined,
   title: undefined,
-  active: undefined,
+  active: false,
+  activeChildren: false,
   onClick: undefined,
   onHover: undefined
 };

--- a/packages/react/src/adapters/GlobalNav/SideNav/ModuleAdapter.test.js
+++ b/packages/react/src/adapters/GlobalNav/SideNav/ModuleAdapter.test.js
@@ -27,6 +27,7 @@ describe("ModuleAdapter", () => {
                   onClick={() => {}}
                   onHover={() => {}}
                   active
+                  activeChildren
                 >
                   <CollapseAdapter />
                   <SubmoduleAdapter />
@@ -38,6 +39,7 @@ describe("ModuleAdapter", () => {
       );
 
       mockInstance.deactivate();
+      mockInstance.deactivateChildren();
 
       // Doesn't implement show and hide.
       mockInstance.show();

--- a/packages/react/src/elements/components/GlobalNav/SideNav/SideNav.test.js
+++ b/packages/react/src/elements/components/GlobalNav/SideNav/SideNav.test.js
@@ -89,10 +89,11 @@ describe("<SideNav>", () => {
     });
 
     describe("matching a submodule", () => {
-      it("passes active to the submodule but not its parent", () => {
+      it("passes active to the submodule and activeChildren to its parent", () => {
         const wrapper = mount(<Context activeModuleId="sub-1" />);
         expect(wrapper.find(Submodule).first()).toHaveProp("active", true);
         expect(wrapper.find(Module).first()).toHaveProp("active", false);
+        expect(wrapper.find(Module).first()).toHaveProp("activeChildren", true);
       });
     });
   });

--- a/packages/react/src/elements/components/GlobalNav/SideNav/model.js
+++ b/packages/react/src/elements/components/GlobalNav/SideNav/model.js
@@ -37,6 +37,7 @@ export function getModuleState(moduleStates, id) {
 export function mergeState({ modules, submodules, ...props }, state) {
   const activeModuleId = props.activeModuleId || state.activeModuleId;
   const activeModule = modules.find(m => m.id === activeModuleId) || {};
+  const activeSubmodule = submodules.find(m => m.id === activeModuleId) || {};
 
   return {
     ...props,
@@ -44,6 +45,7 @@ export function mergeState({ modules, submodules, ...props }, state) {
       const moduleWithState = {
         ...module,
         active: module.id === activeModule.id,
+        activeChildren: module.id === activeSubmodule.moduleId,
         ...getModuleState(state.moduleStates, module.id)
       };
 

--- a/packages/react/src/elements/components/GlobalNav/SideNav/model.test.js
+++ b/packages/react/src/elements/components/GlobalNav/SideNav/model.test.js
@@ -103,13 +103,14 @@ describe("SideNav model", () => {
           );
 
           expect(result.modules[0].active).toBeFalsy();
+          expect(result.modules[0].activeChildren).toBeTruthy();
           expect(result.submodules[0].active).toBeTruthy();
         });
       });
     });
 
     describe("with an active submodule", () => {
-      it("sets active on the submodule but not the parent module", () => {
+      it("sets active on the submodule and activeChildren on the parent module", () => {
         const state = {
           activeModuleId: "A",
           moduleStates: {}
@@ -117,6 +118,7 @@ describe("SideNav model", () => {
         const result = mergeState(props, state);
 
         expect(result.modules[0].active).toBeFalsy();
+        expect(result.modules[0].activeChildren).toBeTruthy();
         expect(result.submodules[0].active).toBeTruthy();
       });
     });

--- a/packages/react/src/elements/components/GlobalNav/TopNav/Help/Option.test.js
+++ b/packages/react/src/elements/components/GlobalNav/TopNav/Help/Option.test.js
@@ -1,0 +1,15 @@
+/* eslint-disable no-console */
+import React from "react";
+import { mount } from "enzyme";
+import Option from "./Option";
+
+describe("Option", () => {
+  it("raises no errors", () => {
+    const errorSpy = jest.fn();
+    console.error = errorSpy;
+
+    mount(<Option name="Option" onClick={() => {}} />);
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/playground/index.js
+++ b/packages/react/src/playground/index.js
@@ -302,9 +302,6 @@ class Playground extends React.Component {
   navigate = id => {
     console.log("Go to", id);
     this.setState({ activeModuleId: id });
-    if (window.innerWidth <= breakpoints.tablet) {
-      this.setState({ isSideNavOpen: false });
-    }
   };
 
   closeHelp = () => {

--- a/packages/vanilla/src/components/global-nav/side-nav/group/module/module.js
+++ b/packages/vanilla/src/components/global-nav/side-nav/group/module/module.js
@@ -129,6 +129,24 @@ class Module extends Core {
     );
   }
 
+  activateChildren() {
+    this._findDOMEl(
+      '.hig__global-nav__side-nav__section__group__module__link',
+      this.el
+    ).classList.add(
+      'hig__global-nav__side-nav__section__group__module__link--active-children'
+    );
+  }
+
+  deactivateChildren() {
+    this._findDOMEl(
+      '.hig__global-nav__side-nav__section__group__module__link',
+      this.el
+    ).classList.remove(
+      'hig__global-nav__side-nav__section__group__module__link--active-children'
+    );
+  }
+
   _setExternalLinkIcon() {
     if (this._findDOMEl('a', this.el).getAttribute('target') === '_blank') {
       const mountEl = this._findDOMEl(

--- a/packages/vanilla/src/components/global-nav/side-nav/group/module/module.scss
+++ b/packages/vanilla/src/components/global-nav/side-nav/group/module/module.scss
@@ -88,14 +88,18 @@
     }
   }
   &:hover,
-  &--active {
-    color: color(hig-blue-50);
+  &--active,
+  &--active-children {
     &::before {
       border-left-color: color(hig-blue-50);
     }
     .hig__global-nav__side-nav__section__group__module__link__icon svg * {
       fill: color(hig-blue-50);
     }
+  }
+  &:hover,
+  &--active {
+    color: color(hig-blue-50);
     .hig__global-nav__side-nav__section__group__module__link__external-link-icon svg * {
       stroke: color(hig-blue-50);
     }
@@ -128,14 +132,18 @@
       }
     }
     &:hover,
-    &--active {
-      color: color(hig-blue-40);
+    &--active,
+    &--active-children {
       &::before {
         border-left-color: color(hig-blue-40);
       }
       .hig__global-nav__side-nav__section__group__module__link__icon svg * {
         fill: color(hig-blue-40);
       }
+    }
+    &:hover,
+    &--active {
+      color: color(hig-blue-40);
       .hig__global-nav__side-nav__section__group__module__link__external-link-icon svg * {
         stroke: color(hig-blue-40);
       }


### PR DESCRIPTION
In https://github.com/Autodesk/hig/pull/659, I omitted the part where the icon and vertical line still indicate a module is semi-active.

<img width="142" alt="screen shot 2018-01-25 at 10 54 08 am" src="https://user-images.githubusercontent.com/1744567/35406756-a3a97b06-01be-11e8-9439-86cf4c99d6e0.png">
<img width="139" alt="screen shot 2018-01-25 at 10 54 15 am" src="https://user-images.githubusercontent.com/1744567/35406757-a3c472da-01be-11e8-98c4-70402fe7d963.png">

This PR also updates the playground to not do anything additional to the sidenav on navigation (fixes https://github.com/Autodesk/hig/issues/648).