### PR TITLE
fix(top-nav): Correct flyout styling

### DIFF
--- a/packages/top-nav/src/presenters/ProfileContent.js
+++ b/packages/top-nav/src/presenters/ProfileContent.js
@@ -11,9 +11,7 @@ export default function ProfileContent(props) {
       <div className="hig__top-nav__profile-flyout-content__email">
         {profileEmail}
       </div>
-      <div className="hig__top-nav__profile-flyout-content__links">
-        {children}
-      </div>
+      {children}
     </div>
   );
 }

--- a/packages/top-nav/src/top-nav.scss
+++ b/packages/top-nav/src/top-nav.scss
@@ -110,35 +110,24 @@
 .hig__top-nav__profile-flyout-content {
   @include reset;
 
+  padding: 4px 14px;
+
   &__name {
     font-weight: bold;
     white-space: nowrap;
     text-overflow: ellipsis;
-    overflow-x: hidden;
+    overflow: hidden;
     font-size: 16px;
+    line-height: 24px;
+    color: #222934;
   }
 
   &__email {
     white-space: nowrap;
     text-overflow: ellipsis;
-    overflow-x: hidden;
+    overflow: hidden;
+    color: #565C5F;
+    line-height: 16px;
     font-size: 12px;
-    color: color(hig-cool-gray-50);
-  }
-
-  &__links {
-    display: flex;
-    flex-wrap: wrap;
-    margin-top: 10px;
-    min-width: 225px;
-  }
-
-  &__link {
-    margin-top: 10px;
-    margin-right: 10px;
-
-    &:last-child {
-      margin-right: unset;
-    }
   }
 }

--- a/packages/top-nav/src/top-nav.scss
+++ b/packages/top-nav/src/top-nav.scss
@@ -86,6 +86,16 @@
   }
 }
 
+// This is required since the flyout wraps children in DIV elements
+// without any classes.
+// It's neccessary to break encapsulation here, due to the Flyout component
+// still being in Vanilla.
+// TODO: Migrate the Flyout component into its own package, and stop rendering useless DIVs.
+.hig__top-nav .hig__flyout__panel > div:not([class]) {
+  display: flex;
+  flex-direction: column;
+}
+
 .hig__top-nav__profile-action {
   padding: 0 0 0 12px;
   margin: 12px 12px 12px 0;
@@ -101,6 +111,7 @@
   @include reset;
 
   &__name {
+    font-weight: bold;
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow-x: hidden;


### PR DESCRIPTION
### Overview

Fixes incorrect styles in `TopNav` component. Sadly, one the fixes is a hack that will need to be resolved by migrating the `Flyout` component from Vanilla.

### Preview

* [Release `@hig/top-nav@0.1.0-alpha.40ad6b99`](https://www.npmjs.com/package/@hig/top-nav)
* [Storybook](https://hig-fix-top-nav-styles.surge.sh/?knob-Name=Jon%20Snow&knob-Size=large&selectedKind=TopNav&selectedStory=accounts&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel)