### PR TITLE
fix(top-nav): Remove unnecessarily restrictive logo styles

### DIFF
--- a/packages/top-nav/src/__stories__/TopNav.stories.js
+++ b/packages/top-nav/src/__stories__/TopNav.stories.js
@@ -17,9 +17,13 @@ storybook.add("accounts", () => (
         label="Autodesk Accounts"
         title="Autodesk Accounts"
         link="https://autodesk.com"
-        // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={{ __html: accountLogo }}
-      />
+      >
+        <figure
+          style={{ width: "auto", height: "24px", margin: "0" }}
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: accountLogo }}
+        />
+      </TopNav.Logo>
     }
     rightActions={
       <TopNav.Interactions>

--- a/packages/top-nav/src/top-nav.scss
+++ b/packages/top-nav/src/top-nav.scss
@@ -48,12 +48,6 @@
 .hig__top-nav__logo {
   display: flex;
   cursor: pointer;
-
-  > img,
-  > svg {
-    height: 24px;
-    width: auto;
-  }
 }
 
 .hig__top-nav__interactions {


### PR DESCRIPTION
### Overview

Technically speaking, logos should be allowed to be any size within the TopNav.

We can provide additional components (e.g. `LogoImage`) to facilitate having components at the recommended size.