### PR TITLE
Bugfixes: Search - Set focus on mouseover

### DIFF
--- a/packages/react/src/elements/components/GlobalNav/TopNav/Search.js
+++ b/packages/react/src/elements/components/GlobalNav/TopNav/Search.js
@@ -50,12 +50,15 @@ export default class Search extends Component {
     this.hideOptions();
   };
 
+  handleOptionHover = focusedOptionIndex => () =>
+    this.setState({ focusedOptionIndex });
+
   hideOptions = () => {
     this.setState({ showOptions: false, focusedOptionIndex: undefined });
   };
 
   handleFocusOut = () => {
-    this.setState({ clearIconVisible: false, focusedOptionIndex: undefined });
+    this.setState({ clearIconVisible: false });
   };
 
   handleFocusIn = () => {
@@ -158,6 +161,7 @@ export default class Search extends Component {
                 focused={index === this.state.focusedOptionIndex}
                 {...option}
                 onClick={this.handleOptionSelect}
+                onHover={this.handleOptionHover(index)}
               />
             ))
           : null}

--- a/packages/react/src/elements/components/Typography/Body.js
+++ b/packages/react/src/elements/components/Typography/Body.js
@@ -36,9 +36,5 @@ Body.propTypes = {
   /**
    * Sizes the text with one of the supported modifiers
    */
-  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES),
-  /**
-   * Indicates the initial Typography style
-   */
-  type: PropTypes.oneOf(VanillaTypography.VALID_TYPES).isRequired
+  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES)
 };

--- a/packages/react/src/elements/components/Typography/Bold.js
+++ b/packages/react/src/elements/components/Typography/Bold.js
@@ -36,9 +36,5 @@ Bold.propTypes = {
   /**
    * Sizes the text with one of the supported modifiers
    */
-  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES),
-  /**
-   * Indicates the initial Typography style
-   */
-  type: PropTypes.oneOf(VanillaTypography.VALID_TYPES).isRequired
+  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES)
 };

--- a/packages/react/src/elements/components/Typography/Caption.js
+++ b/packages/react/src/elements/components/Typography/Caption.js
@@ -36,9 +36,5 @@ Caption.propTypes = {
   /**
    * Sizes the text with one of the supported modifiers
    */
-  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES),
-  /**
-   * Indicates the initial Typography style
-   */
-  type: PropTypes.oneOf(VanillaTypography.VALID_TYPES).isRequired
+  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES)
 };

--- a/packages/react/src/elements/components/Typography/Disabled.js
+++ b/packages/react/src/elements/components/Typography/Disabled.js
@@ -36,9 +36,5 @@ Disabled.propTypes = {
   /**
    * Sizes the text with one of the supported modifiers
    */
-  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES),
-  /**
-   * Indicates the initial Typography style
-   */
-  type: PropTypes.oneOf(VanillaTypography.VALID_TYPES).isRequired
+  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES)
 };

--- a/packages/react/src/elements/components/Typography/H1.js
+++ b/packages/react/src/elements/components/Typography/H1.js
@@ -33,9 +33,5 @@ H1.propTypes = {
   /**
    * Sizes the text with one of the supported modifiers
    */
-  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES),
-  /**
-   * Indicates the initial Typography style
-   */
-  type: PropTypes.oneOf(VanillaTypography.VALID_TYPES).isRequired
+  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES)
 };

--- a/packages/react/src/elements/components/Typography/H2.js
+++ b/packages/react/src/elements/components/Typography/H2.js
@@ -33,9 +33,5 @@ H2.propTypes = {
   /**
    * Sizes the text with one of the supported modifiers
    */
-  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES),
-  /**
-   * Indicates the initial Typography style
-   */
-  type: PropTypes.oneOf(VanillaTypography.VALID_TYPES).isRequired
+  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES)
 };

--- a/packages/react/src/elements/components/Typography/H3.js
+++ b/packages/react/src/elements/components/Typography/H3.js
@@ -33,9 +33,5 @@ H3.propTypes = {
   /**
    * Sizes the text with one of the supported modifiers
    */
-  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES),
-  /**
-   * Indicates the initial Typography style
-   */
-  type: PropTypes.oneOf(VanillaTypography.VALID_TYPES).isRequired
+  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES)
 };

--- a/packages/react/src/elements/components/Typography/Sub1.js
+++ b/packages/react/src/elements/components/Typography/Sub1.js
@@ -36,9 +36,5 @@ Sub1.propTypes = {
   /**
    * Sizes the text with one of the supported modifiers
    */
-  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES),
-  /**
-   * Indicates the initial Typography style
-   */
-  type: PropTypes.oneOf(VanillaTypography.VALID_TYPES).isRequired
+  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES)
 };

--- a/packages/react/src/elements/components/Typography/Sub2.js
+++ b/packages/react/src/elements/components/Typography/Sub2.js
@@ -36,9 +36,5 @@ Sub2.propTypes = {
   /**
    * Sizes the text with one of the supported modifiers
    */
-  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES),
-  /**
-   * Indicates the initial Typography style
-   */
-  type: PropTypes.oneOf(VanillaTypography.VALID_TYPES).isRequired
+  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES)
 };

--- a/packages/react/src/elements/components/Typography/Text.js
+++ b/packages/react/src/elements/components/Typography/Text.js
@@ -33,9 +33,5 @@ Text.propTypes = {
   /**
    * Sizes the text with one of the supported modifiers
    */
-  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES),
-  /**
-   * Indicates the initial Typography style
-   */
-  type: PropTypes.oneOf(VanillaTypography.VALID_TYPES).isRequired
+  size: PropTypes.oneOf(VanillaTypography.VALID_SIZES)
 };


### PR DESCRIPTION
1. Ensure search option is focused on mouseover.
2. Cleans up an extra proptype from https://github.com/Autodesk/hig/pull/669.