### PR TITLE
fix(side-nav): Apply themes directly to SideNav

### DIFF
--- a/packages/side-nav/src/containers/docked.scss
+++ b/packages/side-nav/src/containers/docked.scss
@@ -10,7 +10,8 @@
 
 .hig__side-nav-container--docked {
   @include reset;
-  @include vendor-prefix('transition', side-nav-transition('left'));
+  @include vendor-prefix("transition", side-nav-transition("left"));
+  @include shadow("inner-right");
 
   position: fixed;
   top: 0;
@@ -18,10 +19,10 @@
   bottom: 0;
   height: 100vh;
   width: $side-nav-max-width;
+  padding-right: 4px;
   z-index: 2;
 
   overflow-x: hidden;
-  @include shadow("inner-right");
 }
 
 .hig--light-theme {

--- a/packages/side-nav/src/presenters/side-nav.scss
+++ b/packages/side-nav/src/presenters/side-nav.scss
@@ -11,14 +11,13 @@
   width: 100%;
   height: 100%;
   overflow: hidden;
-  background: transparent;
 }
 
 .hig__side-nav__overflow {
   @include vendor-prefix('box-sizing', 'border-box');
   flex: 1 1 auto;
   height: 100%;
-  margin: 4px 4px 4px 0;
+  margin: 4px 0;
   overflow-y: scroll;
   overflow-x: hidden;
 
@@ -86,6 +85,10 @@
 
 // Light theme
 .hig--light-theme {
+  &.hig__side-nav {
+    background: color(hig-white);
+  }
+
   .hig__side-nav__overflow::-webkit-scrollbar-thumb {
     background-color: color(hig-cool-gray-50);
   }
@@ -114,6 +117,10 @@
 
 // Dark Blue
 .hig--dark-blue-theme {
+  &.hig__side-nav {
+    background-color: color(hig-cool-gray-60);
+  }
+
   .hig__side-nav__overflow::-webkit-scrollbar-thumb {
     background-color: color(hig-cool-gray-40);
   }


### PR DESCRIPTION
It was a little confusing that only the containers change based on the theme. Making some adjustments so that the docked container shadow still appears.

![screen shot 2018-05-15 at 10 47 17 am](https://user-images.githubusercontent.com/1744567/40074798-7d7177b4-582f-11e8-9a0e-d4f55afad9ce.png)
