### PR TITLE
Fix Progress ring inside Qt web page

### DIFF
--- a/packages/vanilla/src/components/progress-ring/progress-ring-determinate.js
+++ b/packages/vanilla/src/components/progress-ring/progress-ring-determinate.js
@@ -22,7 +22,7 @@ class ProgressRingDeterminate {
   }
 
   initSegments() {
-    this.segments = this.el.querySelectorAll('.hig__progress-ring__segment');
+    this.segments = Array.from(this.el.querySelectorAll('.hig__progress-ring__segment'));
     this.SEGMENT_COUNT = this.segments.length;
     this.FADE_DELAY_FACTOR = 1 / this.SEGMENT_COUNT;
   }

--- a/packages/vanilla/src/components/progress-ring/progress-ring-indeterminate.js
+++ b/packages/vanilla/src/components/progress-ring/progress-ring-indeterminate.js
@@ -22,7 +22,7 @@ class ProgressRingIndeterminate {
   }
 
   initSegments() {
-    this.segments = this.el.querySelectorAll('.hig__progress-ring__segment');
+    this.segments = Array.from(this.el.querySelectorAll('.hig__progress-ring__segment'));
 
     this.SEGMENT_COUNT = this.segments.length;
     this.SEGMENT_DELAY_FACTOR = CYCLE_DURATION / this.SEGMENT_COUNT;


### PR DESCRIPTION
Before, when using a progress ring inside of my 3ds Max plugin using a Qt Web app, I would get `bundle.js:13722Uncaught TypeError: this.segments.forEach is not a function`.
This is because this.segments actually ended up being only an object (`typeof this,segments === object`). So casting it in Array with `Array.from()` from the instantiation fixes the problem.
You can see below the before and after (Left ring = Determinate ring; Ring ring = Indeterminate ring). (And yes, in the first pic, there is supposed to be two rings, but one of them just doesn't appear)

![failing](https://user-images.githubusercontent.com/11926403/37101248-12265032-21f3-11e8-95fc-f7b5d4df0d2e.png)

![working](https://user-images.githubusercontent.com/11926403/37101152-de812f4a-21f2-11e8-91ca-9fadc57c2564.gif)
