### PR TITLE
feat(banner): Tweak Banner design and API

### DIFF
--- a/packages/banner/src/Banner.js
+++ b/packages/banner/src/Banner.js
@@ -14,10 +14,10 @@ import BannerPresenter from "./BannerPresenter";
  * @property {string} [type]
  * @property {string} [placement]
  * @property {string} [label]
- * @property {string} [message]
+ * @property {string} [labelledBy]
+ * @property {any} [actions]
  * @property {string} [dismissButtonTitle]
  * @property {Function} [onDismiss]
- * @property {string} [labelId]
  * @property {boolean} [isVisible]
  * @property {any} [children]
  */
@@ -40,18 +40,18 @@ export default class Banner extends Component {
     placement: PropTypes.oneOf(AVAILABLE_PLACEMENTS),
     /** The label of the message displayed */
     label: PropTypes.string,
-    /** The displayed message */
-    message: PropTypes.string,
+    /** The ID used for ARIA labeling */
+    labelledBy: PropTypes.string,
+    /** Banner actions; Any JSX, or a render prop function */
+    actions: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
     /** Accessibility text for the dismiss button */
     dismissButtonTitle: PropTypes.string,
     /** Called when the banner is dismissed */
     onDismiss: PropTypes.func,
-    /** The ID used for ARIA labeling */
-    labelId: PropTypes.string,
     /** Animation; Determines the visibility of the banner */
     isVisible: PropTypes.bool,
-    /** Banner actions; Any JSX, or a render prop function */
-    children: PropTypes.oneOfType([PropTypes.node, PropTypes.func])
+    /** The displayed message */
+    children: PropTypes.string
   };
 
   /** @type {BannerProps | any} */
@@ -68,7 +68,7 @@ export default class Banner extends Component {
   };
 
   render() {
-    const { isVisible, children: actions } = this.props;
+    const { isVisible, actions } = this.props;
     const { renderPresenter } = this;
 
     return (

--- a/packages/banner/src/Banner.test.js
+++ b/packages/banner/src/Banner.test.js
@@ -4,49 +4,44 @@ import React from "react";
 import Banner from "./Banner";
 
 describe("banner/Banner", () => {
-  describe("Action", () => {
-    it("exposes the `Action` component", () => {
-      expect(Banner).toHaveProperty("Action", expect.any(Function));
-    });
-  });
+  const exposedComponents = ["Action", "Interactions", "Presenter"];
+  const componentMatcher = expect.any(Function);
 
-  describe("Interactions", () => {
-    it("exposes the `Interactions` component", () => {
-      expect(Banner).toHaveProperty("Interactions", expect.any(Function));
-    });
-  });
-
-  describe("Presenter", () => {
-    it("exposes the `Presenter` component", () => {
-      expect(Banner).toHaveProperty("Presenter", expect.any(Function));
+  exposedComponents.forEach(componentName => {
+    describe(componentName, () => {
+      it(`exposes the \`${componentName}\` component`, () => {
+        expect(Banner).toHaveProperty(componentName, componentMatcher);
+      });
     });
   });
 
   describe("rendering", () => {
+    const renderedComponents = [
+      "BannerAnimator",
+      "BannerContainer",
+      "BannerPresenter"
+    ];
+
+    let wrapper;
+
     beforeAll(() => {
       window.requestAnimationFrame = jest.fn();
+    });
+
+    beforeEach(() => {
+      wrapper = mount(<Banner />);
     });
 
     afterAll(() => {
       delete window.requestAnimationFrame;
     });
 
-    it("renders the `BannerAnimator`", () => {
-      const wrapper = mount(<Banner />);
-
-      expect(wrapper.find("BannerAnimator")).toBePresent();
-    });
-
-    it("renders the `BannerContainer`", () => {
-      const wrapper = mount(<Banner />);
-
-      expect(wrapper.find("BannerContainer")).toBePresent();
-    });
-
-    it("renders the `BannerPresenter`", () => {
-      const wrapper = mount(<Banner />);
-
-      expect(wrapper.find("BannerPresenter")).toBePresent();
+    renderedComponents.forEach(componentName => {
+      describe(componentName, () => {
+        it(`renders a \`${componentName}\` component`, () => {
+          expect(wrapper.find(componentName)).toBePresent();
+        });
+      });
     });
   });
 });

--- a/packages/banner/src/BannerContainer.js
+++ b/packages/banner/src/BannerContainer.js
@@ -190,7 +190,7 @@ export default class BannerContainer extends Component {
       refContent,
       refNotification,
       refInteractionsWrapper,
-      children: this.renderActions()
+      actions: this.renderActions()
     };
   }
 

--- a/packages/banner/src/BannerContainer.test.js
+++ b/packages/banner/src/BannerContainer.test.js
@@ -25,7 +25,7 @@ describe("banner/BannerContainer", () => {
     const [[presenterBag]] = presenterRenderProp.mock.calls;
 
     expect(presenterBag).toMatchObject({
-      children: "foobar",
+      actions: "foobar",
       isWrappingContent: false,
       refContent: expect.any(Function),
       refInteractionsWrapper: expect.any(Function),

--- a/packages/banner/src/BannerPresenter/BannerPresenter.js
+++ b/packages/banner/src/BannerPresenter/BannerPresenter.js
@@ -2,7 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import { types, AVAILABLE_TYPES } from "../types";
-import { placements, AVAILABLE_PLACEMENTS } from "../placements";
 
 import {
   Content,
@@ -18,7 +17,6 @@ import {
 /**
  * @typedef {Object} BannerPresenterProps
  * @property {string} [type]
- * @property {string} [placement]
  * @property {string} [label]
  * @property {string} [message]
  * @property {string} [dismissButtonTitle]
@@ -39,7 +37,6 @@ import {
 export default function BannerPresenter(props) {
   const {
     type,
-    placement,
     label,
     message,
     dismissButtonTitle,
@@ -59,7 +56,6 @@ export default function BannerPresenter(props) {
   return (
     <Wrapper
       type={type}
-      placement={placement}
       hasActions={hasActions}
       isWrappingContent={isWrappingContent}
       labelledBy={wrapperLabelledBy}
@@ -84,7 +80,6 @@ export default function BannerPresenter(props) {
 /** @type {BannerPresenterProps} */
 BannerPresenter.defaultProps = {
   type: types.PRIMARY,
-  placement: placements.STANDARD,
   message: "Message",
   dismissButtonTitle: "Dismiss",
   isWrappingContent: false
@@ -93,8 +88,6 @@ BannerPresenter.defaultProps = {
 BannerPresenter.propTypes = {
   /** Indicates the style of banner */
   type: PropTypes.oneOf(AVAILABLE_TYPES),
-  /** Determines the intended placement of banner */
-  placement: PropTypes.oneOf(AVAILABLE_PLACEMENTS),
   /** The label of the message displayed */
   label: PropTypes.string,
   /** The displayed message */

--- a/packages/banner/src/BannerPresenter/BannerPresenter.js
+++ b/packages/banner/src/BannerPresenter/BannerPresenter.js
@@ -18,10 +18,10 @@ import {
  * @typedef {Object} BannerPresenterProps
  * @property {string} [type]
  * @property {string} [label]
- * @property {string} [message]
+ * @property {string} [labelledBy]
+ * @property {any} [actions]
  * @property {string} [dismissButtonTitle]
  * @property {Function} [onDismiss]
- * @property {string} [labelId]
  * @property {boolean} [isWrappingContent]
  * @property {function(HTMLDivElement): any} [refContent]
  * @property {function(HTMLParagraphElement): any} [refNotification]
@@ -38,37 +38,35 @@ export default function BannerPresenter(props) {
   const {
     type,
     label,
-    message,
+    labelledBy,
+    actions,
     dismissButtonTitle,
     onDismiss,
-    labelId,
     isWrappingContent,
     refContent,
     refNotification,
     refInteractionsWrapper,
-    children
+    children: message,
   } = props;
 
-  const hasLabel = !!label;
-  const hasActions = React.Children.count(children) > 0;
-  const wrapperLabelledBy = hasLabel ? labelId : undefined;
+  const hasActions = React.Children.count(actions) > 0;
 
   return (
     <Wrapper
       type={type}
       hasActions={hasActions}
       isWrappingContent={isWrappingContent}
-      labelledBy={wrapperLabelledBy}
+      label={label}
+      labelledBy={labelledBy}
     >
       <Icon type={type} />
       <Content innerRef={refContent}>
         <Notification innerRef={refNotification}>
-          {hasLabel ? <Label id={labelId}>{label}</Label> : null}
           <Message>{message}</Message>
         </Notification>
         {hasActions ? (
           <InteractionsWrapper innerRef={refInteractionsWrapper}>
-            {children}
+            {actions}
           </InteractionsWrapper>
         ) : null}
       </Content>
@@ -80,9 +78,9 @@ export default function BannerPresenter(props) {
 /** @type {BannerPresenterProps} */
 BannerPresenter.defaultProps = {
   type: types.PRIMARY,
-  message: "Message",
   dismissButtonTitle: "Dismiss",
-  isWrappingContent: false
+  isWrappingContent: false,
+  children: "Message"
 };
 
 BannerPresenter.propTypes = {
@@ -90,14 +88,14 @@ BannerPresenter.propTypes = {
   type: PropTypes.oneOf(AVAILABLE_TYPES),
   /** The label of the message displayed */
   label: PropTypes.string,
-  /** The displayed message */
-  message: PropTypes.string,
+  /** The ID used for ARIA labeling */
+  labelledBy: PropTypes.string,
+  /** Banner actions */
+  actions: PropTypes.node,
   /** Accessibility text for the dismiss button */
   dismissButtonTitle: PropTypes.string,
   /** Called when the banner is dismissed */
   onDismiss: PropTypes.func,
-  /** The ID used for ARIA labeling */
-  labelId: PropTypes.string,
   /** Determines whether the banner content wraps */
   isWrappingContent: PropTypes.bool,
   /** References content element */
@@ -106,6 +104,6 @@ BannerPresenter.propTypes = {
   refNotification: PropTypes.func,
   /** References interactions wrapper element */
   refInteractionsWrapper: PropTypes.func,
-  /** Banner actions */
+  /** The displayed message */
   children: PropTypes.node
 };

--- a/packages/banner/src/BannerPresenter/BannerPresenter.test.js
+++ b/packages/banner/src/BannerPresenter/BannerPresenter.test.js
@@ -1,7 +1,6 @@
 import React from "react";
 import renderer from "react-test-renderer";
 
-import { placements } from "../placements";
 import { types } from "../types";
 import BannerPresenter from "./BannerPresenter";
 
@@ -22,7 +21,6 @@ describe.only("banner/BannerPresenter/BannerPresenter", () => {
     {
       description: "renders with a string as children",
       props: {
-        placement: placements.TOP,
         children: "foobar"
       }
     },

--- a/packages/banner/src/BannerPresenter/BannerPresenter.test.js
+++ b/packages/banner/src/BannerPresenter/BannerPresenter.test.js
@@ -15,26 +15,26 @@ describe.only("banner/BannerPresenter/BannerPresenter", () => {
       props: {
         type: types.URGENT,
         label: "HELLO",
-        message: "World"
+        children: "World"
       }
     },
     {
-      description: "renders with a string as children",
+      description: "renders with a string as actions",
       props: {
-        children: "foobar"
+        actions: "foobar"
       }
     },
     {
-      description: "renders with a node as children",
+      description: "renders with a node as actions",
       props: {
         dismissButtonTitle: "boom",
-        children: <span>foo</span>
+        actions: <span>foo</span>
       }
     },
     {
-      description: "renders with a fragment as children",
+      description: "renders with a fragment as actions",
       props: {
-        children: [<span key="0">bar</span>, <div key="1">baz</div>]
+        actions: [<span key="0">bar</span>, <div key="1">baz</div>]
       }
     }
   ].forEach(({ description, props: { children, ...otherProps } }) => {

--- a/packages/banner/src/BannerPresenter/banner-presenter.scss
+++ b/packages/banner/src/BannerPresenter/banner-presenter.scss
@@ -44,12 +44,13 @@
   }
 }
 
-.hig__banner__notification {
+.hig__banner__message {
   flex-basis: 50%;
   min-width: $banner-notification-width-min;
   max-width: $banner-notification-width-max;
   padding-bottom: $banner-message-padding-y;
   margin: 0 auto 0 0;
+  text-align: left;
 
   .hig__banner--interactive & {
     margin-right: $banner-content-spacing-min;

--- a/packages/banner/src/BannerPresenter/banner-presenter.scss
+++ b/packages/banner/src/BannerPresenter/banner-presenter.scss
@@ -7,14 +7,6 @@
   border-width: 1px 0;
   border-style: solid;
 
-  &.hig__banner--bottom {
-    border-bottom-width: 0;
-  }
-
-  &.hig__banner--top {
-    border-top-width: 0;
-  }
-
   &.hig__banner--urgent {
     border-color: $banner-border-color--urgent;
     background-color: $banner-background-color--urgent;

--- a/packages/banner/src/BannerPresenter/presenters.js
+++ b/packages/banner/src/BannerPresenter/presenters.js
@@ -6,7 +6,6 @@ import cx from "classnames";
 import { Icon as BasicIcon, IconButton, Text } from "hig-react";
 
 import "./banner-presenter.scss";
-import { placements } from "../placements";
 import { types } from "../types";
 
 /** @todo Reference from constant on `Text` component */
@@ -36,12 +35,6 @@ const classNames = Object.freeze({
 });
 
 /** @type {Object.<string, string>} */
-const wrapperModifiersByPlacement = {
-  [placements.BOTTOM]: classNames.wrapperBottom,
-  [placements.TOP]: classNames.wrapperTop
-};
-
-/** @type {Object.<string, string>} */
 const wrapperModifiersByType = {
   [types.PRIMARY]: classNames.wrapperPrimary,
   [types.COMPLETE]: classNames.wrapperComplete,
@@ -66,7 +59,6 @@ const iconNamesByType = {
 /**
  * @typedef {Object} WrapperProps
  * @property {string} type
- * @property {string} placement
  * @property {boolean} hasActions
  * @property {string | undefined} [labelledBy]
  * @property {boolean} isWrappingContent
@@ -80,7 +72,6 @@ const iconNamesByType = {
 export function Wrapper(props) {
   const {
     type,
-    placement,
     hasActions,
     labelledBy,
     isWrappingContent,
@@ -90,7 +81,6 @@ export function Wrapper(props) {
   const classes = cx(
     classNames.wrapper,
     wrapperModifiersByType[type],
-    wrapperModifiersByPlacement[placement],
     hasActions ? classNames.wrapperInteractive : undefined,
     isWrappingContent ? classNames.wrapperWrapContent : undefined
   );

--- a/packages/banner/src/BannerPresenter/presenters.js
+++ b/packages/banner/src/BannerPresenter/presenters.js
@@ -22,7 +22,7 @@ const classNames = Object.freeze({
   dismissButton: "hig__banner__dismiss-button",
   iconBackground: "hig__banner__icon-background",
   interactionsWrapper: "hig__banner__interactions-wrapper",
-  notification: "hig__banner__notification",
+  notification: "hig__banner__message",
   wrapper: "hig__banner",
   wrapperBottom: "hig__banner--bottom",
   wrapperUrgent: "hig__banner--urgent",
@@ -73,6 +73,7 @@ export function Wrapper(props) {
   const {
     type,
     hasActions,
+    label,
     labelledBy,
     isWrappingContent,
     children
@@ -86,7 +87,12 @@ export function Wrapper(props) {
   );
 
   return (
-    <div role="alert" aria-labelledby={labelledBy} className={classes}>
+    <div
+      role="alert"
+      aria-label={label}
+      aria-labelledby={labelledBy}
+      className={classes}
+    >
       {children}
     </div>
   );
@@ -158,30 +164,12 @@ export function Notification({ innerRef, children }) {
 }
 
 /**
- * @typedef {Object} LabelProps
- * @property {string} [id]
- * @property {any} [children]
- */
-
-/**
- * @param {LabelProps} props
- * @returns {JSX.Element}
- */
-export function Label({ id, children }) {
-  return <Text color={TEXT_COLOR} id={id}>{`${children}: `}</Text>;
-}
-
-/**
  * @param {StyledProps} props
  * @returns {JSX.Element}
  */
 export function Message({ children }) {
   if (typeof children === "string") {
     return <Text color={TEXT_COLOR}>{children}</Text>;
-  }
-
-  if (typeof children === "function") {
-    return children();
   }
 
   return children;

--- a/packages/banner/src/__stories__/Banner.stories.js
+++ b/packages/banner/src/__stories__/Banner.stories.js
@@ -10,31 +10,29 @@ import Banner from "../Banner";
 function getBannerKnobs(props) {
   const {
     type,
-    placement,
+    children,
     label,
-    message,
     dismissButtonTitle,
     onDismiss,
     ...otherProps
   } = props;
 
   return {
+    ...otherProps,
     type: select("Type", Banner.AVAILABLE_TYPES, type),
-    placement: select("Placement", Banner.AVAILABLE_PLACEMENTS, placement),
+    children: text("Message", children),
     label: text("Label", label),
-    message: text("Message", message),
     dismissButtonTitle: text("Dismiss title", dismissButtonTitle),
-    onDismiss: action("Banner dismissed", onDismiss),
-    labelId: "unique-id",
-    isVisible: true,
-    ...otherProps
+    onDismiss: action("Banner dismissed", onDismiss)
   };
 }
 
-function BannerDemo({ children, ...props }) {
+function BannerDemo(props) {
+  const { children, ...otherProps } = getBannerKnobs(props);
+
   return (
     <div style={{ marginBottom: "15px" }}>
-      <Banner {...getBannerKnobs(props)}>{children}</Banner>
+      <Banner {...otherProps}>{children}</Banner>
     </div>
   );
 }
@@ -42,8 +40,6 @@ function BannerDemo({ children, ...props }) {
 function BannerStory({ props }) {
   return <BannerDemo {...props} />;
 }
-
-const bannerStories = storiesOf("Banner", module);
 
 const stories = [
   {
@@ -54,12 +50,11 @@ const stories = [
     description: "verbose, with interactions",
     props: {
       type: Banner.types.WARNING,
-      label: "PROCESS COMPLETE",
-      // eslint-disable-next-line max-len
-      message:
-        "Changes have been made to you document. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam.",
+      children:
+        // eslint-disable-next-line max-len
+        "PROCESS COMPLETE: Changes have been made to you document. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam.",
       /** @todo Cleanup/refactor */
-      children: ({ isWrappingActions }) => (
+      actions: ({ isWrappingActions }) => (
         <Banner.Interactions isWrappingActions={isWrappingActions}>
           <Banner.Action>
             <Button
@@ -82,6 +77,8 @@ const stories = [
     }
   }
 ];
+
+const bannerStories = storiesOf("Banner", module);
 
 stories.forEach(({ description, props }) => {
   bannerStories.add(description, () => <BannerStory props={props} />);


### PR DESCRIPTION
### Overview

This PR updates the `Banner` component's design in response to feedback. The API has also been updated to correlate with the design changes.

Resolves #830

> **Snapshot tests will fail in the future since jest isn't setup.**
I'd rather not spend time getting this setup since @eskfung is already working on it.

### Example

```js
function BannerWithAMessage() {
  return <Banner>INFO: This is an informative message.</Banner>
}
```

```js
const renderBannerActions = ({ isWrappingActions }) => (
  <Banner.Interactions isWrappingActions={isWrappingActions}>
    <Banner.Action>
      <Button title="Click Me" />
    </Banner.Action>
  </Banner.Interactions>
);

function BannerWithAnAction() {
  return <Banner actions={renderBannerActions}>ISSUE: This is a warning message.</Banner>;
}
```