### PR TITLE
Transparent backgrounds on radio buttons and checkboxes

### DIFF
--- a/packages/vanilla/src/basics/form-elements/input-button/input-button.scss
+++ b/packages/vanilla/src/basics/form-elements/input-button/input-button.scss
@@ -44,7 +44,7 @@
   position: relative;
   color: transparent;
   border: 1px solid color(hig-cool-gray-30);
-  background-color: color(hig-white);
+  background-color: transparent;
   text-align: center;
   font-size: 25px;
   line-height: 14px;
@@ -85,7 +85,7 @@
   .hig__input-button__input[disabled] + & {
     border-color: color(hig-cool-gray-30);
     border-style: dotted;
-    background-color: color(hig-white);
+    background-color: transparent;
     pointer-events: none;
   }
 
@@ -141,4 +141,3 @@
   left: 50%;
   transform: translateX(-50%) translateY(-50%);
 }
-


### PR DESCRIPTION
Here's the playground with a dark-themed background:

![screen shot 2018-02-09 at 3 51 50 pm](https://user-images.githubusercontent.com/1744567/36056130-ab067102-0db6-11e8-947f-8a2b14a172be.png)
