### PR TITLE
feat: Prop-driven TextField

### DIFF
--- a/packages/text-field/src/TextField.js
+++ b/packages/text-field/src/TextField.js
@@ -73,6 +73,10 @@ export default class TextField extends Component {
      */
     placeholder: PropTypes.string,
     /**
+     * Marks input as read-only
+     */
+    readOnly: PropTypes.bool,
+    /**
      * Text describing why the field is required
      */
     required: PropTypes.string,
@@ -163,6 +167,7 @@ export default class TextField extends Component {
               name={this.props.name}
               type={this.props.type}
               disabled={this.props.disabled}
+              readOnly={this.props.readOnly}
               placeholder={this.props.placeholder}
               onBlur={this.props.onBlur}
               onFocus={this.props.onFocus}

--- a/packages/text-field/src/TextField.js
+++ b/packages/text-field/src/TextField.js
@@ -82,25 +82,33 @@ export default class TextField extends Component {
      */
     type: PropTypes.string,
     /**
-     * Value of the field
+     * Initial value of the field
      */
     value: PropTypes.string
   };
 
   render() {
+    const {
+      defaultValue,
+      onChange,
+      onClearButtonClick,
+      value: initialValue,
+      ...otherProps
+    } = this.props;
+
     return (
       <TextFieldController
-        defaultValue={this.props.defaultValue}
-        onChange={this.props.onChange}
-        onClearButtonClick={this.props.onClearButtonClick}
-        value={this.props.value}
+        defaultValue={defaultValue}
+        onChange={onChange}
+        onClearButtonClick={onClearButtonClick}
+        value={initialValue}
       >
-        {({ value, onChange, onClearButtonClick }) => (
+        {({ value, handleChange, handleInputClear }) => (
           <TextFieldPresenter
-            {...this.props}
+            {...otherProps}
             value={value}
-            onChange={onChange}
-            onClearButtonClick={onClearButtonClick}
+            onChange={handleChange}
+            onClearButtonClick={handleInputClear}
           />
         )}
       </TextFieldController>

--- a/packages/text-field/src/TextField.js
+++ b/packages/text-field/src/TextField.js
@@ -1,19 +1,12 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import cx from "classnames";
-import IconButton from "@hig/icon-button";
-import Input from "./presenters/Input";
-
-import "./text-field.scss";
-
-function generatedId() {
-  return `text-field-${Math.floor(Math.random() * 100000, 5)}`;
-}
+import TextFieldController from "./TextFieldController";
+import TextFieldPresenter from "./TextFieldPresenter";
 
 export default class TextField extends Component {
   static propTypes = {
     /**
-     * Initial value of the field, user actions will override
+     * Initial value of the field
      */
     defaultValue: PropTypes.string,
     /**
@@ -94,124 +87,23 @@ export default class TextField extends Component {
     value: PropTypes.string
   };
 
-  static defaultProps = {
-    id: generatedId(),
-    type: "text"
-  };
-
-  state = {
-    value: this.props.defaultValue || this.props.value
-  };
-
-  handleChange = event => {
-    this.setState({ value: event.target.value });
-    if (this.props.onChange) this.props.onChange(event);
-  };
-
-  handleInputClear = event => {
-    this.setState({ value: "" });
-    // @TODO: seems we should also trigger the onChange handler?
-    if (this.props.onClearButtonClick) this.props.onClearButtonClick(event);
-  };
-
-  hasClearableInput() {
-    return (
-      this.props.showClearButton &&
-      this.state.value &&
-      this.state.value.length > 0
-    );
-  }
-
-  shouldShowInstructions() {
-    if (this.props.instructions) {
-      if (this.props.errors) {
-        return !this.props.hideInstructionsOnErrors;
-      }
-      return true;
-    }
-
-    return false;
-  }
-
   render() {
-    const hasClearableInput = this.hasClearableInput();
-
     return (
-      <div
-        className={cx("hig__text-field", {
-          "hig__text-field--required": this.props.required,
-          "hig__text-field--clear-button-visible": hasClearableInput
-        })}
+      <TextFieldController
+        defaultValue={this.props.defaultValue}
+        onChange={this.props.onChange}
+        onClearButtonClick={this.props.onClearButtonClick}
+        value={this.props.value}
       >
-        <div
-          className={cx("hig__text-field__content", {
-            "hig__text-field__content--with-icon": this.props.icon
-          })}
-        >
-          <div className="hig__text-field__input-wrapper">
-            {this.props.icon && (
-              <label
-                className={cx("hig__text-field__icon-v1", {
-                  "hig__text-field__icon-v1--disabled": this.props.disabled
-                })}
-                htmlFor={this.props.id}
-              >
-                {this.props.icon}
-              </label>
-            )}
-
-            <Input
-              id={this.props.id}
-              value={this.state.value}
-              onChange={this.handleChange}
-              name={this.props.name}
-              type={this.props.type}
-              disabled={this.props.disabled}
-              readOnly={this.props.readOnly}
-              placeholder={this.props.placeholder}
-              onBlur={this.props.onBlur}
-              onFocus={this.props.onFocus}
-              onInput={this.props.onInput}
-            />
-
-            {this.props.label && (
-              <label
-                htmlFor={this.props.id}
-                className="hig__text-field__label-v1"
-              >
-                {this.props.label}
-              </label>
-            )}
-
-            {hasClearableInput && (
-              <span className="hig__text-field__clear">
-                <IconButton
-                  type="transparent"
-                  icon="clear-small"
-                  title="Clear field"
-                  onClick={this.handleInputClear}
-                />
-              </span>
-            )}
-          </div>
-
-          {this.shouldShowInstructions() && (
-            <p className="hig__text-field__instructions">
-              {this.props.instructions}
-            </p>
-          )}
-
-          {this.props.errors && (
-            <p className="hig__text-field__errors">{this.props.errors}</p>
-          )}
-
-          {this.props.required && (
-            <p className="hig__text-field__required-notice">
-              {this.props.required}
-            </p>
-          )}
-        </div>
-      </div>
+        {({ value, onChange, onClearButtonClick }) => (
+          <TextFieldPresenter
+            {...this.props}
+            value={value}
+            onChange={onChange}
+            onClearButtonClick={onClearButtonClick}
+          />
+        )}
+      </TextFieldController>
     );
   }
 }

--- a/packages/text-field/src/TextFieldController.js
+++ b/packages/text-field/src/TextFieldController.js
@@ -5,7 +5,6 @@ export default class TextFieldController extends Component {
   static propTypes = {
     /**
      * A render prop function
-     *
      */
     children: PropTypes.func,
     /**
@@ -44,8 +43,8 @@ export default class TextFieldController extends Component {
   render() {
     return this.props.children({
       value: this.state.value,
-      onChange: this.handleChange,
-      onClearButtonClick: this.handleInputClear
+      handleChange: this.handleChange,
+      handleInputClear: this.handleInputClear
     });
   }
 }

--- a/packages/text-field/src/TextFieldController.js
+++ b/packages/text-field/src/TextFieldController.js
@@ -1,0 +1,51 @@
+import { Component } from "react";
+import PropTypes from "prop-types";
+
+export default class TextFieldController extends Component {
+  static propTypes = {
+    /**
+     * A render prop function
+     *
+     */
+    children: PropTypes.func,
+    /**
+     * Initial value of the field
+     */
+    defaultValue: PropTypes.string,
+    /**
+     * Called after user changes the value of the field
+     */
+    onChange: PropTypes.func,
+    /**
+     * Called when user clicks the clear button
+     */
+    onClearButtonClick: PropTypes.func,
+    /**
+     * Initial value of the field
+     */
+    value: PropTypes.string
+  };
+
+  state = {
+    value: this.props.defaultValue || this.props.value
+  };
+
+  handleChange = event => {
+    this.setState({ value: event.target.value });
+    if (this.props.onChange) this.props.onChange(event);
+  };
+
+  handleInputClear = event => {
+    this.setState({ value: "" });
+    // @TODO: seems we should also trigger the onChange handler?
+    if (this.props.onClearButtonClick) this.props.onClearButtonClick(event);
+  };
+
+  render() {
+    return this.props.children({
+      value: this.state.value,
+      onChange: this.handleChange,
+      onClearButtonClick: this.handleInputClear
+    });
+  }
+}

--- a/packages/text-field/src/TextFieldPresenter.js
+++ b/packages/text-field/src/TextFieldPresenter.js
@@ -10,7 +10,7 @@ function generatedId() {
   return `text-field-${Math.floor(Math.random() * 100000, 5)}`;
 }
 
-export default class TextField extends Component {
+export default class TextFieldPresenter extends Component {
   static propTypes = {
     /**
      * Prevents user actions on the field

--- a/packages/text-field/src/TextFieldPresenter.js
+++ b/packages/text-field/src/TextFieldPresenter.js
@@ -1,0 +1,198 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import cx from "classnames";
+import IconButton from "@hig/icon-button";
+import Input from "./presenters/Input";
+
+import "./text-field.scss";
+
+function generatedId() {
+  return `text-field-${Math.floor(Math.random() * 100000, 5)}`;
+}
+
+export default class TextField extends Component {
+  static propTypes = {
+    /**
+     * Prevents user actions on the field
+     */
+    disabled: PropTypes.bool,
+    /**
+     * Error text for the field. Setting this value applies error styling to the entire component.
+     */
+    errors: PropTypes.string,
+    /**
+     * When true, displays passed error text. When false, displays instructions with error styling.
+     */
+    hideInstructionsOnErrors: PropTypes.bool,
+    /**
+     * HTML ID attribute
+     */
+    id: PropTypes.string,
+    /**
+     * Icon element that precedes the input.
+     */
+    icon: PropTypes.node,
+    /**
+     * Instructional text for the field
+     */
+    instructions: PropTypes.string,
+    /**
+     * Text describing what the field represents
+     */
+    label: PropTypes.string,
+    /**
+     * Name of the field when submitted with a form
+     */
+    name: PropTypes.string,
+    /**
+     * Called when user moves focus from the field
+     */
+    onBlur: PropTypes.func,
+    /**
+     * Called after user changes the value of the field
+     */
+    onChange: PropTypes.func,
+    /**
+     * Called when user clicks the clear button
+     */
+    onClearButtonClick: PropTypes.func,
+    /**
+     * Called when user puts focus onto the field
+     */
+    onFocus: PropTypes.func,
+    /**
+     * Called as user changes the value of the field
+     */
+    onInput: PropTypes.func,
+    /**
+     * Example of what the user should type into the field
+     */
+    placeholder: PropTypes.string,
+    /**
+     * Marks input as read-only
+     */
+    readOnly: PropTypes.bool,
+    /**
+     * Text describing why the field is required
+     */
+    required: PropTypes.string,
+    /**
+     * When true, causes the clear button to appear
+     */
+    showClearButton: PropTypes.bool,
+    /**
+     * Corresponds to the type attribute of an <input>. Relevant for designating a password field, for example.
+     */
+    type: PropTypes.string,
+    /**
+     * Value of the field
+     */
+    value: PropTypes.string
+  };
+
+  static defaultProps = {
+    id: generatedId(),
+    type: "text"
+  };
+
+  hasClearableInput() {
+    return (
+      this.props.showClearButton &&
+      this.props.value &&
+      this.props.value.length > 0
+    );
+  }
+
+  shouldShowInstructions() {
+    if (this.props.instructions) {
+      if (this.props.errors) {
+        return !this.props.hideInstructionsOnErrors;
+      }
+      return true;
+    }
+
+    return false;
+  }
+
+  render() {
+    const hasClearableInput = this.hasClearableInput();
+
+    return (
+      <div
+        className={cx("hig__text-field", {
+          "hig__text-field--required": this.props.required,
+          "hig__text-field--clear-button-visible": hasClearableInput
+        })}
+      >
+        <div
+          className={cx("hig__text-field__content", {
+            "hig__text-field__content--with-icon": this.props.icon
+          })}
+        >
+          <div className="hig__text-field__input-wrapper">
+            {this.props.icon && (
+              <label
+                className={cx("hig__text-field__icon-v1", {
+                  "hig__text-field__icon-v1--disabled": this.props.disabled
+                })}
+                htmlFor={this.props.id}
+              >
+                {this.props.icon}
+              </label>
+            )}
+
+            <Input
+              id={this.props.id}
+              value={this.props.value}
+              onChange={this.props.onChange}
+              name={this.props.name}
+              type={this.props.type}
+              disabled={this.props.disabled}
+              readOnly={this.props.readOnly}
+              placeholder={this.props.placeholder}
+              onBlur={this.props.onBlur}
+              onFocus={this.props.onFocus}
+              onInput={this.props.onInput}
+            />
+
+            {this.props.label && (
+              <label
+                htmlFor={this.props.id}
+                className="hig__text-field__label-v1"
+              >
+                {this.props.label}
+              </label>
+            )}
+
+            {hasClearableInput && (
+              <span className="hig__text-field__clear">
+                <IconButton
+                  type="transparent"
+                  icon="clear-small"
+                  title="Clear field"
+                  onClick={this.props.onClearButtonClick}
+                />
+              </span>
+            )}
+          </div>
+
+          {this.shouldShowInstructions() && (
+            <p className="hig__text-field__instructions">
+              {this.props.instructions}
+            </p>
+          )}
+
+          {this.props.errors && (
+            <p className="hig__text-field__errors">{this.props.errors}</p>
+          )}
+
+          {this.props.required && (
+            <p className="hig__text-field__required-notice">
+              {this.props.required}
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  }
+}

--- a/packages/text-field/src/__stories__/getKnobs.js
+++ b/packages/text-field/src/__stories__/getKnobs.js
@@ -22,6 +22,7 @@ const knobLabels = {
   onFocus: "onFocus",
   onInput: "onInput",
   placeholder: "Placeholder",
+  readOnly: "Read-only",
   required: "Required",
   showClearButton: "Show Clear Button",
   value: "Value"
@@ -43,6 +44,7 @@ export default function getKnobs(props) {
     onFocus,
     onInput,
     placeholder,
+    readOnly,
     required,
     showClearButton,
     value,
@@ -77,6 +79,7 @@ export default function getKnobs(props) {
     onFocus: action(knobLabels.onFocus),
     onInput: action(knobLabels.onInput),
     placeholder: text(knobLabels.placeholder, placeholder, knobGroupIds.basic),
+    readOnly: boolean(knobLabels.readOnly, readOnly, knobGroupIds.basic),
     required: text(knobLabels.required, required, knobGroupIds.basic),
     showClearButton: boolean(
       knobLabels.showClearButton,

--- a/packages/text-field/src/index.js
+++ b/packages/text-field/src/index.js
@@ -1,1 +1,2 @@
 export { default } from "./TextField";
+export { default as TextFieldPresenter } from "./TextFieldPresenter";

--- a/packages/text-field/src/index.test.js
+++ b/packages/text-field/src/index.test.js
@@ -5,6 +5,10 @@ describe("text-field/index", () => {
     {
       name: "default",
       value: expect.any(Function)
+    },
+    {
+      name: "TextFieldPresenter",
+      value: expect.any(Function)
     }
   ].forEach(({ name, value }) => {
     it(`exports ${name}`, () => {

--- a/packages/text-field/src/presenters/Input.js
+++ b/packages/text-field/src/presenters/Input.js
@@ -39,6 +39,10 @@ export default class Input extends Component {
      */
     placeholder: PropTypes.string,
     /**
+     * Marks input as read-only
+     */
+    readOnly: PropTypes.bool,
+    /**
      * Corresponds to the type attribute of an <input>. Relevant for designating a password field, for example.
      */
     type: PropTypes.string,

--- a/packages/text-field/src/presenters/Input.test.js
+++ b/packages/text-field/src/presenters/Input.test.js
@@ -12,6 +12,18 @@ describe("Input", () => {
     expect(tree).toMatchSnapshot();
   });
 
+  describe("input attributes", () => {
+    it("permits the disabled attribute", () => {
+      wrapper = subject({ disabled: true });
+      expect(wrapper.containsMatchingElement(<input disabled />)).toEqual(true);
+    });
+
+    it("permits the readonly attribute", () => {
+      wrapper = subject({ readOnly: true });
+      expect(wrapper.containsMatchingElement(<input readOnly />)).toEqual(true);
+    });
+  });
+
   describe("event handlers", () => {
     let eventHandler;
 


### PR DESCRIPTION
# Why is this necessary?

The current, single export from `@hig/text-field` is a controlled component. The state of the input's value is encapsulated inside, and changing the value is handled through the change handler, instead of through updates to the value prop.

In refactoring Dropdown, I found I would want to use a `TextField` to implement a combobox-type input. In this component, the state of the input would need to be hoisted up to the Dropdown component, and passed _down_ to a child `TextField`. So, it makes sense for us to provide a component that is completely driven by props -- with state management left as an exercise for the consumer.

# Description

* Support a new `readOnly` prop.
* Split `TextField` into `TextFieldPresenter` and `TextFieldController`. Export `TextFieldPresenter`.