### PR TITLE
Chores: increment package versions

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.4.0",
+  "lerna": "2.11.0",
   "command": {
     "init": {
       "independent": true

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "archiver": "^2.1.1",
-    "lerna": "^2.9.0",
+    "lerna": "^2.11.0",
     "mkdirp": "^0.5.1",
     "node-fetch": "^1.7.3",
     "registry-url": "^3.1.0"

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -18,14 +18,14 @@
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.10",
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1"
+    "@hig/styles": "^0.1.1",
+    "prop-types": "^15.6.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -15,6 +15,7 @@
   ],
   "dependencies": {
     "classnames": "^2.2.5",
+    "prop-types": "^15.6.1",
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
@@ -24,8 +25,7 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1",
-    "prop-types": "^15.6.1"
+    "@hig/styles": "^0.1.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -28,10 +28,10 @@
     "@hig/eslint-config": "^0.1.0",
     "@hig/rich-text": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1"
+    "@hig/styles": "^0.1.1",
+    "prop-types": "^15.6.1"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.10",
     "react": "^15.4.1 || ^16.3.2"
   },
   "scripts": {

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -20,6 +20,7 @@
     "@hig/themes": "^0.1.0",
     "@hig/typography": "^0.1.0",
     "classnames": "^2.2.5",
+    "prop-types": "^15.6.1",
     "react-lifecycles-compat": "^2.0.0"
   },
   "devDependencies": {
@@ -28,8 +29,7 @@
     "@hig/eslint-config": "^0.1.0",
     "@hig/rich-text": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1",
-    "prop-types": "^15.6.1"
+    "@hig/styles": "^0.1.1"
   },
   "peerDependencies": {
     "react": "^15.4.1 || ^16.3.2"

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -15,15 +15,15 @@
   ],
   "dependencies": {
     "@hig/themes": "^0.1.0",
-    "classnames": "^2.2.5"
+    "classnames": "^2.2.5",
+    "prop-types": "^15.6.1"
   },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/icon": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1",
-    "prop-types": "^15.6.1"
+    "@hig/styles": "^0.1.1"
   },
   "peerDependencies": {
     "react": "^15.4.1 || ^16.3.2"

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -22,10 +22,10 @@
     "@hig/eslint-config": "^0.1.0",
     "@hig/icon": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1"
+    "@hig/styles": "^0.1.1",
+    "prop-types": "^15.6.1"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.10",
     "react": "^15.4.1 || ^16.3.2"
   },
   "scripts": {

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "hig-react": "^0.29.0",
+    "prop-types": "^15.6.1",
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
@@ -25,8 +26,7 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1",
-    "prop-types": "^15.6.1"
+    "@hig/styles": "^0.1.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -19,14 +19,14 @@
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.10",
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1"
+    "@hig/styles": "^0.1.1",
+    "prop-types": "^15.6.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -42,7 +42,6 @@
     "@hig/typography": "^0.1.0"
   },
   "peerDependencies": {
-    "prop-types": "^15.6.1",
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -42,7 +42,7 @@
     "@hig/typography": "^0.1.0"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.10",
+    "prop-types": "^15.6.1",
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "hig-react": "^0.29.0",
+    "prop-types": "^15.6.1",
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
@@ -25,8 +26,7 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1",
-    "prop-types": "^15.6.1"
+    "@hig/styles": "^0.1.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -19,14 +19,14 @@
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.10",
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1"
+    "@hig/styles": "^0.1.1",
+    "prop-types": "^15.6.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/flyout/package.json
+++ b/packages/flyout/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "hig-react": "^0.29.0",
+    "prop-types": "^15.6.1",
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
@@ -25,8 +26,7 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1",
-    "prop-types": "^15.6.1"
+    "@hig/styles": "^0.1.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/flyout/package.json
+++ b/packages/flyout/package.json
@@ -19,14 +19,14 @@
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.10",
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1"
+    "@hig/styles": "^0.1.1",
+    "prop-types": "^15.6.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/icon-button/package.json
+++ b/packages/icon-button/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
+    "@hig/icons": "^0.1.0",
     "@hig/scripts": "^0.1.0",
     "@hig/styles": "^0.1.1",
     "prop-types": "^15.6.1"

--- a/packages/icon-button/package.json
+++ b/packages/icon-button/package.json
@@ -22,10 +22,10 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1"
+    "@hig/styles": "^0.1.1",
+    "prop-types": "^15.6.1"
   },
   "peerDependencies": {
-    "prop-types": "^15.6.1",
     "react": "^15.4.1 || ^16.3.2"
   },
   "scripts": {

--- a/packages/icon-button/package.json
+++ b/packages/icon-button/package.json
@@ -16,15 +16,15 @@
   ],
   "dependencies": {
     "@hig/icon": "^0.1.0",
-    "classnames": "^2.2.5"
+    "classnames": "^2.2.5",
+    "prop-types": "^15.6.1"
   },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/icons": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1",
-    "prop-types": "^15.6.1"
+    "@hig/styles": "^0.1.1"
   },
   "peerDependencies": {
     "react": "^15.4.1 || ^16.3.2"

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -16,14 +16,14 @@
   ],
   "dependencies": {
     "@hig/icons": "^0.1.0",
-    "classnames": "^2.2.5"
+    "classnames": "^2.2.5",
+    "prop-types": "^15.6.1"
   },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1",
-    "prop-types": "^15.6.1"
+    "@hig/styles": "^0.1.1"
   },
   "peerDependencies": {
     "react": "^15.4.1 || ^16.3.2"

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -22,10 +22,10 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1"
+    "@hig/styles": "^0.1.1",
+    "prop-types": "^15.6.1"
   },
   "peerDependencies": {
-    "prop-types": "^15.6.1",
     "react": "^15.4.1 || ^16.3.2"
   },
   "scripts": {

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hig/icon",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "HIG Icon component",
   "author": "Autodesk Inc.",
   "license": "Apache-2.0",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "hig-react": "^0.29.0",
+    "prop-types": "^15.6.1",
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
@@ -25,8 +26,7 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1",
-    "prop-types": "^15.6.1"
+    "@hig/styles": "^0.1.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -19,14 +19,14 @@
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.10",
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1"
+    "@hig/styles": "^0.1.1",
+    "prop-types": "^15.6.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/notifications-flyout/package.json
+++ b/packages/notifications-flyout/package.json
@@ -18,6 +18,7 @@
     "@hig/icon-button": "^0.1.0",
     "@hig/rich-text": "^0.1.0",
     "classnames": "^2.2.5",
+    "prop-types": "^15.6.1",
     "react-transition-group": "^2.3.0"
   },
   "devDependencies": {
@@ -26,8 +27,7 @@
     "@hig/scripts": "^0.1.0",
     "@hig/styles": "^0.1.1",
     "@hig/timestamp": "^0.1.0",
-    "hig-react": "^0.29.0",
-    "prop-types": "^15.6.1"
+    "hig-react": "^0.29.0"
   },
   "peerDependencies": {
     "react": "^15.4.1 || ^16.3.2"

--- a/packages/notifications-flyout/package.json
+++ b/packages/notifications-flyout/package.json
@@ -26,10 +26,10 @@
     "@hig/scripts": "^0.1.0",
     "@hig/styles": "^0.1.1",
     "@hig/timestamp": "^0.1.0",
-    "hig-react": "^0.29.0"
+    "hig-react": "^0.29.0",
+    "prop-types": "^15.6.1"
   },
   "peerDependencies": {
-    "prop-types": "^15.6.1",
     "react": "^15.4.1 || ^16.3.2"
   },
   "scripts": {

--- a/packages/profile-flyout/package.json
+++ b/packages/profile-flyout/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "hig-react": "^0.29.0",
+    "prop-types": "^15.6.1",
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
@@ -25,8 +26,7 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1",
-    "prop-types": "^15.6.1"
+    "@hig/styles": "^0.1.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/profile-flyout/package.json
+++ b/packages/profile-flyout/package.json
@@ -19,14 +19,14 @@
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.10",
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1"
+    "@hig/styles": "^0.1.1",
+    "prop-types": "^15.6.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "hig-react": "^0.29.0",
+    "prop-types": "^15.6.1",
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
@@ -25,8 +26,7 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1",
-    "prop-types": "^15.6.1"
+    "@hig/styles": "^0.1.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -19,14 +19,14 @@
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.10",
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1"
+    "@hig/styles": "^0.1.1",
+    "prop-types": "^15.6.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/progress-ring/package.json
+++ b/packages/progress-ring/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "hig-react": "^0.29.0",
+    "prop-types": "^15.6.1",
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
@@ -25,8 +26,7 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1",
-    "prop-types": "^15.6.1"
+    "@hig/styles": "^0.1.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/progress-ring/package.json
+++ b/packages/progress-ring/package.json
@@ -19,14 +19,14 @@
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.10",
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1"
+    "@hig/styles": "^0.1.1",
+    "prop-types": "^15.6.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/project-account-switcher/package.json
+++ b/packages/project-account-switcher/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "hig-react": "^0.29.0",
+    "prop-types": "^15.6.1",
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
@@ -25,8 +26,7 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1",
-    "prop-types": "^15.6.1"
+    "@hig/styles": "^0.1.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/project-account-switcher/package.json
+++ b/packages/project-account-switcher/package.json
@@ -19,14 +19,14 @@
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.10",
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1"
+    "@hig/styles": "^0.1.1",
+    "prop-types": "^15.6.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/radio-button/package.json
+++ b/packages/radio-button/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "hig-react": "^0.29.0",
+    "prop-types": "^15.6.1",
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
@@ -25,8 +26,7 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1",
-    "prop-types": "^15.6.1"
+    "@hig/styles": "^0.1.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/radio-button/package.json
+++ b/packages/radio-button/package.json
@@ -19,14 +19,14 @@
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.10",
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1"
+    "@hig/styles": "^0.1.1",
+    "prop-types": "^15.6.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -21,10 +21,10 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1"
+    "@hig/styles": "^0.1.1",
+    "prop-types": "^15.6.1"
   },
   "peerDependencies": {
-    "prop-types": "^15.6.1",
     "react": "^15.4.1 || ^16.3.2"
   },
   "scripts": {

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -15,14 +15,14 @@
     "build/*"
   ],
   "dependencies": {
-    "classnames": "^2.2.5"
+    "classnames": "^2.2.5",
+    "prop-types": "^15.6.1"
   },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1",
-    "prop-types": "^15.6.1"
+    "@hig/styles": "^0.1.1"
   },
   "peerDependencies": {
     "react": "^15.4.1 || ^16.3.2"

--- a/packages/side-nav/package.json
+++ b/packages/side-nav/package.json
@@ -25,10 +25,10 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1"
+    "@hig/styles": "^0.1.1",
+    "prop-types": "^15.6.1"
   },
   "peerDependencies": {
-    "prop-types": "^15.6.1",
     "react": "^15.4.1 || ^16.3.2"
   },
   "scripts": {

--- a/packages/side-nav/package.json
+++ b/packages/side-nav/package.json
@@ -19,14 +19,14 @@
     "@hig/icon-button": "^0.1.0",
     "@hig/skeleton-item": "^0.1.0",
     "@hig/themes": "^0.1.0",
-    "classnames": "^2.2.5"
+    "classnames": "^2.2.5",
+    "prop-types": "^15.6.1"
   },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1",
-    "prop-types": "^15.6.1"
+    "@hig/styles": "^0.1.1"
   },
   "peerDependencies": {
     "react": "^15.4.1 || ^16.3.2"

--- a/packages/skeleton-item/package.json
+++ b/packages/skeleton-item/package.json
@@ -16,14 +16,14 @@
   ],
   "dependencies": {
     "@hig/themes": "^0.1.0",
-    "classnames": "^2.2.5"
+    "classnames": "^2.2.5",
+    "prop-types": "^15.6.1"
   },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1",
-    "prop-types": "^15.6.1"
+    "@hig/styles": "^0.1.1"
   },
   "peerDependencies": {
     "react": "^15.4.1 || ^16.3.2"

--- a/packages/skeleton-item/package.json
+++ b/packages/skeleton-item/package.json
@@ -22,10 +22,10 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1"
+    "@hig/styles": "^0.1.1",
+    "prop-types": "^15.6.1"
   },
   "peerDependencies": {
-    "prop-types": "^15.6.1",
     "react": "^15.4.1 || ^16.3.2"
   },
   "scripts": {

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "hig-react": "^0.29.0",
+    "prop-types": "^15.6.1",
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
@@ -25,8 +26,7 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1",
-    "prop-types": "^15.6.1"
+    "@hig/styles": "^0.1.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -19,14 +19,14 @@
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.10",
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1"
+    "@hig/styles": "^0.1.1",
+    "prop-types": "^15.6.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -52,7 +52,6 @@
     "jest-extended": "^0.6.0",
     "json-loader": "^0.5.7",
     "lodash": "^4.17.5",
-    "prop-types": "^15.6.1",
     "raf": "^3.4.0",
     "raw-loader": "^0.5.1",
     "react": "^15.6.2",
@@ -62,7 +61,8 @@
   },
   "dependencies": {
     "@hig/themes": "^0.1.0",
-    "hig-react": "^0.29.0"
+    "hig-react": "^0.29.0",
+    "prop-types": "^15.6.1"
   },
   "eslintConfig": {
     "extends": "@hig"

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -22,7 +22,6 @@
     "react-virtualized": "^9.19.1"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.10",
     "react": "^15.4.1"
   },
   "devDependencies": {
@@ -30,7 +29,8 @@
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
     "@hig/styles": "^0.1.1",
-    "delay": "^2.0.0"
+    "delay": "^2.0.0",
+    "prop-types": "^15.6.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -17,6 +17,7 @@
     "@hig/themes": "^0.1.0",
     "classnames": "^2.2.3",
     "lodash": "^4.17.5",
+    "prop-types": "^15.6.1",
     "react-draggable": "^3.0.5",
     "react-lifecycles-compat": "^3.0.2",
     "react-virtualized": "^9.19.1"
@@ -29,8 +30,7 @@
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
     "@hig/styles": "^0.1.1",
-    "delay": "^2.0.0",
-    "prop-types": "^15.6.1"
+    "delay": "^2.0.0"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "hig-react": "^0.29.0",
+    "prop-types": "^15.6.1",
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
@@ -25,8 +26,7 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1",
-    "prop-types": "^15.6.1"
+    "@hig/styles": "^0.1.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -19,14 +19,14 @@
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.10",
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1"
+    "@hig/styles": "^0.1.1",
+    "prop-types": "^15.6.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -15,7 +15,8 @@
   ],
   "dependencies": {
     "classnames": "^2.2.5",
-    "hig-react": "^0.29.0"
+    "hig-react": "^0.29.0",
+    "prop-types": "^15.6.1"
   },
   "peerDependencies": {
     "react": "^15.4.1 || ^16.3.2"
@@ -24,8 +25,7 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1",
-    "prop-types": "^15.6.1"
+    "@hig/styles": "^0.1.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -18,14 +18,14 @@
     "hig-react": "^0.29.0"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.10",
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1"
+    "@hig/styles": "^0.1.1",
+    "prop-types": "^15.6.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/text-field/package.json
+++ b/packages/text-field/package.json
@@ -17,6 +17,7 @@
     "@hig/icon-button": "^0.1.0",
     "classnames": "^2.2.5",
     "hig-react": "^0.29.0",
+    "prop-types": "^15.6.1",
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
@@ -26,8 +27,7 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1",
-    "prop-types": "^15.6.1"
+    "@hig/styles": "^0.1.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/text-field/package.json
+++ b/packages/text-field/package.json
@@ -20,14 +20,14 @@
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.10",
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1"
+    "@hig/styles": "^0.1.1",
+    "prop-types": "^15.6.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/text-link/package.json
+++ b/packages/text-link/package.json
@@ -19,14 +19,14 @@
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.10",
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1"
+    "@hig/styles": "^0.1.1",
+    "prop-types": "^15.6.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/text-link/package.json
+++ b/packages/text-link/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@hig/themes": "^0.1.0",
     "classnames": "^2.2.5",
+    "prop-types": "^15.6.1",
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
@@ -25,8 +26,7 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1",
-    "prop-types": "^15.6.1"
+    "@hig/styles": "^0.1.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -13,13 +13,15 @@
   "files": [
     "build/*"
   ],
+  "dependencies": {
+    "prop-types": "^15.6.1"
+  },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/banner": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1",
-    "prop-types": "^15.6.1"
+    "@hig/styles": "^0.1.1"
   },
   "peerDependencies": {
     "react": "^15.4.1 || ^16.3.2"

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -18,10 +18,10 @@
     "@hig/banner": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1"
+    "@hig/styles": "^0.1.1",
+    "prop-types": "^15.6.1"
   },
   "peerDependencies": {
-    "prop-types": "^15.6.1",
     "react": "^15.4.1 || ^16.3.2"
   },
   "scripts": {

--- a/packages/timestamp/package.json
+++ b/packages/timestamp/package.json
@@ -15,15 +15,15 @@
     "build/*"
   ],
   "dependencies": {
-    "classnames": "^2.2.5"
+    "classnames": "^2.2.5",
+    "prop-types": "^15.6.1"
   },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
     "@hig/styles": "^0.1.1",
-    "mockdate": "^2.0.2",
-    "prop-types": "^15.6.1"
+    "mockdate": "^2.0.2"
   },
   "peerDependencies": {
     "react": "^15.4.1 || ^16.3.2"

--- a/packages/timestamp/package.json
+++ b/packages/timestamp/package.json
@@ -22,10 +22,10 @@
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
     "@hig/styles": "^0.1.1",
-    "mockdate": "^2.0.2"
+    "mockdate": "^2.0.2",
+    "prop-types": "^15.6.1"
   },
   "peerDependencies": {
-    "prop-types": "^15.6.1",
     "react": "^15.4.1 || ^16.3.2"
   },
   "scripts": {

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "hig-react": "^0.29.0",
+    "prop-types": "^15.6.1",
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
@@ -25,8 +26,7 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1",
-    "prop-types": "^15.6.1"
+    "@hig/styles": "^0.1.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -19,14 +19,14 @@
     "react-lifecycles-compat": "^3.0.2"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.10",
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1"
+    "@hig/styles": "^0.1.1",
+    "prop-types": "^15.6.1"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/top-nav/package.json
+++ b/packages/top-nav/package.json
@@ -27,7 +27,7 @@
     "lint": "eslint src --color --ext .js,.jsx"
   },
   "dependencies": {
-    "@hig/avatar": "^0.1.0-alpha.59de67eb",
+    "@hig/avatar": "^0.1.0",
     "@hig/icon": "^0.1.0",
     "classnames": "^2.2.5",
     "hig-react": "0.28.35",

--- a/packages/top-nav/package.json
+++ b/packages/top-nav/package.json
@@ -17,10 +17,10 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1"
+    "@hig/styles": "^0.1.1",
+    "prop-types": "^15.6.1"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.10",
     "react": "^15.4.1 || ^16.3.2"
   },
   "scripts": {

--- a/packages/top-nav/package.json
+++ b/packages/top-nav/package.json
@@ -17,8 +17,7 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1",
-    "prop-types": "^15.6.1"
+    "@hig/styles": "^0.1.1"
   },
   "peerDependencies": {
     "react": "^15.4.1 || ^16.3.2"
@@ -31,7 +30,8 @@
     "@hig/avatar": "^0.1.0-alpha.59de67eb",
     "@hig/icon": "^0.1.0",
     "classnames": "^2.2.5",
-    "hig-react": "0.28.35"
+    "hig-react": "0.28.35",
+    "prop-types": "^15.6.1"
   },
   "eslintConfig": {
     "extends": "@hig"

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -21,10 +21,10 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1"
+    "@hig/styles": "^0.1.1",
+    "prop-types": "^15.6.1"
   },
   "peerDependencies": {
-    "prop-types": "^15.6.1",
     "react": "^15.4.1 || ^16.3.2"
   },
   "scripts": {

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -15,14 +15,14 @@
     "build/*"
   ],
   "dependencies": {
-    "classnames": "^2.2.5"
+    "classnames": "^2.2.5",
+    "prop-types": "^15.6.1"
   },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.0",
-    "@hig/styles": "^0.1.1",
-    "prop-types": "^15.6.1"
+    "@hig/styles": "^0.1.1"
   },
   "peerDependencies": {
     "react": "^15.4.1 || ^16.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7570,9 +7570,9 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-lerna@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/lerna/-/lerna-2.9.0.tgz#303f70bc50b1c4541bdcf54eda13c36fe54401f3"
+lerna@^2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/lerna/-/lerna-2.11.0.tgz#89b5681e286d388dda5bbbdbbf6b84c8094eff65"
   dependencies:
     async "^1.5.0"
     chalk "^2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,13 +16,6 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@hig/avatar@^0.1.0-alpha.59de67eb":
-  version "0.1.0-alpha.59de67eb"
-  resolved "https://registry.yarnpkg.com/@hig/avatar/-/avatar-0.1.0-alpha.59de67eb.tgz#e9491f84429fe60a84d63af5b1923d00423db7c7"
-  dependencies:
-    classnames "^2.2.5"
-    react-lifecycles-compat "^3.0.2"
-
 "@storybook/addon-actions@3.4.0", "@storybook/addon-actions@^3.4.0":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-3.4.0.tgz#8f6f869f708856845dff210af9340e54b443f346"


### PR DESCRIPTION
* Update Lerna: 2.9.0 to 2.11.0
* Specify PropTypes as a ~dev~ dependency
* Update `@hig/icon`: 0.1.0 to 0.1.1. I unpublished 0.1.0 without fully realizing the effect 😬 .