### PR TITLE
sideNavOpenByDefault doco fix

### DIFF
--- a/packages/react/src/elements/components/GlobalNav/readme.md
+++ b/packages/react/src/elements/components/GlobalNav/readme.md
@@ -171,10 +171,10 @@ const submodules = [
 By default the Sidenav is closed when the page loads.
 If you want to have it open by default,
 but otherwise don't need to control it,
-pass `true` to `showSideNavByDefault`.
+pass `true` to `sideNavOpenByDefault`.
 
 ```js
-<GlobalNav showSideNavByDefault={true} />
+<GlobalNav sideNavOpenByDefault={true} />
 ```
 
 ### Controlling open/close state of the Sidenav<a name="side-nav-controlled"></a>


### PR DESCRIPTION
Spotted the `README.md` had the wrong term used for showing the side by by default, fixed