### PR TITLE
Features: Prop-driven Flyout

### DIFF
--- a/packages/react/src/elements/components/Flyout.js
+++ b/packages/react/src/elements/components/Flyout.js
@@ -7,8 +7,14 @@ export default class Flyout extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      open: false
+      open: this.props.initiallyOpen
     };
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (!this.state.open && this.state.open !== prevState.open) {
+      this.props.onClose();
+    }
   }
 
   closeFlyout = () => {
@@ -37,6 +43,11 @@ export default class Flyout extends Component {
   }
 }
 
+Flyout.defaultProps = {
+  initiallyOpen: false,
+  onClose: () => {}
+};
+
 Flyout.propTypes = {
   /**
    * Where the flyout will be anchored relative to target
@@ -51,7 +62,15 @@ Flyout.propTypes = {
    */
   content: PropTypes.node,
   /**
+   * When true, renders the flyout open on mount
+   */
+  initiallyOpen: PropTypes.bool,
+  /**
    * Max height of the flyout content, in pixels
    */
-  maxHeight: PropTypes.number
+  maxHeight: PropTypes.number,
+  /**
+   * Function to call when flyout closes
+   */
+  onClose: PropTypes.func
 };

--- a/packages/react/src/elements/components/Flyout.js
+++ b/packages/react/src/elements/components/Flyout.js
@@ -7,18 +7,13 @@ export default class Flyout extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      open: this.props.initiallyOpen
+      open: false
     };
-  }
-
-  componentDidUpdate(prevProps, prevState) {
-    if (!this.state.open && this.state.open !== prevState.open) {
-      this.props.onClose();
-    }
   }
 
   closeFlyout = () => {
     this.setState({ open: false });
+    this.props.onClickOutside();
   };
 
   toggleFlyout = () => {
@@ -32,7 +27,11 @@ export default class Flyout extends Component {
     return (
       <FlyoutAdapter
         anchorPoint={this.props.anchorPoint}
-        open={this.state.open}
+        open={
+          typeof this.props.open === "boolean"
+            ? this.props.open
+            : this.state.open
+        }
         onClickOutside={this.closeFlyout}
         content={this.props.content}
         maxHeight={this.props.maxHeight}
@@ -44,8 +43,7 @@ export default class Flyout extends Component {
 }
 
 Flyout.defaultProps = {
-  initiallyOpen: false,
-  onClose: () => {}
+  onClickOutside: () => {}
 };
 
 Flyout.propTypes = {
@@ -62,15 +60,15 @@ Flyout.propTypes = {
    */
   content: PropTypes.node,
   /**
-   * When true, renders the flyout open on mount
-   */
-  initiallyOpen: PropTypes.bool,
-  /**
    * Max height of the flyout content, in pixels
    */
   maxHeight: PropTypes.number,
   /**
-   * Function to call when flyout closes
+   * Function to call when clicking outside of the flyout
    */
-  onClose: PropTypes.func
+  onClickOutside: PropTypes.func,
+  /**
+   * When provided, it overrides the flyout's open state
+   */
+  open: PropTypes.bool
 };

--- a/packages/react/src/elements/components/Flyout.test.js
+++ b/packages/react/src/elements/components/Flyout.test.js
@@ -19,4 +19,13 @@ describe("<Flyout />", () => {
       expect(wrapper.find(FlyoutAdapter)).toHaveProp("open", true);
     });
   });
+
+  describe("initiallyOpen", () => {
+    it("initially opens the FlyoutAdapter", () => {
+      const wrapper = shallow(<Flyout initiallyOpen />);
+      expect(wrapper.find(FlyoutAdapter)).toHaveProp("open", true);
+      wrapper.instance().toggleFlyout();
+      expect(wrapper.find(FlyoutAdapter)).toHaveProp("open", false);
+    });
+  });
 });

--- a/packages/react/src/elements/components/Flyout.test.js
+++ b/packages/react/src/elements/components/Flyout.test.js
@@ -20,12 +20,23 @@ describe("<Flyout />", () => {
     });
   });
 
-  describe("initiallyOpen", () => {
-    it("initially opens the FlyoutAdapter", () => {
-      const wrapper = shallow(<Flyout initiallyOpen />);
-      expect(wrapper.find(FlyoutAdapter)).toHaveProp("open", true);
-      wrapper.instance().toggleFlyout();
-      expect(wrapper.find(FlyoutAdapter)).toHaveProp("open", false);
+  describe("open", () => {
+    describe("when true", () => {
+      it("keeps the Flyout open", () => {
+        const wrapper = shallow(<Flyout open />);
+        expect(wrapper.find(FlyoutAdapter)).toHaveProp("open", true);
+        wrapper.instance().toggleFlyout();
+        expect(wrapper.find(FlyoutAdapter)).toHaveProp("open", true);
+      });
+    });
+
+    describe("when false", () => {
+      it("keeps the Flyout closed", () => {
+        const wrapper = shallow(<Flyout open={false} />);
+        expect(wrapper.find(FlyoutAdapter)).toHaveProp("open", false);
+        wrapper.instance().toggleFlyout();
+        expect(wrapper.find(FlyoutAdapter)).toHaveProp("open", false);
+      });
     });
   });
 });


### PR DESCRIPTION
Changes to the website necessitated being aware of whether the flyout was open or closed, and to initially render it open. This interface seemed to be the best way to achieve that without totally removing open/close state from the component.