### PR TITLE
build: Use babel external helpers plugin again

### DIFF
--- a/packages/babel-preset/build.js
+++ b/packages/babel-preset/build.js
@@ -21,6 +21,6 @@ module.exports = function createBuildPreset() {
       "stage-2",
       "react"
     ],
-    plugins: ["react-docgen"]
+    plugins: ["external-helpers", "react-docgen"]
   };
 };

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -15,6 +15,7 @@
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.4",
+    "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-react-docgen": "^1.8.1",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -13,6 +13,15 @@
   "files": [
     "build/*"
   ],
+  "dependencies": {
+    "@hig/icon": "^0.1.0-alpha",
+    "@hig/icon-button": "^0.1.0-alpha",
+    "@hig/icons": "^0.1.0-alpha",
+    "@hig/themes": "^0.1.0-alpha",
+    "@hig/typography": "^0.1.0-alpha",
+    "classnames": "^2.2.5",
+    "react-lifecycles-compat": "^2.0.0"
+  },
   "devDependencies": {
     "@hig/babel-preset": "0.1.0",
     "@hig/button": "^0.1.0-alpha",
@@ -28,14 +37,6 @@
   "scripts": {
     "build": "hig-scripts-build",
     "lint": "eslint src --color --ext .js,.jsx"
-  },
-  "dependencies": {
-    "@hig/icon": "^0.1.0-alpha",
-    "@hig/icon-button": "^0.1.0-alpha",
-    "@hig/icons": "^0.1.0-alpha",
-    "@hig/themes": "^0.1.0-alpha",
-    "@hig/typography": "^0.1.0-alpha",
-    "react-lifecycles-compat": "^2.0.0"
   },
   "eslintConfig": { "extends": "@hig" },
   "babel": {

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -13,6 +13,10 @@
   "files": [
     "build/*"
   ],
+  "dependencies": {
+    "@hig/themes": "^0.1.0-alpha",
+    "classnames": "^2.2.5"
+  },
   "devDependencies": {
     "@hig/babel-preset": "0.1.0",
     "@hig/eslint-config": "0.1.0",
@@ -27,9 +31,6 @@
   "scripts": {
     "build": "hig-scripts-build",
     "lint": "eslint src --color --ext .js,.jsx"
-  },
-  "dependencies": {
-    "@hig/themes": "^0.1.0-alpha"
   },
   "babel": {
     "env": {

--- a/packages/icon-button/package.json
+++ b/packages/icon-button/package.json
@@ -15,7 +15,8 @@
     "build/*"
   ],
   "dependencies": {
-    "@hig/icon": "^0.1.0-alpha"
+    "@hig/icon": "^0.1.0-alpha",
+    "classnames": "^2.2.5"
   },
   "devDependencies": {
     "@hig/babel-preset": "0.1.0",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -15,7 +15,8 @@
     "build/*"
   ],
   "dependencies": {
-    "@hig/icons": "^0.1.0-alpha"
+    "@hig/icons": "^0.1.0-alpha",
+    "classnames": "^2.2.5"
   },
   "devDependencies": {
     "@hig/babel-preset": "0.1.0",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@hig/babel-preset": "0.1.0",
-    "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",

--- a/packages/skeleton-item/package.json
+++ b/packages/skeleton-item/package.json
@@ -15,7 +15,8 @@
     "build/*"
   ],
   "dependencies": {
-    "@hig/themes": "^0.1.0-alpha"
+    "@hig/themes": "^0.1.0-alpha",
+    "classnames": "^2.2.5"
   },
   "devDependencies": {
     "@hig/babel-preset": "0.1.0",

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -14,6 +14,9 @@
   "files": [
     "build/*"
   ],
+  "dependencies": {
+    "classnames": "^2.2.5"
+  },
   "devDependencies": {
     "@hig/babel-preset": "0.1.0",
     "@hig/eslint-config": "0.1.0",


### PR DESCRIPTION
We moved a lot of things around, and this plugin was no longer getting used in the build process.