### PR TITLE
Chores: Re-enable useful ESLint rules

### DIFF
--- a/packages/react/.eslintrc.js
+++ b/packages/react/.eslintrc.js
@@ -24,9 +24,8 @@ module.exports = {
     "no-underscore-dangle": 0,
     "prettier/prettier": "error",
     "react/jsx-filename-extension": 0,
-    "react/no-unused-prop-types": 0,
     "react/prefer-stateless-function": 0,
-    "react/prop-types": 0,
+    "react/prop-types": "warn",
     "react/require-default-props": 0,
     "react/style-prop-object": 0
   }

--- a/packages/react/.eslintrc.js
+++ b/packages/react/.eslintrc.js
@@ -21,8 +21,6 @@ module.exports = {
   rules: {
     "class-methods-use-this": 0,
     "import/no-extraneous-dependencies": 0,
-    "jsx-a11y/alt-text": 0,
-    "jsx-a11y/href-no-hash": "off",
     "max-len": [1, { code: 100 }],
     "no-underscore-dangle": 0,
     "prettier/prettier": "error",

--- a/packages/react/.eslintrc.js
+++ b/packages/react/.eslintrc.js
@@ -19,7 +19,6 @@ module.exports = {
     window: true
   },
   rules: {
-    "class-methods-use-this": 0,
     "import/no-extraneous-dependencies": 0,
     "max-len": [1, { code: 100 }],
     "no-underscore-dangle": 0,

--- a/packages/react/src/adapters/HIGAdapter/MapsEventListener.js
+++ b/packages/react/src/adapters/HIGAdapter/MapsEventListener.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-unused-prop-types */
 import { Component } from "react";
 import PropTypes from "prop-types";
 import throwIfNoHIGMethod from "./throwIfNoHIGMethod";
@@ -58,3 +59,4 @@ export default class MapsEventlistener extends Component {
     return null;
   }
 }
+/* eslint-enable react/no-unused-prop-types */

--- a/packages/react/src/adapters/HIGAdapter/MountedByHIGParent.js
+++ b/packages/react/src/adapters/HIGAdapter/MountedByHIGParent.js
@@ -29,12 +29,12 @@ export default class MountedByHIGParent extends Component {
     this.mountToParent(nextProps);
   }
 
-  mountToParent(props) {
+  mountToParent = props => {
     if (props.higParent && !props.mounted) {
       props.higParent[props.mounter](props.higInstance);
       props.onMount();
     }
-  }
+  };
 
   render() {
     return null;

--- a/packages/react/src/adapters/HIGAdapter/MountedByHIGParent.js
+++ b/packages/react/src/adapters/HIGAdapter/MountedByHIGParent.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-unused-prop-types */
 import { Component } from "react";
 import PropTypes from "prop-types";
 import HIGPropTypes from "./HIGPropTypes";
@@ -40,3 +41,4 @@ export default class MountedByHIGParent extends Component {
     return null;
   }
 }
+/* eslint-enable react/no-unused-prop-types */

--- a/packages/react/src/adapters/HIGAdapter/MountedByHIGParentList.js
+++ b/packages/react/src/adapters/HIGAdapter/MountedByHIGParentList.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-unused-prop-types */
 import { PureComponent } from "react";
 import PropTypes from "prop-types";
 import HIGPropTypes from "./HIGPropTypes";
@@ -35,3 +36,4 @@ export default class MountedByHIGParentList extends PureComponent {
     return null;
   }
 }
+/* eslint-enable react/no-unused-prop-types */

--- a/packages/react/src/adapters/HIGAdapter/MountsAnyChild.js
+++ b/packages/react/src/adapters/HIGAdapter/MountsAnyChild.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-unused-prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import HIGPropTypes from "./HIGPropTypes";
@@ -58,3 +59,4 @@ export default class MountsAnyChild extends Component {
     return <div ref={this.setEl}>{children}</div>;
   }
 }
+/* eslint-enable react/no-unused-prop-types */

--- a/packages/react/src/elements/components/Avatar/index.js
+++ b/packages/react/src/elements/components/Avatar/index.js
@@ -37,7 +37,11 @@ export default class Avatar extends Component {
       <div className={avatarClasses}>
         {this.props.image && (
           <div className="hig__avatar__image-wrapper">
-            <img className="hig__avatar__image" src={this.props.image} />
+            <img
+              className="hig__avatar__image"
+              src={this.props.image}
+              alt={`Avatar for ${this.props.name}`}
+            />
           </div>
         )}
         <div className="hig__avatar__initials">

--- a/packages/react/src/elements/components/Icon/Icon.js
+++ b/packages/react/src/elements/components/Icon/Icon.js
@@ -22,16 +22,15 @@ export default class Icon extends Component {
         );
   }
 
-  setIconClass(icon, size) {
-    return AvailableSizes.includes(size)
+  setIconClass = (icon, size) =>
+    AvailableSizes.includes(size)
       ? `hig__icon--${size}-size`
       : console.error(
           `Icon named "${icon} size "${size}" not found, only these size are allowed: `,
           AvailableSizes
         );
-  }
 
-  _confirmNameOrSVG(icon, size) {
+  _confirmNameOrSVG = (icon, size) => {
     const isNamedIcon = Icons[`${icon}-${size}`];
     const isSVG = /^<svg/.test(icon);
 
@@ -41,7 +40,7 @@ export default class Icon extends Component {
       return icon;
     }
     console.warn(`NO HIG ICON: ${icon}`);
-  }
+  };
 
   render() {
     const iconClasses = cx(

--- a/packages/react/src/elements/components/IconButton/IconButton.js
+++ b/packages/react/src/elements/components/IconButton/IconButton.js
@@ -9,19 +9,13 @@ import Icon from "../Icon/Icon";
 const AvailableTypes = ["primary", "flat", "transparent"];
 
 export default class IconButton extends Component {
-  setButtonStateClass(buttonState) {
-    return buttonState ? "hig__icon-button--disabled" : "";
-  }
-
-  setTabIndex(buttonState) {
-    return buttonState ? -1 : 0;
-  }
+  setTabIndex = buttonState => (buttonState ? -1 : 0);
 
   render() {
     const iconButtonClasses = cx(
       "hig__icon-button",
       `hig__icon-button--${this.props.type}`,
-      this.setButtonStateClass(this.props.disabled)
+      { "hig__icon-button--disabled": this.props.disabled }
     );
     return (
       <a

--- a/packages/react/src/elements/components/Table/HeaderCheckbox.js
+++ b/packages/react/src/elements/components/Table/HeaderCheckbox.js
@@ -6,8 +6,8 @@ import Checkbox from "../../../adapters/FormElements/CheckboxAdapter";
 
 class HeaderCheckbox extends React.Component {
   static propTypes = {
-    checked: PropTypes.bool,
-    onChange: PropTypes.func
+    selected: PropTypes.bool,
+    onSelectAllSelectionChange: PropTypes.func
   };
 
   constructor(props) {

--- a/packages/react/src/elements/components/Table/RowCheckbox.js
+++ b/packages/react/src/elements/components/Table/RowCheckbox.js
@@ -6,7 +6,7 @@ import Checkbox from "../../../adapters/FormElements/CheckboxAdapter";
 
 class RowCheckbox extends React.Component {
   static propTypes = {
-    checked: PropTypes.bool,
+    selected: PropTypes.bool,
     onChange: PropTypes.func
   };
 

--- a/packages/react/src/elements/components/Table/SelectableTable.js
+++ b/packages/react/src/elements/components/Table/SelectableTable.js
@@ -5,10 +5,6 @@ import HeaderCheckbox from "./HeaderCheckbox";
 import RowCheckbox from "./RowCheckbox";
 
 export default class SelectableTable extends Component {
-  static propTypes = {
-    selectable: PropTypes.bool
-  };
-
   static defaultProps = {
     columns: [],
     data: [],

--- a/packages/react/src/elements/components/Table/Table.js
+++ b/packages/react/src/elements/components/Table/Table.js
@@ -59,22 +59,20 @@ export default class Table extends Component {
     density: undefined
   };
 
-  renderTable(columns, data, density) {
-    return (
-      <TableAdapter density={density}>
-        <TableHeadAdapter>
-          {columns.map((column, index) => getHeadCell({ column, index }))}
-        </TableHeadAdapter>
-        {data.map(row => (
-          <TableRowAdapter key={row.id} selected={row.selected}>
-            {columns.map((column, index) =>
-              getCell({ column, data: row, index })
-            )}
-          </TableRowAdapter>
-        ))}
-      </TableAdapter>
-    );
-  }
+  renderTable = (columns, data, density) => (
+    <TableAdapter density={density}>
+      <TableHeadAdapter>
+        {columns.map((column, index) => getHeadCell({ column, index }))}
+      </TableHeadAdapter>
+      {data.map(row => (
+        <TableRowAdapter key={row.id} selected={row.selected}>
+          {columns.map((column, index) =>
+            getCell({ column, data: row, index })
+          )}
+        </TableRowAdapter>
+      ))}
+    </TableAdapter>
+  );
 
   render() {
     const isSelectable = this.props.selectable;

--- a/packages/react/src/elements/components/Tabs/PlaceholderTab.js
+++ b/packages/react/src/elements/components/Tabs/PlaceholderTab.js
@@ -5,7 +5,8 @@ export default class PlaceholderTab extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      activeTabId: undefined
+      activeTabId: undefined,
+      active: props.active
     };
   }
 
@@ -16,17 +17,9 @@ export default class PlaceholderTab extends React.Component {
 
 PlaceholderTab.propTypes = {
   /**
-   * Brief text identifying the tab content
-   */
-  label: PropTypes.string.isRequired,
-  /**
    * When true, tabs content will be shown
    */
-  active: PropTypes.bool,
-  /**
-   * Content to display when tab is active
-   */
-  children: PropTypes.node.isRequired
+  active: PropTypes.bool
 };
 
 PlaceholderTab.defaultProps = {

--- a/packages/react/src/elements/components/Toast/Toast.test.js
+++ b/packages/react/src/elements/components/Toast/Toast.test.js
@@ -19,7 +19,9 @@ describe("Toast", () => {
   });
 
   it("adds an image to the expected container", () => {
-    const thumbnail = <img src="placekitten.com/g/60/60" />;
+    const thumbnail = (
+      <img src="placekitten.com/g/60/60" alt="placekitten 60x60" />
+    );
     const wrapper = mount(<Toast image={thumbnail}>Who wants toast?</Toast>);
 
     expect(

--- a/packages/react/src/playground/index.js
+++ b/packages/react/src/playground/index.js
@@ -328,11 +328,10 @@ class Playground extends React.Component {
     console.log("project clicked", id);
   };
 
-  _initialReadNotifications(notifications) {
-    return notifications
+  _initialReadNotifications = notifications =>
+    notifications
       .filter(notification => !notification.unread)
       .map(notification => notification.id);
-  }
 
   topNavQueryProps = () => {
     const props = {

--- a/packages/react/src/playground/sections/NotificationsSection.js
+++ b/packages/react/src/playground/sections/NotificationsSection.js
@@ -142,11 +142,10 @@ class NotificationsSection extends PureComponent {
     console.log("Feature notification dismissed");
   };
 
-  _initialReadNotifications(notifications) {
-    return notifications
+  _initialReadNotifications = notifications =>
+    notifications
       .filter(notification => !notification.unread)
       .map(notification => notification.id);
-  }
 
   render() {
     return (

--- a/packages/react/src/playground/sections/PasswordFieldSection.js
+++ b/packages/react/src/playground/sections/PasswordFieldSection.js
@@ -15,13 +15,13 @@ class PasswordFieldSection extends PureComponent {
     this.setState({ password: event.target.value });
   };
 
-  logEvent(event) {
+  logEvent = event => {
     let messageParts = [`PasswordField triggered an ${event.type} event`];
     if (event.target.value !== undefined) {
       messageParts = messageParts.concat(`: ${event.target.value}`);
     }
     console.log(messageParts.join(""));
-  }
+  };
 
   render() {
     return (

--- a/packages/react/src/playground/sections/TextFieldSection.js
+++ b/packages/react/src/playground/sections/TextFieldSection.js
@@ -19,13 +19,13 @@ class TextFieldSection extends PureComponent {
     this.setState({ value: "" });
   };
 
-  logEvent(event) {
+  logEvent = event => {
     let messageParts = [`TextField triggered an ${event.type} event`];
     if (event.target.value !== undefined) {
       messageParts = messageParts.concat(`: ${event.target.value}`);
     }
     console.log(messageParts.join(""));
-  }
+  };
 
   render() {
     return (

--- a/packages/react/src/playground/sections/TypographySection.js
+++ b/packages/react/src/playground/sections/TypographySection.js
@@ -14,8 +14,8 @@ import {
 } from "../../hig-react";
 
 class TypographySection extends PureComponent {
-  renderTextExamples() {
-    return ["small", "medium", "large"].map(size =>
+  renderTextExamples = () =>
+    ["small", "medium", "large"].map(size =>
       [
         "hig-white",
         "hig-cool-gray-70",
@@ -55,7 +55,7 @@ class TypographySection extends PureComponent {
         </div>
       ))
     );
-  }
+
   render() {
     return (
       <PlaygroundSection title="TYPOGRAPHY">


### PR DESCRIPTION
This primarily comes from CircleCI trying to deploy the playground from `development`.

```
Treating warnings as errors because process.env.CI = true.
Most CI servers set it automatically.

Failed to compile.

./src/elements/components/Avatar/index.js
  Line 40:  img elements must have an alt prop, either with meaningful text, or an empty string for decorative images  jsx-a11y/alt-text
```

As it turns out, it's easier (and better) to follow the disabled `jsx-a11y` and `react/prop-types` rules. We no longer need to keep them disabled.