### PR TITLE
Corrected copyright doco

### DIFF
--- a/packages/react/src/elements/components/GlobalNav/readme.md
+++ b/packages/react/src/elements/components/GlobalNav/readme.md
@@ -480,7 +480,9 @@ If you need to override the copyright notice at the bottom of the Sidenav,
 for example, to display it in another language, provide a string to the `copyright` prop.
 
 ```js
-<GlobalNav copyright="© 2017 Autodesk, Inc." />
+<GlobalNav
+  sideNav={{copyright:"© 2017 Autodesk, Inc."}}
+/>
 ```
 
 ### Custom Sidenav content<a name="side-nav-slot"></a>


### PR DESCRIPTION
Found the doco for `copyright` was in the `GlobalNav` section, should be in the `sideNav` section. Fixed.