### PR TITLE
Feature: Add components to @hig/components

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -28,6 +28,8 @@
     "@hig/icon-button": "^0.1.1",
     "@hig/icons": "^0.1.0",
     "@hig/modal": "^0.1.1-alpha",
+    "@hig/notifications-flyout": "^0.1.1-alpha",
+    "@hig/notifications-toast": "^0.1.0-alpha",
     "@hig/progress-bar": "^0.1.1-alpha",
     "@hig/progress-ring": "^0.1.1-alpha",
     "@hig/radio-button": "^0.1.1-alpha",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -54,6 +54,7 @@
     "@hig/scripts": "^0.1.0",
     "@hig/semantic-release-config": "^0.1.0",
     "clean-css": "^4.1.11",
+    "esprima": "^4.0.0",
     "mkdirp": "^0.5.1",
     "rollup": "^0.59.2"
   },

--- a/packages/scripts/bin/build.js
+++ b/packages/scripts/bin/build.js
@@ -1,2 +1,5 @@
 #! /usr/bin/env node
-require("@hig/scripts/buildPackage")().catch(console.error);
+require("@hig/scripts/buildPackage")().catch(error => {
+  console.error("Build failed.", error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Chores

### Use Esprima to determine named exports

Instead of importing modules to determine the named exports, the build script now uses Esprima to parse modules, and retrieves the named exports from the AST.

This makes the build system agnostic to the functionality within the modules, making it much more stable and flexible.

### Build script failures

Build scripts now properly exit when errors occur.

## Feature

The following components have been added to `@hig/components`:

* `@hig/notifications-flyout`
* `@hig/notifications-toast`
* ~`@hig/profile-flyout`~
* ~`@hig/project-account-switcher`~