### PR TITLE
Allow empty errors to trigger TextField error state

### DIFF
--- a/packages/react/src/adapters/FormElements/TextFieldAdapter.js
+++ b/packages/react/src/adapters/FormElements/TextFieldAdapter.js
@@ -82,7 +82,9 @@ export default class TextFieldAdapter extends Component {
             </MapsPropToMethod>
             <MapsPropToMethod value={this.props.errors} {...adapterProps}>
               {(instance, value) =>
-                value ? instance.setErrors(value) : instance.unsetErrors()
+                typeof value === "string"
+                  ? instance.setErrors(value)
+                  : instance.unsetErrors()
               }
             </MapsPropToMethod>
             <MapsPropToMethod

--- a/packages/react/src/adapters/FormElements/TextFieldAdapter.test.js
+++ b/packages/react/src/adapters/FormElements/TextFieldAdapter.test.js
@@ -33,7 +33,7 @@ describe("TextFieldAdapter", () => {
           disabled={false}
           showClearButton={false}
           required=""
-          errors=""
+          errors={null}
           hideInstructionsOnErrors={false}
         />
       );

--- a/packages/react/src/playground/sections/TextFieldSection.js
+++ b/packages/react/src/playground/sections/TextFieldSection.js
@@ -42,6 +42,37 @@ class TextFieldSection extends PureComponent {
           required="This field is required."
           showClearButton={this.state.value.length > 0}
         />
+
+        <TextField
+          label="Text field where instructions show errors"
+          placeholder="Example text"
+          onBlur={this.logEvent}
+          onChange={this.logEvent}
+          onClearButtonClick={this.clearValue}
+          onFocus={this.logEvent}
+          onInput={this.setValue}
+          value={this.state.value}
+          required="This field is required."
+          showClearButton={this.state.value.length > 0}
+          instructions="These are your instructions"
+          errors="" // Can be an empty string to have the instructions appear as errors
+        />
+
+        <TextField
+          label="Text field where error text is displayed instead of instructions"
+          placeholder="Example text"
+          onBlur={this.logEvent}
+          onChange={this.logEvent}
+          onClearButtonClick={this.clearValue}
+          onFocus={this.logEvent}
+          onInput={this.setValue}
+          value={this.state.value}
+          required="This field is required."
+          showClearButton={this.state.value.length > 0}
+          instructions="These are your instructions"
+          errors="Here is your error string"
+          hideInstructionsOnErrors
+        />
       </PlaygroundSection>
     );
   }


### PR DESCRIPTION
Adds text field error examples to playground

![screen shot 2018-03-01 at 10 44 33 am](https://user-images.githubusercontent.com/1744567/36863093-966f3260-1d3d-11e8-8ac0-0294e3d907a2.png)
