### PR TITLE
fix(style): Add `min-height` property

### DIFF
--- a/packages/top-nav/src/top-nav.scss
+++ b/packages/top-nav/src/top-nav.scss
@@ -12,6 +12,7 @@
   display: flex;
   position: relative;
   height: $top-nav-height;
+  min-height: $top-nav-height;
   padding-left: 7px;
   justify-content: space-between;
   align-items: stretch;


### PR DESCRIPTION
This prevents the TopNav from shrinking when used as a flex element.