### PR TITLE
Bugfixes: Autogenerate Typography component docgenInfo

### DIFF
--- a/packages/react/src/elements/components/Typography.js
+++ b/packages/react/src/elements/components/Typography.js
@@ -1,93 +1,11 @@
-import React from "react";
-import Typography from "../../adapters/TypographyAdapter";
+export { default as H1 } from "./Typography/H1";
+export { default as H2 } from "./Typography/H2";
+export { default as H3 } from "./Typography/H3";
+export { default as Text } from "./Typography/Text";
 
-export function H1({ children, ...remainingProps }) {
-  return <Typography type="h1" text={children} {...remainingProps} />;
-}
-
-export function H2({ children, ...remainingProps }) {
-  return <Typography type="h2" text={children} {...remainingProps} />;
-}
-
-export function H3({ children, ...remainingProps }) {
-  return <Typography type="h3" text={children} {...remainingProps} />;
-}
-
-export function Text({ children, ...remainingProps }) {
-  return <Typography type="text" text={children} {...remainingProps} />;
-}
-
-export function Sub1({ children, ...remainingProps }) {
-  console.warn(
-    "Component Sub1 is deprecated and will be removed in the next version"
-  );
-  return <Typography type="sub1" text={children} {...remainingProps} />;
-}
-
-export function Sub2({ children, ...remainingProps }) {
-  console.warn(
-    "Component Sub2 is deprecated and will be removed in the next version"
-  );
-  return <Typography type="sub2" text={children} {...remainingProps} />;
-}
-
-export function Body({ children, ...remainingProps }) {
-  console.warn(
-    "Component Body is deprecated and will be removed in the next version"
-  );
-  return <Typography type="body" text={children} {...remainingProps} />;
-}
-
-export function Bold({ children, ...remainingProps }) {
-  console.warn(
-    "Component Bold is deprecated and will be removed in the next version"
-  );
-  return <Typography type="bold" text={children} {...remainingProps} />;
-}
-
-export function Disabled({ children, ...remainingProps }) {
-  console.warn(
-    "Component Disabled is deprecated and will be removed in the next version"
-  );
-  return <Typography type="disabled" text={children} {...remainingProps} />;
-}
-
-export function Caption({ children, ...remainingProps }) {
-  console.warn(
-    "Component Caption is deprecated and will be removed in the next version"
-  );
-  return <Typography type="caption" text={children} {...remainingProps} />;
-}
-
-const docgenInfo = {
-  props: {
-    bold: {
-      description: "Whether to render bold text"
-    },
-    color: {
-      description:
-        "A text color. One of: 'hig-white', 'hig-cool-gray-70', 'hig-blue-50', 'hig-green-good', 'hig-yellow-warning', 'hig-red-alert'"
-    },
-    disabled: {
-      description: "Whether to show text as disabled"
-    },
-    opacity: {
-      description: "An opacity value to modify the color, between 0.0 and 1.0"
-    },
-    size: {
-      description: "One of: 'small', 'medium', 'large'"
-    },
-    children: {
-      description: "any content"
-    }
-  }
-};
-
-const { type, text, ...propTypes } = Typography.propTypes;
-
-[H1, H2, H3, Text, Sub1, Sub2, Body, Bold, Disabled, Caption].forEach(
-  componentClass => {
-    componentClass.__docgenInfo = docgenInfo; // eslint-disable-line no-param-reassign
-    componentClass.propTypes = propTypes; // eslint-disable-line no-param-reassign
-  }
-);
+export { default as Body } from "./Typography/Body";
+export { default as Bold } from "./Typography/Bold";
+export { default as Caption } from "./Typography/Caption";
+export { default as Disabled } from "./Typography/Disabled";
+export { default as Sub1 } from "./Typography/Sub1";
+export { default as Sub2 } from "./Typography/Sub2";

--- a/packages/react/src/elements/components/Typography/Body.js
+++ b/packages/react/src/elements/components/Typography/Body.js
@@ -1,0 +1,44 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Typography as VanillaTypography } from "hig-vanilla";
+import Typography from "../../../adapters/TypographyAdapter";
+
+export default class Body extends React.PureComponent {
+  render() {
+    console.warn(
+      "Component Body is deprecated and will be removed in the next version"
+    );
+    const { children, ...remainingProps } = this.props;
+    return <Typography type="body" text={children} {...remainingProps} />;
+  }
+}
+Body.propTypes = {
+  /**
+   * Whether to render bold text
+   */
+  bold: PropTypes.bool,
+  /**
+   * Text to show inside the typography
+   */
+  children: PropTypes.string.isRequired,
+  /**
+   * Colors the text with one of the supported HIG colors
+   */
+  color: PropTypes.oneOf(VanillaTypography.VALID_COLORS),
+  /**
+   * Whether to show text as disabled
+   */
+  disabled: PropTypes.bool,
+  /**
+   * An opacity value to modify the color, between 0.0 and 1.0
+   */
+  opacity: PropTypes.number,
+  /**
+   * Sizes the text with one of the supported modifiers
+   */
+  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES),
+  /**
+   * Indicates the initial Typography style
+   */
+  type: PropTypes.oneOf(VanillaTypography.VALID_TYPES).isRequired
+};

--- a/packages/react/src/elements/components/Typography/Bold.js
+++ b/packages/react/src/elements/components/Typography/Bold.js
@@ -1,0 +1,44 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Typography as VanillaTypography } from "hig-vanilla";
+import Typography from "../../../adapters/TypographyAdapter";
+
+export default class Bold extends React.PureComponent {
+  render() {
+    console.warn(
+      "Component Bold is deprecated and will be removed in the next version"
+    );
+    const { children, ...remainingProps } = this.props;
+    return <Typography type="bold" text={children} {...remainingProps} />;
+  }
+}
+Bold.propTypes = {
+  /**
+   * Whether to render bold text
+   */
+  bold: PropTypes.bool,
+  /**
+   * Text to show inside the typography
+   */
+  children: PropTypes.string.isRequired,
+  /**
+   * Colors the text with one of the supported HIG colors
+   */
+  color: PropTypes.oneOf(VanillaTypography.VALID_COLORS),
+  /**
+   * Whether to show text as disabled
+   */
+  disabled: PropTypes.bool,
+  /**
+   * An opacity value to modify the color, between 0.0 and 1.0
+   */
+  opacity: PropTypes.number,
+  /**
+   * Sizes the text with one of the supported modifiers
+   */
+  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES),
+  /**
+   * Indicates the initial Typography style
+   */
+  type: PropTypes.oneOf(VanillaTypography.VALID_TYPES).isRequired
+};

--- a/packages/react/src/elements/components/Typography/Caption.js
+++ b/packages/react/src/elements/components/Typography/Caption.js
@@ -1,0 +1,44 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Typography as VanillaTypography } from "hig-vanilla";
+import Typography from "../../../adapters/TypographyAdapter";
+
+export default class Caption extends React.PureComponent {
+  render() {
+    console.warn(
+      "Component Caption is deprecated and will be removed in the next version"
+    );
+    const { children, ...remainingProps } = this.props;
+    return <Typography type="caption" text={children} {...remainingProps} />;
+  }
+}
+Caption.propTypes = {
+  /**
+   * Whether to render bold text
+   */
+  bold: PropTypes.bool,
+  /**
+   * Text to show inside the typography
+   */
+  children: PropTypes.string.isRequired,
+  /**
+   * Colors the text with one of the supported HIG colors
+   */
+  color: PropTypes.oneOf(VanillaTypography.VALID_COLORS),
+  /**
+   * Whether to show text as disabled
+   */
+  disabled: PropTypes.bool,
+  /**
+   * An opacity value to modify the color, between 0.0 and 1.0
+   */
+  opacity: PropTypes.number,
+  /**
+   * Sizes the text with one of the supported modifiers
+   */
+  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES),
+  /**
+   * Indicates the initial Typography style
+   */
+  type: PropTypes.oneOf(VanillaTypography.VALID_TYPES).isRequired
+};

--- a/packages/react/src/elements/components/Typography/Disabled.js
+++ b/packages/react/src/elements/components/Typography/Disabled.js
@@ -1,0 +1,44 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Typography as VanillaTypography } from "hig-vanilla";
+import Typography from "../../../adapters/TypographyAdapter";
+
+export default class Disabled extends React.PureComponent {
+  render() {
+    console.warn(
+      "Component Disabled is deprecated and will be removed in the next version"
+    );
+    const { children, ...remainingProps } = this.props;
+    return <Typography type="Disabled" text={children} {...remainingProps} />;
+  }
+}
+Disabled.propTypes = {
+  /**
+   * Whether to render bold text
+   */
+  bold: PropTypes.bool,
+  /**
+   * Text to show inside the typography
+   */
+  children: PropTypes.string.isRequired,
+  /**
+   * Colors the text with one of the supported HIG colors
+   */
+  color: PropTypes.oneOf(VanillaTypography.VALID_COLORS),
+  /**
+   * Whether to show text as disabled
+   */
+  disabled: PropTypes.bool,
+  /**
+   * An opacity value to modify the color, between 0.0 and 1.0
+   */
+  opacity: PropTypes.number,
+  /**
+   * Sizes the text with one of the supported modifiers
+   */
+  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES),
+  /**
+   * Indicates the initial Typography style
+   */
+  type: PropTypes.oneOf(VanillaTypography.VALID_TYPES).isRequired
+};

--- a/packages/react/src/elements/components/Typography/H1.js
+++ b/packages/react/src/elements/components/Typography/H1.js
@@ -1,0 +1,41 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Typography as VanillaTypography } from "hig-vanilla";
+import Typography from "../../../adapters/TypographyAdapter";
+
+export default class H1 extends React.PureComponent {
+  render() {
+    const { children, ...remainingProps } = this.props;
+    return <Typography type="h1" text={children} {...remainingProps} />;
+  }
+}
+H1.propTypes = {
+  /**
+   * Whether to render bold text
+   */
+  bold: PropTypes.bool,
+  /**
+   * Text to show inside the typography
+   */
+  children: PropTypes.string.isRequired,
+  /**
+   * Colors the text with one of the supported HIG colors
+   */
+  color: PropTypes.oneOf(VanillaTypography.VALID_COLORS),
+  /**
+   * Whether to show text as disabled
+   */
+  disabled: PropTypes.bool,
+  /**
+   * An opacity value to modify the color, between 0.0 and 1.0
+   */
+  opacity: PropTypes.number,
+  /**
+   * Sizes the text with one of the supported modifiers
+   */
+  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES),
+  /**
+   * Indicates the initial Typography style
+   */
+  type: PropTypes.oneOf(VanillaTypography.VALID_TYPES).isRequired
+};

--- a/packages/react/src/elements/components/Typography/H2.js
+++ b/packages/react/src/elements/components/Typography/H2.js
@@ -1,0 +1,41 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Typography as VanillaTypography } from "hig-vanilla";
+import Typography from "../../../adapters/TypographyAdapter";
+
+export default class H2 extends React.PureComponent {
+  render() {
+    const { children, ...remainingProps } = this.props;
+    return <Typography type="h2" text={children} {...remainingProps} />;
+  }
+}
+H2.propTypes = {
+  /**
+   * Whether to render bold text
+   */
+  bold: PropTypes.bool,
+  /**
+   * Text to show inside the typography
+   */
+  children: PropTypes.string.isRequired,
+  /**
+   * Colors the text with one of the supported HIG colors
+   */
+  color: PropTypes.oneOf(VanillaTypography.VALID_COLORS),
+  /**
+   * Whether to show text as disabled
+   */
+  disabled: PropTypes.bool,
+  /**
+   * An opacity value to modify the color, between 0.0 and 1.0
+   */
+  opacity: PropTypes.number,
+  /**
+   * Sizes the text with one of the supported modifiers
+   */
+  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES),
+  /**
+   * Indicates the initial Typography style
+   */
+  type: PropTypes.oneOf(VanillaTypography.VALID_TYPES).isRequired
+};

--- a/packages/react/src/elements/components/Typography/H3.js
+++ b/packages/react/src/elements/components/Typography/H3.js
@@ -1,0 +1,41 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Typography as VanillaTypography } from "hig-vanilla";
+import Typography from "../../../adapters/TypographyAdapter";
+
+export default class H3 extends React.PureComponent {
+  render() {
+    const { children, ...remainingProps } = this.props;
+    return <Typography type="h3" text={children} {...remainingProps} />;
+  }
+}
+H3.propTypes = {
+  /**
+   * Whether to render bold text
+   */
+  bold: PropTypes.bool,
+  /**
+   * Text to show inside the typography
+   */
+  children: PropTypes.string.isRequired,
+  /**
+   * Colors the text with one of the supported HIG colors
+   */
+  color: PropTypes.oneOf(VanillaTypography.VALID_COLORS),
+  /**
+   * Whether to show text as disabled
+   */
+  disabled: PropTypes.bool,
+  /**
+   * An opacity value to modify the color, between 0.0 and 1.0
+   */
+  opacity: PropTypes.number,
+  /**
+   * Sizes the text with one of the supported modifiers
+   */
+  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES),
+  /**
+   * Indicates the initial Typography style
+   */
+  type: PropTypes.oneOf(VanillaTypography.VALID_TYPES).isRequired
+};

--- a/packages/react/src/elements/components/Typography/Sub1.js
+++ b/packages/react/src/elements/components/Typography/Sub1.js
@@ -1,0 +1,44 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Typography as VanillaTypography } from "hig-vanilla";
+import Typography from "../../../adapters/TypographyAdapter";
+
+export default class Sub1 extends React.PureComponent {
+  render() {
+    console.warn(
+      "Component Sub1 is deprecated and will be removed in the next version"
+    );
+    const { children, ...remainingProps } = this.props;
+    return <Typography type="sub1" text={children} {...remainingProps} />;
+  }
+}
+Sub1.propTypes = {
+  /**
+   * Whether to render bold text
+   */
+  bold: PropTypes.bool,
+  /**
+   * Text to show inside the typography
+   */
+  children: PropTypes.string.isRequired,
+  /**
+   * Colors the text with one of the supported HIG colors
+   */
+  color: PropTypes.oneOf(VanillaTypography.VALID_COLORS),
+  /**
+   * Whether to show text as disabled
+   */
+  disabled: PropTypes.bool,
+  /**
+   * An opacity value to modify the color, between 0.0 and 1.0
+   */
+  opacity: PropTypes.number,
+  /**
+   * Sizes the text with one of the supported modifiers
+   */
+  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES),
+  /**
+   * Indicates the initial Typography style
+   */
+  type: PropTypes.oneOf(VanillaTypography.VALID_TYPES).isRequired
+};

--- a/packages/react/src/elements/components/Typography/Sub2.js
+++ b/packages/react/src/elements/components/Typography/Sub2.js
@@ -1,0 +1,44 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Typography as VanillaTypography } from "hig-vanilla";
+import Typography from "../../../adapters/TypographyAdapter";
+
+export default class Sub2 extends React.PureComponent {
+  render() {
+    console.warn(
+      "Component Sub2 is deprecated and will be removed in the next version"
+    );
+    const { children, ...remainingProps } = this.props;
+    return <Typography type="sub2" text={children} {...remainingProps} />;
+  }
+}
+Sub2.propTypes = {
+  /**
+   * Whether to render bold text
+   */
+  bold: PropTypes.bool,
+  /**
+   * Text to show inside the typography
+   */
+  children: PropTypes.string.isRequired,
+  /**
+   * Colors the text with one of the supported HIG colors
+   */
+  color: PropTypes.oneOf(VanillaTypography.VALID_COLORS),
+  /**
+   * Whether to show text as disabled
+   */
+  disabled: PropTypes.bool,
+  /**
+   * An opacity value to modify the color, between 0.0 and 1.0
+   */
+  opacity: PropTypes.number,
+  /**
+   * Sizes the text with one of the supported modifiers
+   */
+  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES),
+  /**
+   * Indicates the initial Typography style
+   */
+  type: PropTypes.oneOf(VanillaTypography.VALID_TYPES).isRequired
+};

--- a/packages/react/src/elements/components/Typography/Text.js
+++ b/packages/react/src/elements/components/Typography/Text.js
@@ -1,0 +1,41 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Typography as VanillaTypography } from "hig-vanilla";
+import Typography from "../../../adapters/TypographyAdapter";
+
+export default class Text extends React.PureComponent {
+  render() {
+    const { children, ...remainingProps } = this.props;
+    return <Typography type="text" text={children} {...remainingProps} />;
+  }
+}
+Text.propTypes = {
+  /**
+   * Whether to render bold text
+   */
+  bold: PropTypes.bool,
+  /**
+   * Text to show inside the typography
+   */
+  children: PropTypes.string.isRequired,
+  /**
+   * Colors the text with one of the supported HIG colors
+   */
+  color: PropTypes.oneOf(VanillaTypography.VALID_COLORS),
+  /**
+   * Whether to show text as disabled
+   */
+  disabled: PropTypes.bool,
+  /**
+   * An opacity value to modify the color, between 0.0 and 1.0
+   */
+  opacity: PropTypes.number,
+  /**
+   * Sizes the text with one of the supported modifiers
+   */
+  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES),
+  /**
+   * Indicates the initial Typography style
+   */
+  type: PropTypes.oneOf(VanillaTypography.VALID_TYPES).isRequired
+};


### PR DESCRIPTION
At the expense of some repetition, this makes it much easier for our docgen plugin to annotate
individual typography components. It also more accurately documents the `children` prop instead of `text`, since the interfaces for Typography and TypographyAdapter differ slightly.