### PR TITLE
Chores: Add storybook addons

### DIFF
--- a/packages/react/.storybook/addons.js
+++ b/packages/react/.storybook/addons.js
@@ -1,1 +1,4 @@
-import '@storybook/addon-actions/register';
+import "@storybook/addon-actions/register";
+import "@storybook/addon-knobs/register";
+import "@storybook/addon-notes/register";
+import "@storybook/addon-viewport/register";

--- a/packages/react/.storybook/arrayToObject.js
+++ b/packages/react/.storybook/arrayToObject.js
@@ -1,0 +1,5 @@
+export default function arrayToObject(arr) {
+  var rv = {};
+  for (var i = 0; i < arr.length; ++i) rv[arr[i]] = arr[i];
+  return rv;
+}

--- a/packages/react/.storybook/config.js
+++ b/packages/react/.storybook/config.js
@@ -1,5 +1,6 @@
 import { configure, addDecorator } from "@storybook/react";
 import { withInfo } from "@storybook/addon-info";
+import { withKnobs } from "@storybook/addon-knobs/react";
 import "hig-vanilla/lib/hig.css";
 
 const req = require.context("../stories", true);
@@ -8,5 +9,6 @@ function loadStories() {
 }
 
 addDecorator((story, context) => withInfo({ header: true })(story)(context));
+addDecorator(withKnobs);
 
 configure(loadStories, module);

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,6 +40,9 @@
   "devDependencies": {
     "@storybook/addon-actions": "^3.3.14",
     "@storybook/addon-info": "^3.3.14",
+    "@storybook/addon-knobs": "^3.3.14",
+    "@storybook/addon-notes": "^3.3.14",
+    "@storybook/addon-viewport": "^3.3.14",
     "@storybook/react": "^3.3.14",
     "@types/jest": "^19.2.3",
     "@types/node": "^7.0.21",

--- a/packages/react/stories/Button.js
+++ b/packages/react/stories/Button.js
@@ -1,16 +1,41 @@
 import React from "react";
+import { Button as VanillaButton } from "hig-vanilla";
 import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
+import { text, boolean, select } from "@storybook/addon-knobs/react";
 import { Button } from "../src/hig-react";
+import arrayToObject from "../.storybook/arrayToObject";
 
 storiesOf("Button", module)
   .add("default, with event handlers", () => (
     <Button
-      title="Button Text"
+      title={text("Title", "Button Text")}
       onBlur={action("onBlur")}
       onClick={action("onClick")}
       onFocus={action("onFocus")}
       onHover={action("onHover")}
+      disabled={boolean("Disabled", false)}
+      link={text("Link")}
+      target={select(
+        "Target",
+        arrayToObject(["_self", "_blank", "_parent", "_top"])
+      )}
+      size={select(
+        "Size",
+        arrayToObject(VanillaButton.AvailableSizes),
+        "standard"
+      )}
+      type={select(
+        "Type",
+        arrayToObject(VanillaButton.AvailableTypes),
+        "primary"
+      )}
+      width={select(
+        "Width",
+        arrayToObject(VanillaButton.AvailableWidths),
+        "shrink"
+      )}
+      icon={text("Icon")}
     />
   ))
   .add("disabled", () => <Button title="Button Text" disabled />)
@@ -28,16 +53,16 @@ storiesOf("Button/Link", module)
     />
   ));
 
-storiesOf("Button/sizes", module)
+storiesOf("Button/Sizes", module)
   .add("small", () => <Button title="Button Text" size="small" />)
   .add("standard", () => <Button title="Button Text" size="standard" />)
   .add("large", () => <Button title="Button Text" size="large" />);
 
-storiesOf("Button/types", module)
-  .add("primary", () => <Button title="Button Text" types="primary" />)
-  .add("secondary", () => <Button title="Button Text" types="secondary" />)
-  .add("flat", () => <Button title="Button Text" types="flat" />);
+storiesOf("Button/Types", module)
+  .add("primary", () => <Button title="Button Text" type="primary" />)
+  .add("secondary", () => <Button title="Button Text" type="secondary" />)
+  .add("flat", () => <Button title="Button Text" type="flat" />);
 
-storiesOf("Button/widths", module)
+storiesOf("Button/Widths", module)
   .add("shrink", () => <Button title="Button Text" width="shrink" />)
   .add("grow", () => <Button title="Button Text" width="grow" />);

--- a/packages/react/stories/Button.js
+++ b/packages/react/stories/Button.js
@@ -6,63 +6,35 @@ import { text, boolean, select } from "@storybook/addon-knobs/react";
 import { Button } from "../src/hig-react";
 import arrayToObject from "../.storybook/arrayToObject";
 
-storiesOf("Button", module)
-  .add("default, with event handlers", () => (
-    <Button
-      title={text("Title", "Button Text")}
-      onBlur={action("onBlur")}
-      onClick={action("onClick")}
-      onFocus={action("onFocus")}
-      onHover={action("onHover")}
-      disabled={boolean("Disabled", false)}
-      link={text("Link")}
-      target={select(
-        "Target",
-        arrayToObject(["_self", "_blank", "_parent", "_top"])
-      )}
-      size={select(
-        "Size",
-        arrayToObject(VanillaButton.AvailableSizes),
-        "standard"
-      )}
-      type={select(
-        "Type",
-        arrayToObject(VanillaButton.AvailableTypes),
-        "primary"
-      )}
-      width={select(
-        "Width",
-        arrayToObject(VanillaButton.AvailableWidths),
-        "shrink"
-      )}
-      icon={text("Icon")}
-    />
-  ))
-  .add("disabled", () => <Button title="Button Text" disabled />)
-  .add("with icon", () => <Button title="Button Text" icon="settings" />);
-
-storiesOf("Button/Link", module)
-  .add("default", () => (
-    <Button title="Button Text" link="https://www.autodesk.com/" />
-  ))
-  .add("target", () => (
-    <Button
-      title="Button Text"
-      link="https://www.autodesk.com/"
-      target="_blank"
-    />
-  ));
-
-storiesOf("Button/Sizes", module)
-  .add("small", () => <Button title="Button Text" size="small" />)
-  .add("standard", () => <Button title="Button Text" size="standard" />)
-  .add("large", () => <Button title="Button Text" size="large" />);
-
-storiesOf("Button/Types", module)
-  .add("primary", () => <Button title="Button Text" type="primary" />)
-  .add("secondary", () => <Button title="Button Text" type="secondary" />)
-  .add("flat", () => <Button title="Button Text" type="flat" />);
-
-storiesOf("Button/Widths", module)
-  .add("shrink", () => <Button title="Button Text" width="shrink" />)
-  .add("grow", () => <Button title="Button Text" width="grow" />);
+storiesOf("Button", module).add("default, with event handlers", () => (
+  <Button
+    title={text("Title", "Button Text")}
+    onBlur={action("onBlur")}
+    onClick={action("onClick")}
+    onFocus={action("onFocus")}
+    onHover={action("onHover")}
+    disabled={boolean("Disabled", false)}
+    link={text("Link", "https://www.autodesk.com/")}
+    target={select(
+      "Target",
+      arrayToObject(["_self", "_blank", "_parent", "_top"]),
+      "_blank"
+    )}
+    size={select(
+      "Size",
+      arrayToObject(VanillaButton.AvailableSizes),
+      "standard"
+    )}
+    type={select(
+      "Type",
+      arrayToObject(VanillaButton.AvailableTypes),
+      "primary"
+    )}
+    width={select(
+      "Width",
+      arrayToObject(VanillaButton.AvailableWidths),
+      "shrink"
+    )}
+    icon={text("Icon", "settings")}
+  />
+));

--- a/packages/react/stories/Typography.js
+++ b/packages/react/stories/Typography.js
@@ -20,43 +20,29 @@ import arrayToObject from "../.storybook/arrayToObject";
   Component => {
     const name = Component.name;
 
-    storiesOf(name, module)
-      .add("with text", () => (
-        <Component
-          bold={boolean("Bold", false)}
-          disabled={boolean("Disabled", false)}
-          color={select("Color", arrayToObject(VanillaTypography.VALID_COLORS))}
-          opacity={number("Opacity", 1.0, {
-            range: true,
-            min: 0.0,
-            max: 1.0,
-            step: 0.1
-          })}
-          size={select("Size", arrayToObject(VanillaTypography.VALID_SIZES))}
-        >
-          {`${name} example text`}
-        </Component>
-      ))
-      .add("bold", () => <Component bold>{`${name} example text`}</Component>)
-      .add("disabled", () => (
-        <Component disabled>{`${name} example text`}</Component>
-      ))
-      .add("with custom colors", () => (
-        <Component color="hig-blue-50">{`${name} example text`}</Component>
-      ))
-      .add("with 0.5 opacity", () => (
-        <Component opacity={0.5}>{`${name} example text`}</Component>
-      ));
-
-    storiesOf(`${name}/Sizes`, module)
-      .add("small", () => (
-        <Component size="small">{`${name} example text`}</Component>
-      ))
-      .add("medium", () => (
-        <Component size="medium">{`${name} example text`}</Component>
-      ))
-      .add("large", () => (
-        <Component size="large">{`${name} example text`}</Component>
-      ));
+    storiesOf(name, module).add("with text", () => (
+      <Component
+        bold={boolean("Bold", false)}
+        disabled={boolean("Disabled", false)}
+        color={select(
+          "Color",
+          arrayToObject(VanillaTypography.VALID_COLORS),
+          "hig-cool-gray-70"
+        )}
+        opacity={number("Opacity", 1.0, {
+          range: true,
+          min: 0.0,
+          max: 1.0,
+          step: 0.1
+        })}
+        size={select(
+          "Size",
+          arrayToObject(VanillaTypography.VALID_SIZES),
+          "medium"
+        )}
+      >
+        {`${name} example text`}
+      </Component>
+    ));
   }
 );

--- a/packages/react/stories/Typography.js
+++ b/packages/react/stories/Typography.js
@@ -1,5 +1,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
+import { Typography as VanillaTypography } from "hig-vanilla";
+import { number, boolean, select } from "@storybook/addon-knobs/react";
 import {
   H1,
   H2,
@@ -12,13 +14,29 @@ import {
   Sub1,
   Sub2
 } from "../src/hig-react";
+import arrayToObject from "../.storybook/arrayToObject";
 
 [H1, H2, H3, Text, Body, Bold, Caption, Disabled, Sub1, Sub2].forEach(
   Component => {
     const name = Component.name;
 
     storiesOf(name, module)
-      .add("with text", () => <Component>{`${name} example text`}</Component>)
+      .add("with text", () => (
+        <Component
+          bold={boolean("Bold", false)}
+          disabled={boolean("Disabled", false)}
+          color={select("Color", arrayToObject(VanillaTypography.VALID_COLORS))}
+          opacity={number("Opacity", 1.0, {
+            range: true,
+            min: 0.0,
+            max: 1.0,
+            step: 0.1
+          })}
+          size={select("Size", arrayToObject(VanillaTypography.VALID_SIZES))}
+        >
+          {`${name} example text`}
+        </Component>
+      ))
       .add("bold", () => <Component bold>{`${name} example text`}</Component>)
       .add("disabled", () => (
         <Component disabled>{`${name} example text`}</Component>
@@ -30,7 +48,7 @@ import {
         <Component opacity={0.5}>{`${name} example text`}</Component>
       ));
 
-    storiesOf(`${name}/sizes`, module)
+    storiesOf(`${name}/Sizes`, module)
       .add("small", () => (
         <Component size="small">{`${name} example text`}</Component>
       ))

--- a/packages/react/yarn.lock
+++ b/packages/react/yarn.lock
@@ -27,9 +27,43 @@
     react-addons-create-fragment "^15.5.3"
     util-deprecate "^1.0.2"
 
+"@storybook/addon-knobs@^3.3.14":
+  version "3.3.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-knobs/-/addon-knobs-3.3.14.tgz#129b8273006906236882de7c4a8daba416bc9c48"
+  dependencies:
+    babel-runtime "^6.26.0"
+    deep-equal "^1.0.1"
+    global "^4.3.2"
+    insert-css "^2.0.0"
+    lodash.debounce "^4.0.8"
+    moment "^2.20.1"
+    prop-types "^15.6.0"
+    react-color "^2.11.4"
+    react-datetime "^2.11.1"
+    react-textarea-autosize "^5.2.1"
+    util-deprecate "^1.0.2"
+
 "@storybook/addon-links@^3.3.14":
   version "3.3.14"
   resolved "https://registry.yarnpkg.com/@storybook/addon-links/-/addon-links-3.3.14.tgz#1de63e9b3819927fbb2f963fdabc65f86fde33cc"
+  dependencies:
+    "@storybook/components" "^3.3.14"
+    global "^4.3.2"
+    prop-types "^15.5.10"
+
+"@storybook/addon-notes@^3.3.14":
+  version "3.3.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-notes/-/addon-notes-3.3.14.tgz#389918989f91d42236d7f44774d5aa0cf8f81d05"
+  dependencies:
+    babel-runtime "^6.26.0"
+    prop-types "^15.6.0"
+    util-deprecate "^1.0.2"
+  optionalDependencies:
+    "@types/react" "^16.0.20"
+
+"@storybook/addon-viewport@^3.3.14":
+  version "3.3.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-viewport/-/addon-viewport-3.3.14.tgz#18a9f295aa4247b2ed7747a502bcb16e646d6b4f"
   dependencies:
     "@storybook/components" "^3.3.14"
     global "^4.3.2"
@@ -211,6 +245,10 @@
 "@types/react@^15.0.22", "@types/react@^15.0.24":
   version "15.6.11"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-15.6.11.tgz#c61440937ccf970446cb3ef77007b450ab1e2f91"
+
+"@types/react@^16.0.20":
+  version "16.0.40"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.40.tgz#caabc2296886f40b67f6fc80f0f3464476461df9"
 
 abab@^1.0.3:
   version "1.0.4"
@@ -2436,17 +2474,17 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-class@^15.6.0:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.2.tgz#cf1ed15f12aad7f14ef5f2dfe05e6c42f91ef02a"
+create-react-class@^15.5.2, create-react-class@^15.6.2:
+  version "15.6.3"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-create-react-class@^15.6.2:
-  version "15.6.3"
-  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
+create-react-class@^15.6.0:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.2.tgz#cf1ed15f12aad7f14ef5f2dfe05e6c42f91ef02a"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
@@ -4570,6 +4608,10 @@ inquirer@3.3.0, inquirer@^3.0.6:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
+insert-css@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/insert-css/-/insert-css-2.0.0.tgz#eb5d1097b7542f4c79ea3060d3aee07d053880f4"
+
 internal-ip@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-2.0.3.tgz#ed3cf9b671ac7ff23037bfacad42eb439cd9546c"
@@ -5552,7 +5594,7 @@ lodash@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.17.0, lodash@^4.2.1:
+lodash@^4.0.1, lodash@^4.17.0, lodash@^4.2.1:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
@@ -5634,6 +5676,10 @@ marksy@^6.0.2:
     babel-standalone "^6.26.0"
     he "^1.1.1"
     marked "^0.3.9"
+
+material-colors@^1.2.1:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/material-colors/-/material-colors-1.2.5.tgz#5292593e6754cb1bcc2b98030e4e0d6a3afc9ea1"
 
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
@@ -5817,6 +5863,10 @@ mkdirp@0.5, mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@0.x.x, "mkdirp@>=0.5 0", mkdirp@^
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+moment@^2.20.1:
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.21.0.tgz#2a114b51d2a6ec9e6d83cf803f838a878d8a023a"
 
 moniker@0.1.2:
   version "0.1.2"
@@ -6053,6 +6103,10 @@ oauth-sign@~0.8.1, oauth-sign@~0.8.2:
 object-assign@4.1.1, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
+object-assign@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
 
 object-hash@^1.1.4:
   version "1.2.0"
@@ -6835,7 +6889,7 @@ prop-types@^15.5.10, prop-types@^15.6.0:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.5.9:
+prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.5.9:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
@@ -6993,6 +7047,25 @@ react-addons-test-utils@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.6.2.tgz#c12b6efdc2247c10da7b8770d185080a7b047156"
 
+react-color@^2.11.4:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/react-color/-/react-color-2.14.0.tgz#5828a11c034aa0939befbd888a066ee37d8c3cc2"
+  dependencies:
+    lodash "^4.0.1"
+    material-colors "^1.2.1"
+    prop-types "^15.5.10"
+    reactcss "^1.2.0"
+    tinycolor2 "^1.4.1"
+
+react-datetime@^2.11.1:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/react-datetime/-/react-datetime-2.14.0.tgz#c7859c5b765275d7980f1cca27c03a727ff9ccef"
+  dependencies:
+    create-react-class "^15.5.2"
+    object-assign "^3.0.0"
+    prop-types "^15.5.7"
+    react-onclickoutside "^6.5.0"
+
 react-dev-utils@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-4.2.1.tgz#9f2763e7bafa1a1b9c52254d2a479deec280f111"
@@ -7100,6 +7173,10 @@ react-modal@^3.1.10:
     prop-types "^15.5.10"
     warning "^3.0.0"
 
+react-onclickoutside@^6.5.0:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz#6a5b5b8b4eae6b776259712c89c8a2b36b17be93"
+
 react-scripts@1.0.14:
   version "1.0.14"
   resolved "https://registry.yarnpkg.com/react-scripts/-/react-scripts-1.0.14.tgz#70fe76c9beb67b136b953e875bdfe4ad78d410d1"
@@ -7163,6 +7240,12 @@ react-test-renderer@^15.6.1:
     fbjs "^0.8.9"
     object-assign "^4.1.0"
 
+react-textarea-autosize@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-5.2.1.tgz#2b78f9067180f41b08ac59f78f1581abadd61e54"
+  dependencies:
+    prop-types "^15.6.0"
+
 react-transition-group@^1.1.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-1.2.1.tgz#e11f72b257f921b213229a774df46612346c7ca6"
@@ -7193,6 +7276,12 @@ react@^15.4.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
     prop-types "^15.5.10"
+
+reactcss@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/reactcss/-/reactcss-1.2.3.tgz#c00013875e557b1cf0dfd9a368a1c3dab3b548dd"
+  dependencies:
+    lodash "^4.0.1"
 
 read-all-stream@^3.0.0:
   version "3.1.0"
@@ -8280,6 +8369,10 @@ timers-browserify@^2.0.4:
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.4.tgz#96ca53f4b794a5e7c0e1bd7cc88a372298fa01e6"
   dependencies:
     setimmediate "^1.0.4"
+
+tinycolor2@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
 
 tmp@^0.0.33:
   version "0.0.33"

--- a/packages/vanilla/src/components/button/button.js
+++ b/packages/vanilla/src/components/button/button.js
@@ -44,7 +44,7 @@ class Button extends Core {
 
   setLink(link) {
     !link || link === ''
-      ? this.el.removeAttribte('href')
+      ? this.el.removeAttribute('href')
       : this.el.setAttribute('href', link);
   }
 

--- a/packages/vanilla/src/components/global-nav/side-nav/group/module/module.js
+++ b/packages/vanilla/src/components/global-nav/side-nav/group/module/module.js
@@ -70,7 +70,7 @@ class Module extends Core {
   setLink(link) {
     const anchorEl = this._findDOMEl('a', this.el);
     !link || link === ''
-      ? anchorEl.removeAttribte('href')
+      ? anchorEl.removeAttribute('href')
       : anchorEl.setAttribute('href', link);
   }
 

--- a/packages/vanilla/src/components/global-nav/side-nav/group/module/submodule/submodule.js
+++ b/packages/vanilla/src/components/global-nav/side-nav/group/module/submodule/submodule.js
@@ -37,7 +37,7 @@ class Submodule extends Core {
 
   setLink(link) {
     !link || link === ''
-      ? this.el.removeAttribte('href')
+      ? this.el.removeAttribute('href')
       : this.el.setAttribute('href', link);
   }
 

--- a/packages/vanilla/src/components/global-nav/side-nav/link/link.js
+++ b/packages/vanilla/src/components/global-nav/side-nav/link/link.js
@@ -39,7 +39,7 @@ class Link extends Core {
 
   setLink(link) {
     !link || link === ''
-      ? this.el.removeAttribte('href')
+      ? this.el.removeAttribute('href')
       : this.el.setAttribute('href', link);
   }
 

--- a/packages/vanilla/src/components/global-nav/top-nav/help/option/option.js
+++ b/packages/vanilla/src/components/global-nav/top-nav/help/option/option.js
@@ -20,7 +20,7 @@ class Option extends Core {
 
   setLink(link) {
     !link || link === ''
-      ? this.el.removeAttribte('href')
+      ? this.el.removeAttribute('href')
       : this.el.setAttribute('href', link);
   }
 

--- a/packages/vanilla/src/components/global-nav/top-nav/shortcut/shortcut.js
+++ b/packages/vanilla/src/components/global-nav/top-nav/shortcut/shortcut.js
@@ -37,7 +37,7 @@ class Shortcut extends Core {
 
   setLink(link) {
     link === undefined || link === ''
-      ? this.el.removeAttribte('href')
+      ? this.el.removeAttribute('href')
       : this.el.setAttribute('href', link);
   }
 

--- a/packages/vanilla/src/components/icon-button/icon-button.js
+++ b/packages/vanilla/src/components/icon-button/icon-button.js
@@ -47,7 +47,7 @@ class IconButton extends Core {
 
   setLink(link) {
     !link || link === ''
-      ? this.el.removeAttribte('href')
+      ? this.el.removeAttribute('href')
       : this.el.setAttribute('href', link);
   }
 


### PR DESCRIPTION
Include storybook addons:

* Knobs, for allowing viewer to edit props
* Notes, for additional documentation
* Viewport, for toggling device sizes

![screen shot 2018-03-06 at 2 17 57 pm](https://user-images.githubusercontent.com/1744567/37062292-d9c5dbac-214a-11e8-8fcd-c16039be4449.png)


This also led me to discover some typos in HIG vanilla whose code paths weren't being triggered by our tests.