### PR TITLE
Add @hig/components package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
             - packages/banner/node_modules
             - packages/button/node_modules
             - packages/checkbox/node_modules
+            - packages/components/node_modules
             - packages/dropdown/node_modules
             - packages/eslint-config/node_modules
             - packages/flyout/node_modules
@@ -74,6 +75,7 @@ jobs:
             - packages/banner/build
             - packages/button/build
             - packages/checkbox/build
+            - packages/components/build
             - packages/dropdown/build
             - packages/flyout/build
             - packages/icon/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ jobs:
             - packages/styles/node_modules
             - packages/table/node_modules
             - packages/tabs/node_modules
+            - packages/text-area/node_modules
             - packages/text-field/node_modules
             - packages/text-link/node_modules
             - packages/themes/node_modules
@@ -95,6 +96,7 @@ jobs:
             - packages/styles/build
             - packages/table/build
             - packages/tabs/build
+            - packages/text-area/build
             - packages/text-field/build
             - packages/text-link/build
             - packages/themes/build

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -1,0 +1,42 @@
+# Components
+
+The Components package exports all of the available HIG components for easy access.
+
+Please view the individual components packages for component specific documentation.
+
+## Getting started
+
+### Install the package
+
+```bash
+yarn add @hig/components
+```
+
+## Basic usage
+
+### Import all components and CSS
+
+```jsx
+import * as HIG from "@hig/components";
+import "@hig/components/build/index.css";
+
+<HIG.Button title="Click Me" />;
+```
+
+### Import a single component
+
+```jsx
+import { Button } from "@hig/components";
+import "@hig/components/build/button.css";
+
+<Button title="Click Me" />;
+```
+
+### Import a component with component-specific exports
+
+```jsx
+import Button, { types } from "@hig/components/build/button";
+import "@hig/components/build/button.css";
+
+<Button type={types.PRIMARY} title="Click Me" />;
+```

--- a/packages/components/integration/imports.test.js
+++ b/packages/components/integration/imports.test.js
@@ -1,0 +1,24 @@
+/* eslint-disable import/no-duplicates */
+import * as HIG from "@hig/components";
+import { Button as NamedButton } from "@hig/components";
+import DefaultButton, {
+  types as buttonTypes
+} from "@hig/components/build/button";
+
+describe("components", () => {
+  it("exports components as named exports", () => {
+    expect(HIG).toHaveProperty("Button");
+  });
+
+  it("exports components as a module defaults", () => {
+    expect(DefaultButton).toBeDefined();
+  });
+
+  it("exports that exact same component as a module default and named export", () => {
+    expect(NamedButton).toBe(DefaultButton);
+  });
+
+  it("exports named exports in component modules", () => {
+    expect(buttonTypes).toBeDefined();
+  });
+});

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@hig/components",
+  "version": "0.1.0-alpha",
+  "description": "HIG Components",
+  "author": "Autodesk Inc.",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "build/index.js",
+  "module": "build/index.es.js",
+  "style": "build/index.css",
+  "files": ["build/*"],
+  "dependencies": {
+    "@hig/avatar": "^0.1.0-alpha",
+    "@hig/banner": "^0.1.0-alpha",
+    "@hig/button": "^0.1.0-alpha",
+    "@hig/checkbox": "^0.1.0-alpha",
+    "@hig/dropdown": "^0.1.0-alpha",
+    "@hig/flyout": "^0.1.0-alpha",
+    "@hig/icon": "^0.1.0-alpha",
+    "@hig/icon-button": "^0.1.0-alpha",
+    "@hig/icons": "^0.1.0-alpha",
+    "@hig/modal": "^0.1.0-alpha",
+    "@hig/progress-bar": "^0.1.0-alpha",
+    "@hig/progress-ring": "^0.1.0-alpha",
+    "@hig/radio-button": "^0.1.0-alpha",
+    "@hig/rich-text": "^0.1.0-alpha",
+    "@hig/side-nav": "^0.1.0-alpha",
+    "@hig/skeleton-item": "^0.1.0-alpha",
+    "@hig/slider": "^0.1.0-alpha",
+    "@hig/table": "^0.2.0",
+    "@hig/tabs": "^0.1.0-alpha",
+    "@hig/text-area": "^0.1.0-alpha",
+    "@hig/text-field": "^0.1.0-alpha",
+    "@hig/text-link": "^0.1.0-alpha",
+    "@hig/themes": "^0.1.0-alpha",
+    "@hig/timestamp": "^0.1.0-alpha",
+    "@hig/tooltip": "^0.1.0-alpha",
+    "@hig/typography": "^0.1.0-alpha"
+  },
+  "peerDependencies": {
+    "prop-types": "^15.5.10",
+    "react": "^15.4.1 || ^16.3.2"
+  },
+  "devDependencies": {
+    "@hig/babel-preset": "0.1.0",
+    "@hig/eslint-config": "0.1.0",
+    "clean-css": "^4.1.11",
+    "mkdirp": "^0.5.1",
+    "rollup": "^0.59.2"
+  },
+  "scripts": {
+    "build": "node scripts/build.js",
+    "lint": "eslint src --color --ext .js,.jsx"
+  },
+  "eslintConfig": {
+    "extends": "@hig"
+  },
+  "babel": {
+    "env": {
+      "test": {
+        "presets": ["@hig/babel-preset/test"]
+      }
+    }
+  }
+}

--- a/packages/components/scripts/build.js
+++ b/packages/components/scripts/build.js
@@ -1,0 +1,252 @@
+/* eslint-disable no-console, global-require, import/no-dynamic-require */
+const CleanCss = require("clean-css");
+const fs = require("fs");
+const path = require("path");
+const util = require("util");
+const mkdirpFn = require("mkdirp");
+const rollup = require("rollup");
+
+const componentsPackageMeta = require("../package.json");
+
+const mkdirp = util.promisify(mkdirpFn);
+const readFile = util.promisify(fs.readFile);
+const copyFile = util.promisify(fs.copyFile);
+const writeFile = util.promisify(fs.writeFile);
+
+const BUILD_PATH = path.resolve(__dirname, "../build");
+
+function getPackagePath(packageName) {
+  const packageMainPath = require.resolve(packageName);
+
+  return path.resolve(packageMainPath, "../..");
+}
+
+function getPackageMeta(packagePath) {
+  const packageJsonPath = path.join(packagePath, "package.json");
+
+  if (!fs.existsSync(packageJsonPath)) return null;
+
+  return require(packageJsonPath);
+}
+
+/**
+ * @param {string} packageName
+ */
+function isScopedComponentPackage(packageName) {
+  const packagePath = getPackagePath(packageName);
+  const packageMeta = getPackageMeta(packagePath);
+
+  if (!packageMeta) return false;
+
+  const { name } = packageMeta;
+
+  return name.startsWith("@hig");
+}
+
+/**
+ * @returns {string[]}
+ */
+function getScopedPackages() {
+  const { dependencies } = componentsPackageMeta;
+
+  return Object.keys(dependencies).reduce((result, packageName) => {
+    if (isScopedComponentPackage(packageName)) {
+      const packagePath = getPackagePath(packageName);
+      const packageMeta = getPackageMeta(packagePath);
+      const packageExportNames = Object.keys(require(packagePath));
+
+      result.push({ packagePath, packageMeta, packageExportNames });
+    }
+
+    return result;
+  }, []);
+}
+
+/**
+ * @param {string} word
+ */
+function capitalize(word) {
+  return word.charAt(0).toUpperCase() + word.slice(1);
+}
+
+/**
+ * @param {string} packageName
+ */
+function createModuleName(packageName) {
+  return packageName.slice(5);
+}
+
+/**
+ * @param {string} packageName
+ */
+function createComponentName(packageName) {
+  return packageName
+    .slice(5)
+    .split("-")
+    .map(capitalize)
+    .join("");
+}
+
+/**
+ * @param {Object[]} scopedPackages
+ */
+function renderIndexModule(scopedPackages) {
+  const statements = scopedPackages.map(packageInfo => {
+    const { packageMeta } = packageInfo;
+    const packageName = packageMeta.name;
+    const componentName = createComponentName(packageName);
+
+    return `export { default as ${componentName} } from "${packageName}";`;
+  });
+
+  return `${statements.join("\n")}\n`;
+}
+
+function createIndexModuleDestPath(ext) {
+  return path.resolve(BUILD_PATH, `index.${ext}`);
+}
+
+/**
+ * @param {string} scopedPackages
+ */
+async function createIndexModule(scopedPackages) {
+  const data = renderIndexModule(scopedPackages);
+  const dest = createIndexModuleDestPath("es.js");
+
+  return writeFile(dest, data);
+}
+
+/**
+ * @param {string} packageName
+ */
+function createComponentModuleDestPath(packageName, ext) {
+  const moduleName = createModuleName(packageName);
+
+  return path.resolve(BUILD_PATH, `${moduleName}.${ext}`);
+}
+
+/**
+ * @param {Object} scopedPackage
+ * @param {Object} scopedPackage.packageMeta
+ * @param {string[]} scopedPackage.packageExportNames
+ */
+function createComponentModule({ packageMeta, packageExportNames }) {
+  const packageName = packageMeta.name;
+  const moduleExports = packageExportNames.join(", ");
+  const dest = createComponentModuleDestPath(packageName, "es.js");
+  const data = `export { ${moduleExports} } from "${packageName}";\n`;
+
+  return writeFile(dest, data);
+}
+
+/**
+ * @param {string} scopedPackages
+ */
+function getModulePaths(scopedPackages, ext) {
+  return [
+    createIndexModuleDestPath(ext),
+    ...scopedPackages.map(({ packageMeta }) =>
+      createComponentModuleDestPath(packageMeta.name, ext)
+    )
+  ];
+}
+
+/**
+ * @param {string} scopedPackages
+ */
+async function generateModules(scopedPackages) {
+  await Promise.all([
+    createIndexModule(scopedPackages),
+    ...scopedPackages.map(createComponentModule)
+  ]);
+}
+
+/**
+ * @param {string} srcPath
+ */
+async function transformModule(srcPath) {
+  const destPath = srcPath.replace(".es.js", ".js");
+  const bundle = await rollup.rollup({
+    input: srcPath,
+    external: moduleName => moduleName.startsWith("@hig")
+  });
+
+  return bundle.write({
+    file: destPath,
+    format: "cjs",
+    exports: "named"
+  });
+}
+
+/**
+ * @param {Object[]} scopedPackages
+ */
+async function transformModules(scopedPackages) {
+  const paths = getModulePaths(scopedPackages, "es.js");
+  const operations = paths.map(transformModule);
+
+  return Promise.all(operations);
+}
+
+function getStyleSheetPath({ packagePath, packageMeta }) {
+  const { style: filePath } = packageMeta;
+
+  if (!filePath) return null;
+
+  return path.resolve(packagePath, filePath);
+}
+
+/**
+ * @param {Object[]} scopedPackages
+ */
+async function buildIndexStylesheet(scopedPackages) {
+  const readOperations = scopedPackages.map(async scopedPackage => {
+    const styleSheetPath = getStyleSheetPath(scopedPackage);
+
+    if (!styleSheetPath) return "";
+
+    return readFile(styleSheetPath, "utf8");
+  });
+
+  const sources = await Promise.all(readOperations);
+  const input = sources.join("\n");
+  const dest = createIndexModuleDestPath("css");
+  const output = new CleanCss({ level: 2 }).minify(input);
+
+  return writeFile(dest, output.styles);
+}
+
+/**
+ * @param {Object[]} scopedPackages
+ */
+async function copyComponentStylesheets(scopedPackages) {
+  const operations = scopedPackages.map(async scopedPackage => {
+    const srcPath = getStyleSheetPath(scopedPackage);
+
+    if (!srcPath) return undefined;
+
+    const { packageMeta } = scopedPackage;
+    const packageName = packageMeta.name;
+    const destPath = createComponentModuleDestPath(packageName, "css");
+
+    return copyFile(srcPath, destPath);
+  });
+
+  return Promise.all(operations);
+}
+
+async function start() {
+  const { version } = componentsPackageMeta;
+
+  console.log(`Building @hig/components v${version}`);
+
+  const scopedPackages = getScopedPackages();
+
+  await mkdirp(BUILD_PATH);
+  await generateModules(scopedPackages);
+  await transformModules(scopedPackages);
+  await buildIndexStylesheet(scopedPackages);
+  await copyComponentStylesheets(scopedPackages);
+}
+
+start().catch(console.error);

--- a/packages/scripts/buildPackage.js
+++ b/packages/scripts/buildPackage.js
@@ -56,7 +56,8 @@ const esModulesOutputOptions = {
 
 const cjsOutputOptions = {
   file: mainOutputFile,
-  format: "cjs"
+  format: "cjs",
+  exports: "named"
 };
 
 module.exports = async function buildPackage() {
@@ -64,6 +65,8 @@ module.exports = async function buildPackage() {
 
   const bundle = await rollup.rollup(inputOptions);
 
-  bundle.write(esModulesOutputOptions);
-  bundle.write(cjsOutputOptions);
+  return Promise.all([
+    bundle.write(esModulesOutputOptions),
+    bundle.write(cjsOutputOptions)
+  ]);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,12 @@
     classnames "^2.2.5"
     react-lifecycles-compat "^3.0.2"
 
+"@hig/banner@^0.1.0-alpha":
+  version "0.1.0-alpha"
+  resolved "https://registry.yarnpkg.com/@hig/banner/-/banner-0.1.0-alpha.tgz#8fff5de637a9584750eb389c9205ffdba8e9d020"
+  dependencies:
+    hig-react "^0.28.36"
+
 "@storybook/addon-actions@3.4.0", "@storybook/addon-actions@^3.4.0":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-3.4.0.tgz#8f6f869f708856845dff210af9340e54b443f346"
@@ -292,9 +298,17 @@
   version "0.0.38"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.38.tgz#c1be40aa933723c608820a99a373a16d215a1ca2"
 
+"@types/estree@0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+
 "@types/jest@^19.2.3":
   version "19.2.4"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-19.2.4.tgz#543651712535962b7dc615e18e4a381fc2687442"
+
+"@types/node@*":
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.1.2.tgz#1b928a0baa408fc8ae3ac012cc81375addc147c6"
 
 "@types/node@^7.0.21":
   version "7.0.56"
@@ -2604,7 +2618,7 @@ classnames@^2.2.3, classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
-clean-css@4.1.x:
+clean-css@4.1.x, clean-css@^4.1.11:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.11.tgz#2ecdf145aba38f54740f26cefd0ff3e03e125d6a"
   dependencies:
@@ -5806,6 +5820,12 @@ hig-react@0.28.35:
   resolved "https://registry.yarnpkg.com/hig-react/-/hig-react-0.28.35.tgz#20c48dbec466daa085186dc64af8ee807139c746"
   dependencies:
     hig-vanilla "^0.1.25"
+
+hig-react@^0.28.36:
+  version "0.28.36"
+  resolved "https://registry.yarnpkg.com/hig-react/-/hig-react-0.28.36.tgz#8b5b90970d376e76aef0399e54309b69727b4cd3"
+  dependencies:
+    hig-vanilla "^0.1.26"
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -10964,6 +10984,13 @@ rollup@^0.57.1:
     rollup-pluginutils "^2.0.1"
     signal-exit "^3.0.2"
     sourcemap-codec "^1.4.1"
+
+rollup@^0.59.2:
+  version "0.59.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.59.2.tgz#37011ed83947e4e1071b66f9e7d0574b144affc9"
+  dependencies:
+    "@types/estree" "0.0.39"
+    "@types/node" "*"
 
 run-async@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
### Overview

This adds the `@hig/components` package as described in #768 

* No source files exist. The entire package is built from a script, which is configured by the `package.json`. 
* Some packages couldn't be added due to their dependency upon `hig-vanilla`. They can be added once their source is migrated.
* Since each dependency is versioned, we have control over exactly which versions of what components are exported.
* Duplicate styles are merged in the main stylesheet via [Clean CSS](https://www.npmjs.com/package/clean-css#minify-method).

### Usage

#### Import all components and CSS

```jsx
import * as HIG from "@hig/components";
import "@hig/components/build/index.css";

<HIG.Button title="Click Me" />;
```

#### Import a single component

```jsx
import { Button } from "@hig/components";
import "@hig/components/build/button.css";

<Button title="Click Me" />;
```

#### Import a component with component-specific exports

```jsx
import Button, { types } from "@hig/components/build/button";
import "@hig/components/build/button.css";

<Button type={types.PRIMARY} title="Click Me" />;
```

