### PR TITLE
Bugfixes: Selecting all in selectable table

### DIFF
--- a/packages/react/src/elements/components/Table/SelectableTable.js
+++ b/packages/react/src/elements/components/Table/SelectableTable.js
@@ -22,8 +22,6 @@ export default class SelectableTable extends Component {
       rows: {},
       allRowsSelected: false
     };
-
-    this.initialProps = props;
   }
 
   selectRow = rowInfo => {
@@ -87,8 +85,8 @@ export default class SelectableTable extends Component {
 
   render() {
     const columns = [this.checkboxHeader()].concat(this.props.columns);
-    const data = this.initialProps.data.map(this.mergeRowState);
-    return this.props.children(columns, data, this.props.density);
+    const enhancedData = this.props.data.map(this.mergeRowState);
+    return this.props.children(columns, enhancedData, this.props.density);
   }
 }
 

--- a/packages/react/src/playground/sections/SelectableTableSection.js
+++ b/packages/react/src/playground/sections/SelectableTableSection.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import PlaygroundSection from "../PlaygroundSection";
 
-import { Table, Icon, TextCellContent } from "../../hig-react";
+import { Button, Table, Icon, TextCellContent } from "../../hig-react";
 
 const columns = [
   {
@@ -125,19 +125,11 @@ class SelectableTableSection extends Component {
   }
 
   onSelectionChange = selectedInfo => {
-    if (selectedInfo.selected) {
-      const updatedData = this.state.data.map(row => ({
-        ...row,
-        selected: true
-      }));
-      this.setState({ data: updatedData });
-    } else {
-      const updatedData = this.state.data.map(row => ({
-        ...row,
-        selected: true
-      }));
-      this.setState({ data: updatedData });
-    }
+    const updatedData = this.state.data.map(row => ({
+      ...row,
+      selected: selectedInfo.selected
+    }));
+    this.setState({ data: updatedData });
   };
 
   checkboxHandler = selectedInfo => {
@@ -149,9 +141,22 @@ class SelectableTableSection extends Component {
     this.setState({ data: existingData });
   };
 
+  randomizeSelections = () => {
+    const newData = this.state.data.map(row => ({
+      ...row,
+      selected: Math.random() > 0.5
+    }));
+    this.setState({ data: newData });
+  };
+
   render() {
     return (
       <PlaygroundSection title="Selectable Table">
+        <Button
+          size="standard"
+          title="Randomize selections"
+          onClick={this.randomizeSelections}
+        />
         <Table
           density="standard"
           columns={this.state.columns}


### PR DESCRIPTION
While investigating https://github.com/Autodesk/hig/issues/627 I found some unexpected behavior that prevented the `selected` attributes from propagating as `data` props.

![selectable](https://user-images.githubusercontent.com/1744567/36686670-0a52692c-1adc-11e8-9af7-cc1b184f520d.gif)
