### PR TITLE
Chores: Centralized Jest config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,11 +88,11 @@ jobs:
           command: yarn lint
           working_directory: packages/react
       - run:
-          name: Run Jest Tests (React)
+          name: Run Jest Tests
           command: yarn test-ci
-          working_directory: packages/react
+          working_directory: packages/storybook
       - store_artifacts:
-          path: packages/react/coverage
+          path: packages/storybook/coverage
   react-visual-test:
     <<: *defaults
     steps:

--- a/packages/banner/.babelrc
+++ b/packages/banner/.babelrc
@@ -1,0 +1,17 @@
+{
+  "presets": [
+    [
+      "env",
+      {
+        "targets": {
+          "browsers": "> 1%"
+        }
+      }
+    ],
+    "react",
+    "stage-2"
+  ],
+  "plugins": [
+    "transform-object-rest-spread"
+  ]
+}

--- a/packages/banner/src/BannerPresenter/__snapshots__/BannerPresenter.test.js.snap
+++ b/packages/banner/src/BannerPresenter/__snapshots__/BannerPresenter.test.js.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`banner/BannerPresenter/BannerPresenter renders with a fragment as children 1`] = `
+exports[`banner/BannerPresenter/BannerPresenter renders with a fragment as actions 1`] = `
 <div
+  aria-label={undefined}
   aria-labelledby={undefined}
   className="hig__banner hig__banner--primary hig__banner--interactive"
   role="alert"
@@ -22,7 +23,7 @@ exports[`banner/BannerPresenter/BannerPresenter renders with a fragment as child
     className="hig__banner__content"
   >
     <p
-      className="hig__banner__notification"
+      className="hig__banner__message"
     >
       <span
         className="hig__typography hig__typography__text hig__typography--hig-cool-gray-70"
@@ -70,6 +71,7 @@ exports[`banner/BannerPresenter/BannerPresenter renders with a fragment as child
 
 exports[`banner/BannerPresenter/BannerPresenter renders with a label 1`] = `
 <div
+  aria-label="HELLO"
   aria-labelledby={undefined}
   className="hig__banner hig__banner--urgent"
   role="alert"
@@ -90,14 +92,8 @@ exports[`banner/BannerPresenter/BannerPresenter renders with a label 1`] = `
     className="hig__banner__content"
   >
     <p
-      className="hig__banner__notification"
+      className="hig__banner__message"
     >
-      <span
-        className="hig__typography hig__typography__text hig__typography--hig-cool-gray-70"
-        style={Object {}}
-      >
-        HELLO: 
-      </span>
       <span
         className="hig__typography hig__typography__text hig__typography--hig-cool-gray-70"
         style={Object {}}
@@ -132,8 +128,9 @@ exports[`banner/BannerPresenter/BannerPresenter renders with a label 1`] = `
 </div>
 `;
 
-exports[`banner/BannerPresenter/BannerPresenter renders with a node as children 1`] = `
+exports[`banner/BannerPresenter/BannerPresenter renders with a node as actions 1`] = `
 <div
+  aria-label={undefined}
   aria-labelledby={undefined}
   className="hig__banner hig__banner--primary hig__banner--interactive"
   role="alert"
@@ -154,7 +151,7 @@ exports[`banner/BannerPresenter/BannerPresenter renders with a node as children 
     className="hig__banner__content"
   >
     <p
-      className="hig__banner__notification"
+      className="hig__banner__message"
     >
       <span
         className="hig__typography hig__typography__text hig__typography--hig-cool-gray-70"
@@ -197,10 +194,11 @@ exports[`banner/BannerPresenter/BannerPresenter renders with a node as children 
 </div>
 `;
 
-exports[`banner/BannerPresenter/BannerPresenter renders with a string as children 1`] = `
+exports[`banner/BannerPresenter/BannerPresenter renders with a string as actions 1`] = `
 <div
+  aria-label={undefined}
   aria-labelledby={undefined}
-  className="hig__banner hig__banner--primary hig__banner--top hig__banner--interactive"
+  className="hig__banner hig__banner--primary hig__banner--interactive"
   role="alert"
 >
   <figure
@@ -219,7 +217,7 @@ exports[`banner/BannerPresenter/BannerPresenter renders with a string as childre
     className="hig__banner__content"
   >
     <p
-      className="hig__banner__notification"
+      className="hig__banner__message"
     >
       <span
         className="hig__typography hig__typography__text hig__typography--hig-cool-gray-70"
@@ -262,6 +260,7 @@ exports[`banner/BannerPresenter/BannerPresenter renders with a string as childre
 
 exports[`banner/BannerPresenter/BannerPresenter renders without props 1`] = `
 <div
+  aria-label={undefined}
   aria-labelledby={undefined}
   className="hig__banner hig__banner--primary"
   role="alert"
@@ -282,7 +281,7 @@ exports[`banner/BannerPresenter/BannerPresenter renders without props 1`] = `
     className="hig__banner__content"
   >
     <p
-      className="hig__banner__notification"
+      className="hig__banner__message"
     >
       <span
         className="hig__typography hig__typography__text hig__typography--hig-cool-gray-70"

--- a/packages/react/src/elements/components/Icon/__snapshots__/Icon.test.js.snap
+++ b/packages/react/src/elements/components/Icon/__snapshots__/Icon.test.js.snap
@@ -28,8 +28,8 @@ exports[`Icon renders correctly when using the \`svg\` prop 1`] = `
   dangerouslySetInnerHTML={
     Object {
       "__html": "<svg width=\\"16px\\" height=\\"16px\\" viewBox=\\"0 0 16 16\\">
-      <rect x=\\"2\\" y=\\"2\\" width=\\"12\\" height=\\"12\\" fill=\\"none\\" stroke=\\"red\\" stroke-width=\\"2\\"></rect>
-    </svg>",
+          <rect x=\\"2\\" y=\\"2\\" width=\\"12\\" height=\\"12\\" fill=\\"none\\" stroke=\\"red\\" stroke-width=\\"2\\"></rect>
+        </svg>",
     }
   }
 />

--- a/packages/storybook/jest.config.js
+++ b/packages/storybook/jest.config.js
@@ -7,5 +7,6 @@ module.exports = {
   rootDir: "../../",
   setupFiles: ["raf/polyfill"],
   setupTestFrameworkScriptFile: "<rootDir>/packages/storybook/support/jest/setupTests.js",
+  testPathIgnorePatterns: ["<rootDir>/packages/vanilla"],
   unmockedModulePathPatterns: ["node_modules"]
 };

--- a/packages/storybook/jest.config.js
+++ b/packages/storybook/jest.config.js
@@ -1,4 +1,25 @@
 module.exports = {
+  collectCoverageFrom: [
+    "**/src/**/*.{js,jsx}",
+    "!**/index.js",
+  ],
+  coverageDirectory: "<rootDir>/packages/storybook/coverage",
+  coveragePathIgnorePatterns: [
+    "node_modules",
+    "packages\/vanilla",
+    "src\/playground",
+    "examples\/redux",
+    "__stories__",
+    "__gemini__"
+  ],
+  coverageThreshold: {
+    global: {
+      branches: 60,
+      functions: 60,
+      lines: 60,
+      statements: 60
+    }
+  },
   moduleNameMapper: {
     "\\.(css|scss|svg)$": "<rootDir>/packages/storybook/support/jest/fileMock.js"
   },

--- a/packages/storybook/jest.config.js
+++ b/packages/storybook/jest.config.js
@@ -1,10 +1,11 @@
 module.exports = {
   moduleNameMapper: {
-    "\\.(css|scss|svg)$": "<rootDir>/support/jest/fileMock.js"
+    "\\.(css|scss|svg)$": "<rootDir>/packages/storybook/support/jest/fileMock.js"
   },
   modulePaths: ["node_modules"],
   moduleFileExtensions: ["js", "jsx", "json"],
+  rootDir: "../../",
   setupFiles: ["raf/polyfill"],
-  setupTestFrameworkScriptFile: "<rootDir>/support/jest/setupTests.js",
+  setupTestFrameworkScriptFile: "<rootDir>/packages/storybook/support/jest/setupTests.js",
   unmockedModulePathPatterns: ["node_modules"]
 };

--- a/packages/storybook/jest.config.js
+++ b/packages/storybook/jest.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   collectCoverageFrom: [
-    "**/src/**/*.{js,jsx}",
-    "!**/index.js",
+    "**/src/**/*.{js,jsx}"
   ],
   coverageDirectory: "<rootDir>/packages/storybook/coverage",
   coveragePathIgnorePatterns: [

--- a/packages/storybook/jest.config.js
+++ b/packages/storybook/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  moduleNameMapper: {
+    "\\.(css|scss|svg)$": "<rootDir>/support/jest/fileMock.js"
+  },
+  modulePaths: ["node_modules"],
+  moduleFileExtensions: ["js", "jsx", "json"],
+  setupFiles: ["raf/polyfill"],
+  setupTestFrameworkScriptFile: "<rootDir>/support/jest/setupTests.js",
+  unmockedModulePathPatterns: ["node_modules"]
+};

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -10,7 +10,9 @@
     "storybook": "start-storybook -p 9001 -c .storybook/development",
     "storybook-build": "build-storybook -c .storybook/development",
     "storybook-deploy": "build-storybook -c .storybook/development && surge --project storybook-static",
-    "storybook-test": "start-storybook -p 9876 -c .storybook/test"
+    "storybook-test": "start-storybook -p 9876 -c .storybook/test",
+    "test": "jest",
+    "test-ci": "jest --coverage --runInBand --colors"
   },
   "devDependencies": {
     "@storybook/addon-actions": "^3.4.0",
@@ -27,10 +29,16 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "babel-runtime": "^6.26.0",
+    "enzyme": "^2.9.1",
     "file-loader": "^1.1.11",
+    "jest": "^21.2.1",
+    "jest-enzyme": "^3.8.3",
+    "jest-extended": "^0.6.0",
     "lodash": "^4.17.5",
+    "raf": "^3.4.0",
     "react": "^15.6.2",
     "react-dom": "^15.6.2",
+    "react-test-renderer": "^15.6.1",
     "surge": "^0.20.1"
   }
 }

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -24,6 +24,7 @@
     "@storybook/addons": "^3.4.0",
     "@storybook/react": "^3.4.0",
     "babel-core": "^6.26.0",
+    "babel-jest": "^22.4.3",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",

--- a/packages/storybook/support/jest/fileMock.js
+++ b/packages/storybook/support/jest/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = "test-file-stub";

--- a/packages/storybook/support/jest/matchers/toBeConstants.js
+++ b/packages/storybook/support/jest/matchers/toBeConstants.js
@@ -1,0 +1,101 @@
+const CONSTANT_MATCHER = /^[A-Z0-9_]+$/;
+const VALUE_MATCHER = /^[a-z0-9-]+$/;
+
+/**
+ * @param {string} key
+ * @returns {boolean}
+ */
+function isValidComponentConstantKey(key) {
+  return CONSTANT_MATCHER.test(key);
+}
+
+/**
+ * @param {string} value
+ * @returns {boolean}
+ */
+function isValidComponentConstantValue(value) {
+  return VALUE_MATCHER.test(value);
+}
+
+/**
+ * @param {Object.<string, string>} constants
+ * @returns {string[]} An array of invalid constant keys
+ */
+function getInvalidComponentConstantKeys(constants) {
+  return Object.keys(constants).reduce((invalidKeys, key) => {
+    if (!isValidComponentConstantKey(key)) invalidKeys.push(key);
+    return invalidKeys;
+  }, []);
+}
+
+/**
+ * @param {string[]} values
+ * @returns {string[]} An array of invalid constant values
+ */
+function getInvalidComponentConstantValues(values) {
+  return values.reduce((invalidValues, value) => {
+    if (!isValidComponentConstantValue(value)) invalidValues.push(value);
+    return invalidValues;
+  }, []);
+}
+
+/**
+ * @param {Object} result
+ * @returns {string}
+ */
+function getMessage(result) {
+  const {
+    hasValidKeys,
+    hasValidValues,
+    isFrozen,
+    invalidKeys,
+    invalidValues,
+    label
+  } = result;
+
+  if (!isFrozen) {
+    return `expected ${label} to be frozen.`;
+  }
+
+  if (!hasValidKeys) {
+    return `expected ${label} to have valid keys. Invalid keys: ${invalidKeys}`;
+  }
+
+  if (!hasValidValues) {
+    return `expected ${label} to have valid values. Invalid values: ${invalidValues}`;
+  }
+
+  return `expected ${label} to contain constants`;
+}
+
+function toBeConstants(constants, label) {
+  const isArray = Array.isArray(constants);
+  const isFrozen = Object.isFrozen(constants);
+  const invalidKeys = isArray ? [] : getInvalidComponentConstantKeys(constants);
+  const values = isArray ? constants : Object.values(constants);
+  const invalidValues = getInvalidComponentConstantValues(values);
+  const hasValidKeys = invalidKeys.length === 0;
+  const hasValidValues = invalidValues.length === 0;
+  const pass = hasValidKeys && hasValidValues;
+  const message = getMessage({
+    hasValidKeys,
+    hasValidValues,
+    isFrozen,
+    invalidKeys,
+    invalidValues,
+    label
+  });
+
+  return { pass, message: () => message };
+}
+
+function toHavePropertyOfConstants(Component, propertyName) {
+  const constants = Component[propertyName];
+
+  return toBeConstants(constants, propertyName);
+}
+
+expect.extend({
+  toBeConstants,
+  toHavePropertyOfConstants
+});

--- a/packages/storybook/support/jest/matchers/toHavePropTypesAndDocgenInfo.js
+++ b/packages/storybook/support/jest/matchers/toHavePropTypesAndDocgenInfo.js
@@ -1,0 +1,61 @@
+function checkDocgenInfo(Component) {
+  if (!Component.__docgenInfo || !Component.__docgenInfo.props) {
+    return Object.keys(Component.propTypes);
+  }
+
+  return Object.keys(Component.propTypes).reduce(
+    (undocumentedProps, propName) => {
+      let description;
+      try {
+        description = Component.__docgenInfo.props[propName].description;
+      } catch (TypeError) {
+        return undocumentedProps.concat(propName);
+      }
+      if (description && description.length > 0) {
+        return undocumentedProps;
+      }
+      return undocumentedProps.concat(propName);
+    },
+    []
+  );
+}
+
+function checkComponent(Component) {
+  const propTypes = Component.propTypes;
+
+  if (propTypes === undefined) {
+    return { propTypes: undefined };
+  }
+
+  return {
+    propTypes,
+    undocumentedProps: checkDocgenInfo(Component)
+  };
+}
+
+expect.extend({
+  toHavePropTypesAndDocGenInfo: Component => {
+    const { propTypes, undocumentedProps } = checkComponent(Component);
+
+    if (propTypes === undefined) {
+      return {
+        pass: false,
+        message: () =>
+          `Expected ${Component.name} to have propTypes, but it did not.`
+      };
+    } else if (undocumentedProps.length > 0) {
+      return {
+        pass: false,
+        message: () => `
+Expected component to have documented all propTypes, but it did not.
+${undocumentedProps
+          .map(propName => `docgenInfo is missing for "${propName}".`)
+          .join("\n")}`
+      };
+    }
+    return {
+      pass: true,
+      message: () => "Component implements and documents propTypes as expected."
+    };
+  }
+});

--- a/packages/storybook/support/jest/matchers/toImplementHIGInterfaceOf.js
+++ b/packages/storybook/support/jest/matchers/toImplementHIGInterfaceOf.js
@@ -1,0 +1,54 @@
+function implementsInterface(testFunction, HIGComponent) {
+  const interfaceMethods = Object.keys(HIGComponent._interface.methods);
+  const spiedInstance = interfaceMethods.reduce((instance, methodName) => {
+    jest.spyOn(instance, methodName);
+    return instance;
+  }, new HIGComponent({}));
+
+  testFunction(spiedInstance);
+
+  const uncalledMethods = interfaceMethods.reduce(
+    (acc, methodName) =>
+      spiedInstance[methodName].mock.calls.length === 0
+        ? acc.concat([methodName])
+        : acc,
+    []
+  );
+
+  return {
+    pass: uncalledMethods.length === 0,
+    uncalledMethods,
+    calledCount: interfaceMethods.length - uncalledMethods.length,
+    totalMethods: interfaceMethods.length
+  };
+}
+
+expect.extend({
+  toImplementHIGInterfaceOf: (fn, HIGComponent) => {
+    const {
+      pass,
+      uncalledMethods,
+      calledCount,
+      totalMethods
+    } = implementsInterface(fn, HIGComponent);
+
+    if (pass) {
+      return {
+        message: () =>
+          `
+Expected adapter to excercise the hig interface. ${calledCount} of ${totalMethods} methods called.`,
+        pass: true
+      };
+    }
+    return {
+      message: () => `
+Expected adapter to excercise the hig interface,
+but only ${calledCount} of ${totalMethods} methods called.
+${uncalledMethods
+        .map(methodName => `"${methodName}" was not called`)
+        .join("\n")}
+      `,
+      pass: false
+    };
+  }
+});

--- a/packages/storybook/support/jest/setupTests.js
+++ b/packages/storybook/support/jest/setupTests.js
@@ -1,0 +1,5 @@
+import "jest-enzyme";
+import "jest-extended";
+import "./matchers/toBeConstants";
+import "./matchers/toImplementHIGInterfaceOf";
+import "./matchers/toHavePropTypesAndDocgenInfo";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1103,6 +1103,13 @@ babel-jest@^21.2.0:
     babel-plugin-istanbul "^4.0.0"
     babel-preset-jest "^21.2.0"
 
+babel-jest@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-22.4.3.tgz#4b7a0b6041691bbd422ab49b3b73654a49a6627a"
+  dependencies:
+    babel-plugin-istanbul "^4.1.5"
+    babel-preset-jest "^22.4.3"
+
 babel-loader@7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-7.1.1.tgz#b87134c8b12e3e4c2a94e0546085bc680a2b8488"
@@ -1145,7 +1152,7 @@ babel-plugin-external-helpers@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-istanbul@^4.0.0:
+babel-plugin-istanbul@^4.0.0, babel-plugin-istanbul@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz#6760cdd977f411d3e175bb064f2bc327d99b2b6e"
   dependencies:
@@ -1160,6 +1167,10 @@ babel-plugin-jest-hoist@^20.0.3:
 babel-plugin-jest-hoist@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz#2cef637259bd4b628a6cace039de5fcd14dbb006"
+
+babel-plugin-jest-hoist@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.3.tgz#7d8bcccadc2667f96a0dcc6afe1891875ee6c14a"
 
 babel-plugin-macros@^2.2.0:
   version "2.2.0"
@@ -1727,6 +1738,13 @@ babel-preset-jest@^21.2.0:
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-21.2.0.tgz#ff9d2bce08abd98e8a36d9a8a5189b9173b85638"
   dependencies:
     babel-plugin-jest-hoist "^21.2.0"
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
+
+babel-preset-jest@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-22.4.3.tgz#e92eef9813b7026ab4ca675799f37419b5a44156"
+  dependencies:
+    babel-plugin-jest-hoist "^22.4.3"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
 babel-preset-minify@^0.3.0:


### PR DESCRIPTION
* Configure Jest to run from one location. I threw it into the storybook package, but it should be pretty portable - maybe even to the repo root.
* Updated stale snapshots

# Future Todos

* Use https://github.com/jest-community/jest-runner-eslint to handle linting and unit tests in one command.
* Investigate additional benefits from using `jest --projects`
* Clean up hig-react dependencies and remove unused code examples
* Update packages