### PR TITLE
fix(rich-text): Have Circle publish @hig/rich-text/build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
             - packages/icon-button/node_modules
             - packages/icons/node_modules
             - packages/react/node_modules
+            - packages/rich-text/node_modules
             - packages/side-nav/node_modules
             - packages/skeleton-item/node_modules
             - packages/storybook/node_modules
@@ -55,6 +56,7 @@ jobs:
             - packages/icon/build
             - packages/icon-button/build
             - packages/icons/build
+            - packages/rich-text/build
             - packages/side-nav/build
             - packages/skeleton-item/build
             - packages/top-nav/build


### PR DESCRIPTION
For a successful publish, Circle needs to cache and restore the `build/` directory