### PR TITLE
break(table): remove isScrolling & avoid unnecessary re-render of rows

### DIFF
--- a/packages/table/src/Column.js
+++ b/packages/table/src/Column.js
@@ -90,12 +90,12 @@ class Column extends React.Component {
     sortable: PropTypes.bool,
     /**
      * Custom column header renderer
-     * The callback is of the shape of `({ column, columnIndex, isScrolling, rowData, rowIndex, depth }) => *`
+     * The callback is of the shape of `({ column, columnIndex, rowData, rowIndex, depth }) => *`
      */
     renderHeader: PropTypes.func,
     /**
      * Custom column cell renderer
-     * The callback is of the shape of `({ column, columnIndex, isScrolling, rowData, rowIndex, depth }) => *`
+     * The callback is of the shape of `({ column, columnIndex, rowData, rowIndex, depth }) => *`
      */
     renderCell: PropTypes.func
   };

--- a/packages/table/src/GridTable.js
+++ b/packages/table/src/GridTable.js
@@ -4,6 +4,8 @@ import cx from "classnames";
 import Grid from "react-virtualized/dist/commonjs/Grid";
 import { ThemeContext } from "@hig/themes";
 
+import cellRangeRenderer from "./cellRangeRenderer";
+
 /**
  * A wrapper of the Grid for internal only
  */
@@ -158,6 +160,7 @@ class GridTable extends React.PureComponent {
                 columnWidth={headerWidth}
                 columnCount={1}
                 cellRenderer={this.renderHeaderRow}
+                cellRangeRenderer={cellRangeRenderer}
               />
             )}
             <Grid
@@ -174,6 +177,7 @@ class GridTable extends React.PureComponent {
               onScroll={onScroll}
               onSectionRendered={this._handleSectionRendered}
               onScrollbarPresenceChange={onScrollbarPresenceChange}
+              cellRangeRenderer={cellRangeRenderer}
             />
           </div>
         )}

--- a/packages/table/src/Table.js
+++ b/packages/table/src/Table.js
@@ -225,15 +225,7 @@ class Table extends React.Component {
   // endregion
 
   // region Renders
-  renderRow({
-    key,
-    columns,
-    rowData,
-    rowIndex,
-    style,
-    depth = 0,
-    rootIndex
-  }) {
+  renderRow({ key, columns, rowData, rowIndex, style, depth = 0, rootIndex }) {
     const {
       rowClassName,
       rowStyle,

--- a/packages/table/src/Table.js
+++ b/packages/table/src/Table.js
@@ -227,7 +227,6 @@ class Table extends React.Component {
   // region Renders
   renderRow({
     key,
-    isScrolling,
     columns,
     rowData,
     rowIndex,
@@ -250,8 +249,7 @@ class Table extends React.Component {
     const className = cx("hig__table__row", rowClass, {
       [`hig__table__row--depth-${depth}`]: !!expandColumnKey,
       "hig__table__row--expanded": this.state.expandedRowKeys.includes(rowKey),
-      "hig__table__row--hovered":
-        !isScrolling && rowKey === this.state.hoveredRowKey,
+      "hig__table__row--hovered": rowKey === this.state.hoveredRowKey,
       "hig__table__row--frozen":
         depth === 0 && rowIndex < this.props.frozenRowCount,
       "hig__table__row--customized": renderRow
@@ -275,7 +273,6 @@ class Table extends React.Component {
       className,
       style: flattenedStyle,
       columns,
-      isScrolling,
       rowIndex,
       rowData,
       rowKey,
@@ -315,7 +312,6 @@ class Table extends React.Component {
                 style={expandedStyle}
               >
                 {this.props.renderRowExpanded({
-                  isScrolling,
                   columns,
                   rowData,
                   rowIndex
@@ -329,7 +325,6 @@ class Table extends React.Component {
         expandedRows = rowData.children.map((expandData, expandIndex) => {
           const expandRow = this.renderRow({
             key: `${key}-${expandIndex}`,
-            isScrolling,
             columns,
             rowData: expandData,
             rowIndex: expandIndex,
@@ -342,23 +337,10 @@ class Table extends React.Component {
         });
       }
     }
-    if (!React.Fragment) return [row, expandedRows];
-    return (
-      <React.Fragment key={key}>
-        {row}
-        {expandedRows}
-      </React.Fragment>
-    );
+    return [row, expandedRows];
   }
 
-  renderRowCell({
-    column,
-    columnIndex,
-    isScrolling,
-    rowData,
-    rowIndex,
-    expandIcon
-  }) {
+  renderRowCell({ column, columnIndex, rowData, rowIndex, expandIcon }) {
     const { className, dataKey, dataGetter, renderCell } = column;
     const cellData = dataGetter
       ? dataGetter({ column, columnIndex, rowData, rowIndex })
@@ -370,8 +352,7 @@ class Table extends React.Component {
         column,
         columnIndex,
         rowData,
-        rowIndex,
-        isScrolling
+        rowIndex
       })
     ) : (
       <ThemeContext.Consumer>
@@ -409,7 +390,7 @@ class Table extends React.Component {
     );
   }
 
-  renderHeader({ key, isScrolling, columns, style }) {
+  renderHeader({ key, columns, style }) {
     const { headerClassName, headerStyle, renderHeader } = this.props;
 
     const className = cx("hig__table__header-row", headerClassName, {
@@ -428,7 +409,6 @@ class Table extends React.Component {
       className,
       style: flattenedStyle,
       columns,
-      isScrolling,
       expandColumnKey: this.props.expandColumnKey,
       renderHeader,
       renderCell: this.renderHeaderCell,
@@ -438,11 +418,11 @@ class Table extends React.Component {
     return <TableHeader {...headerProps} />;
   }
 
-  renderHeaderCell({ column, columnIndex, isScrolling, expandIcon }) {
+  renderHeaderCell({ column, columnIndex, expandIcon }) {
     const { headerClassName: className, title, renderHeader } = column;
 
     const cell = renderHeader ? (
-      renderHeader({ column, columnIndex, isScrolling })
+      renderHeader({ column, columnIndex })
     ) : (
       <ThemeContext.Consumer>
         {({ themeClass }) => (
@@ -1085,17 +1065,17 @@ Table.propTypes = {
   renderFooter: PropTypes.func,
   /**
    * Custom header renderer
-   * The callback is of the shape of `({ isScrolling, columns }) => *`
+   * The callback is of the shape of `({ columns }) => *`
    */
   renderHeader: PropTypes.func,
   /**
    * Custom row renderer
-   * The callback is of the shape of `({ isScrolling, columns, rowData, rowIndex, depth }) => *`
+   * The callback is of the shape of `({ columns, rowData, rowIndex, depth }) => *`
    */
   renderRow: PropTypes.func,
   /**
    * Custom extra part of the expanded row renderer
-   * The callback is of the shape of `({ isScrolling, columns, rowData, rowIndex }) => *`
+   * The callback is of the shape of `({ columns, rowData, rowIndex }) => *`
    */
   renderRowExpanded: PropTypes.func,
   /**

--- a/packages/table/src/TableHeader.js
+++ b/packages/table/src/TableHeader.js
@@ -6,47 +6,40 @@ import { ThemeContext } from "@hig/themes";
 /**
  * Header component for the Table
  */
-class TableHeader extends React.PureComponent {
-  render() {
-    const {
-      className,
-      style,
-      columns,
-      isScrolling,
-      expandColumnKey,
-      renderHeader,
-      renderCell,
-      expandIcon: ExpandIcon
-    } = this.props;
+const TableHeader = ({
+  className,
+  style,
+  columns,
+  expandColumnKey,
+  renderHeader,
+  renderCell,
+  expandIcon: ExpandIcon
+}) => {
+  const cells = renderHeader
+    ? renderHeader({ columns })
+    : columns.map((column, columnIndex) =>
+        renderCell({
+          column,
+          columnIndex,
+          expandIcon: column.key === expandColumnKey && <ExpandIcon />
+        })
+      );
 
-    const cells = renderHeader
-      ? renderHeader({ isScrolling, columns })
-      : columns.map((column, columnIndex) =>
-          renderCell({
-            column,
-            columnIndex,
-            isScrolling,
-            expandIcon: column.key === expandColumnKey && <ExpandIcon />
-          })
-        );
-
-    return (
-      <ThemeContext.Consumer>
-        {({ themeClass }) => (
-          <div className={cx(className, themeClass)} style={style}>
-            {cells}
-          </div>
-        )}
-      </ThemeContext.Consumer>
-    );
-  }
-}
+  return (
+    <ThemeContext.Consumer>
+      {({ themeClass }) => (
+        <div className={cx(className, themeClass)} style={style}>
+          {cells}
+        </div>
+      )}
+    </ThemeContext.Consumer>
+  );
+};
 
 TableHeader.propTypes = {
   className: PropTypes.string,
   style: PropTypes.object,
   columns: PropTypes.arrayOf(PropTypes.object).isRequired,
-  isScrolling: PropTypes.bool,
   expandColumnKey: PropTypes.string,
   renderHeader: PropTypes.func,
   renderCell: PropTypes.func,

--- a/packages/table/src/TableRow.js
+++ b/packages/table/src/TableRow.js
@@ -2,11 +2,12 @@ import React from "react";
 import PropTypes from "prop-types";
 import { ThemeContext } from "@hig/themes";
 import cx from "classnames";
+import isEqual from "lodash/isEqual";
 
 /**
  * Row component for the Table
  */
-class TableRow extends React.PureComponent {
+class TableRow extends React.Component {
   constructor(props) {
     super(props);
 
@@ -63,11 +64,22 @@ class TableRow extends React.PureComponent {
     return eventHandlers;
   }
 
+  shouldComponentUpdate(nextProps, nextState) {
+    return (
+      nextProps.className !== this.props.className ||
+      !isEqual(nextProps.style, this.props.style) ||
+      nextProps.columns !== this.props.columns ||
+      nextProps.rowData !== this.props.rowData ||
+      nextProps.rowIndex !== this.props.rowIndex ||
+      nextProps.onRowHover !== this.props.onRowHover ||
+      nextProps.rowEventHandlers !== this.props.rowEventHandlers
+    );
+  }
+
   render() {
     const {
       className,
       style,
-      isScrolling,
       columns,
       rowData,
       rowIndex,
@@ -82,12 +94,11 @@ class TableRow extends React.PureComponent {
     } = this.props;
 
     const cells = renderRow
-      ? renderRow({ isScrolling, columns, rowData, rowIndex, depth })
+      ? renderRow({ columns, rowData, rowIndex, depth })
       : columns.map((column, columnIndex) =>
           renderCell({
             column,
             columnIndex,
-            isScrolling,
             rowData,
             rowIndex,
             expandIcon: column.key === expandColumnKey && (
@@ -123,7 +134,6 @@ TableRow.propTypes = {
   className: PropTypes.string,
   style: PropTypes.object,
   columns: PropTypes.arrayOf(PropTypes.object).isRequired,
-  isScrolling: PropTypes.bool,
   rowData: PropTypes.object.isRequired,
   rowIndex: PropTypes.number.isRequired,
   rowKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),

--- a/packages/table/src/cellRangeRenderer.js
+++ b/packages/table/src/cellRangeRenderer.js
@@ -1,0 +1,93 @@
+/**
+ * Default implementation of cellRangeRenderer used by GridTable.
+ * This renderer supports cell-caching while the user is scrolling.
+ * Modified from https://github.com/bvaughn/react-virtualized/blob/master/source/Grid/defaultCellRangeRenderer.js
+ */
+export default function cellRangeRenderer({
+  cellCache,
+  cellRenderer,
+  columnSizeAndPositionManager,
+  isScrolling,
+  parent, // Grid (or List or Table)
+  rowSizeAndPositionManager,
+  rowStartIndex,
+  rowStopIndex,
+  styleCache,
+  verticalOffsetAdjustment
+}) {
+  const renderedCells = [];
+
+  // Browsers have native size limits for elements (eg Chrome 33M pixels, IE 1.5M pixes).
+  // User cannot scroll beyond these size limitations.
+  // In order to work around this, ScalingCellSizeAndPositionManager compresses offsets.
+  // We should never cache styles for compressed offsets though as this can lead to bugs.
+  // See issue #576 for more.
+  const areOffsetsAdjusted =
+    columnSizeAndPositionManager.areOffsetsAdjusted() ||
+    rowSizeAndPositionManager.areOffsetsAdjusted();
+
+  const canCacheStyle = !isScrolling && !areOffsetsAdjusted;
+
+  for (let rowIndex = rowStartIndex; rowIndex <= rowStopIndex; rowIndex++) {
+    const rowDatum = rowSizeAndPositionManager.getSizeAndPositionOfCell(
+      rowIndex
+    );
+
+    const columnIndex = 0;
+    const columnDatum = columnSizeAndPositionManager.getSizeAndPositionOfCell(
+      columnIndex
+    );
+    const key = `${rowIndex}-${columnIndex}`;
+    let style;
+
+    // Cache style objects so shallow-compare doesn't re-render unnecessarily.
+    if (canCacheStyle && styleCache[key]) {
+      style = styleCache[key];
+    } else {
+      style = {
+        height: rowDatum.size,
+        left: 0,
+        position: "absolute",
+        top: rowDatum.offset + verticalOffsetAdjustment,
+        width: columnDatum.size
+      };
+
+      styleCache[key] = style;
+    }
+
+    const cellRendererParams = {
+      columnIndex,
+      key,
+      parent,
+      rowIndex,
+      style
+    };
+
+    let renderedCell;
+
+    // Avoid re-creating cells while scrolling.
+    // This can lead to the same cell being created many times and can cause performance issues for "heavy" cells.
+    // If a scroll is in progress- cache and reuse cells.
+    // This cache will be thrown away once scrolling completes.
+    // However if we are scaling scroll positions and sizes, we should also avoid caching.
+    // This is because the offset changes slightly as scroll position changes and caching leads to stale values.
+    // For more info refer to issue #395
+    if (isScrolling && !verticalOffsetAdjustment) {
+      if (!cellCache[key]) {
+        cellCache[key] = cellRenderer(cellRendererParams);
+      }
+
+      renderedCell = cellCache[key];
+    } else {
+      // If the user is no longer scrolling, don't cache cells.
+      // This makes dynamic cell content difficult for users and would also lead to a heavier memory footprint.
+      renderedCell = cellRenderer(cellRendererParams);
+    }
+
+    if (renderedCell) {
+      renderedCells.push(renderedCell);
+    }
+  }
+
+  return renderedCells;
+}


### PR DESCRIPTION
`isScrolling` is inconsistent when `fixed=true`, as the frozen tables are synced via setting `scrollTop` which won't make `isScrolling` true. And the changing of `isScrolling will lead rows to re-render, we don't use this param in any chance. Perhaps we can introduce it in again in the future, but for now I think we can just remove it

Also we mutated `style` every time, so the rows perform unnecessary re-rendering still, I changed to do a compare to avoid re-rendering if style not changed