### PR TITLE
Fix: Correct external dependency bundling logic

### DIFF
--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1"
   },

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -32,7 +32,7 @@
     "@hig/button": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/rich-text": "^0.1.1",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1"
   },

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -26,7 +26,7 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/icon": "^0.1.1",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1"
   },

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1"
   },

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "clean-css": "^4.1.11",
     "esprima": "^4.0.0",

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1"
   },

--- a/packages/flyout/package.json
+++ b/packages/flyout/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1"
   },

--- a/packages/icon-button/package.json
+++ b/packages/icon-button/package.json
@@ -27,7 +27,7 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
     "@hig/icons": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1"
   },

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1"
   },

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1",
     "svgo": "^1.0.5"

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1"
   },

--- a/packages/notifications-flyout/package.json
+++ b/packages/notifications-flyout/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1",
     "@hig/timestamp": "^0.1.1",

--- a/packages/notifications-toast/package.json
+++ b/packages/notifications-toast/package.json
@@ -29,7 +29,7 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/button": "^0.1.1",
     "@hig/eslint-config": "0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/styles": "^0.1.1"
   },
   "scripts": {

--- a/packages/profile-flyout/package.json
+++ b/packages/profile-flyout/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1"
   },

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1"
   },

--- a/packages/progress-ring/package.json
+++ b/packages/progress-ring/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1"
   },

--- a/packages/project-account-switcher/package.json
+++ b/packages/project-account-switcher/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1"
   },

--- a/packages/radio-button/package.json
+++ b/packages/radio-button/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1"
   },

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1"
   },

--- a/packages/scripts/createExternalDeterminer.js
+++ b/packages/scripts/createExternalDeterminer.js
@@ -9,8 +9,10 @@ module.exports = function createExternalDeterminer(externalDependencies) {
    * @returns {boolean}
    */
   return function external(moduleName) {
-    const packageName = moduleName.split("/").shift();
-
-    return externalDependencies.includes(packageName);
+    return Boolean(
+      externalDependencies.find(dependencyName =>
+        moduleName.startsWith(dependencyName)
+      )
+    );
   };
 };

--- a/packages/scripts/createExternalDeterminer.test.js
+++ b/packages/scripts/createExternalDeterminer.test.js
@@ -1,0 +1,56 @@
+import createExternalDeterminer from "./createExternalDeterminer";
+
+describe("scripts/createExternalDeterminer", () => {
+  const externalDependencies = Object.freeze(["foo", "bar", "@scoped/foo"]);
+
+  it("creates a function", () => {
+    const determiner = createExternalDeterminer(externalDependencies);
+
+    expect(determiner).toEqual(expect.any(Function));
+  });
+
+  describe("determiner", () => {
+    let determiner;
+
+    beforeEach(() => {
+      determiner = createExternalDeterminer(externalDependencies);
+    });
+
+    [
+      {
+        moduleName: "./relative/module/path",
+        isExternal: false
+      },
+      {
+        moduleName: "../parent/directory",
+        isExternal: false
+      },
+      {
+        moduleName: "foo",
+        isExternal: true
+      },
+      {
+        moduleName: "foo/module-random.css",
+        isExternal: true
+      },
+      {
+        moduleName: "dependency/module-random.js",
+        isExternal: false
+      },
+      {
+        moduleName: "@scoped/foo/hello",
+        isExternal: true
+      },
+      {
+        moduleName: "@scoped/foo",
+        isExternal: true
+      }
+    ].forEach(({ moduleName, isExternal }) => {
+      const prediction = isExternal ? "external" : "not external";
+
+      it(`determines that "${moduleName}" is ${prediction}`, () => {
+        expect(determiner(moduleName)).toEqual(isExternal);
+      });
+    });
+  });
+});

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@hig/scripts",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Scripts for HIG React components",
   "main": "index.js",
   "repository": "https://github.com/Autodesk/hig",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -33,5 +33,17 @@
     "rollup-plugin-postcss": "^1.4.1",
     "semantic-release": "^15.5.0",
     "semver": "^5.5.0"
+  },
+  "eslintConfig": {
+    "extends": "@hig"
+  },
+  "babel": {
+    "env": {
+      "test": {
+        "presets": [
+          "@hig/babel-preset/test"
+        ]
+      }
+    }
   }
 }

--- a/packages/semantic-release-config/package.json
+++ b/packages/semantic-release-config/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "lodash.template": "^4.4.0"
   },
   "scripts": {

--- a/packages/side-nav/package.json
+++ b/packages/side-nav/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1"
   },

--- a/packages/skeleton-item/package.json
+++ b/packages/skeleton-item/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1"
   },

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1"
   },

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -25,7 +25,7 @@
     "vanilla-test-serve": "http-server ../vanilla -p 8080"
   },
   "devDependencies": {
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@storybook/addon-actions": "^3.4.0",
     "@storybook/addon-info": "^3.4.0",
     "@storybook/addon-knobs": "^3.4.0",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "mkdirp": "^0.5.1",
     "node-sass": "^4.9.0"

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1",
     "delay": "^2.0.0"

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1"
   },

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1"
   },

--- a/packages/text-field/package.json
+++ b/packages/text-field/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1"
   },

--- a/packages/text-link/package.json
+++ b/packages/text-link/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1"
   },

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -24,7 +24,7 @@
     "@hig/babel-preset": "^0.1.0",
     "@hig/banner": "^0.1.2",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1"
   },

--- a/packages/timestamp/package.json
+++ b/packages/timestamp/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1",
     "mockdate": "^2.0.2"

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1"
   },

--- a/packages/top-nav/package.json
+++ b/packages/top-nav/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1"
   },

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/scripts": "^0.1.0",
+    "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.1.1"
   },


### PR DESCRIPTION
### Overview

The external determiner wasn't doing it's job, and was allowing some external packages to be bundled. This PR fixes the issue, and adds tests to prevent it from happening again. Bumped the version of `@hig/scripts` to trigger a release for each package.