### PR TITLE
Feat: Re-implement Tabs

### DIFF
--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -15,8 +15,8 @@ yarn add @hig/tabs
 ### Import the component and CSS
 
 ```js
-import { Tabs, Tab } from '@hig/tabs';
-import '@hig/tabs/build/index.css';
+import Tabs, { Tab } from "@hig/tabs";
+import "@hig/tabs/build/index.css";
 ```
 
 ## Basic usage

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -18,16 +18,18 @@
     "build/*"
   ],
   "dependencies": {
+    "@hig/typography": "^0.1.2",
     "classnames": "^2.2.5",
-    "hig-react": "^0.29.0",
     "prop-types": "^15.6.1",
-    "react-lifecycles-compat": "^3.0.2"
+    "react-lifecycles-compat": "^3.0.2",
+    "render-fragment": "^0.1.1"
   },
   "peerDependencies": {
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.0",
+    "@hig/button": "^0.1.2",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.1",
     "@hig/semantic-release-config": "^0.1.0",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hig/tabs",
-  "version": "0.1.1-alpha",
+  "version": "0.1.0",
   "description": "HIG Tabs",
   "author": "Autodesk Inc.",
   "license": "Apache-2.0",

--- a/packages/tabs/src/Tab.js
+++ b/packages/tabs/src/Tab.js
@@ -1,6 +1,53 @@
-import { Tab } from "hig-react";
-import "./tab.scss";
+import React from "react";
+import PropTypes from "prop-types";
 
-Tab.displayName = "Tab";
+import TabPresenter from "./presenters/TabPresenter";
 
-export default Tab;
+/**
+ * @typedef {Object} RenderTabPayload
+ * @property {string} key
+ * @property {boolean} [active]
+ * @property {string} [label]
+ * @property {Function} [handleClick]
+ */
+
+/**
+ * @param {RenderTabPayload} props
+ * @returns {JSX.Element}
+ */
+// eslint-disable-next-line react/prop-types
+function renderTab({ handleClick, ...otherProps }) {
+  return <TabPresenter onClick={handleClick} {...otherProps} />;
+}
+
+/**
+ * @typedef {Object} TabProps
+ * @property {boolean} [active]
+ * @property {string} [children]
+ * @property {string} [label]
+ * @property {Function} [onClick]
+ * @property {string} render A render prop allowing for custom tab components to be rendered
+ */
+
+/**
+ * This component is a facade for interfacing with the `Tabs` component.
+ * The logic within the `Tabs` component is strictly separated from the `TabPresenter`.
+ *
+ * @param {TabProps} props
+ * @returns {null}
+ */
+export default function Tab() {
+  return null;
+}
+
+Tab.defaultProps = {
+  render: renderTab
+};
+
+Tab.propTypes = {
+  active: PropTypes.bool,
+  children: PropTypes.node,
+  label: PropTypes.string,
+  onClick: PropTypes.func,
+  render: PropTypes.func.isRequired
+};

--- a/packages/tabs/src/Tabs.js
+++ b/packages/tabs/src/Tabs.js
@@ -1,6 +1,182 @@
-import { Tabs } from "hig-react";
-import "./tabs.scss";
+import React, { Component, Children } from "react";
+import Fragment from "render-fragment";
+import PropTypes from "prop-types";
+import { polyfill } from "react-lifecycles-compat";
 
-Tabs.displayName = "Tabs";
+import { AVAILABLE_ALIGNMENTS, alignments } from "./alignments";
+import TabsPresenter from "./presenters/TabsPresenter";
+import Tab from "./Tab";
 
-export default Tabs;
+const FIRST_TAB_INDEX = 0;
+
+/**
+ * @typedef {import("./Tab").RenderTabPayload} RenderTabPayload
+ */
+
+/**
+ * @typedef {Object} TabMeta
+ * @property {string} key
+ * @property {import("./tab").TabProps} props
+ */
+
+/**
+ * @typedef {Object} TabsProps
+ * @property {string} [align]
+ * @property {ReactNode} [children]
+ */
+
+/**
+ * @typedef {Object} TabsState
+ * @property {number} activeTabIndex
+ */
+
+/**
+ * @param {ReactNode} children
+ * @returns {TabMeta[]}
+ */
+function createTabs(children) {
+  return Children.toArray(children).reduce((result, child) => {
+    const { type, key, props = {} } = child;
+
+    if (type === Tab) {
+      result.push({ key, props });
+    }
+
+    return result;
+  }, []);
+}
+
+class Tabs extends Component {
+  static propTypes = {
+    /**
+     * Specify how to justify the tabs within their container
+     */
+    align: PropTypes.oneOf(AVAILABLE_ALIGNMENTS),
+    /**
+     * Accepts Tab components
+     */
+    children: PropTypes.node,
+    /**
+     * Called when user activates a tab
+     */
+    onTabChange: PropTypes.func
+  };
+
+  /**
+   * @param {TabsProps} nextProps
+   * @param {TabsState} prevState
+   * @returns {TabsState | null}
+   */
+  static getDerivedStateFromProps(nextProps, prevState) {
+    const { children } = nextProps;
+    const nextTabs = createTabs(children);
+    const nextActiveTabIndex = nextTabs.findIndex(({ props }) => props.active);
+    const { activeTabIndex: prevActiveTabIndex } = prevState;
+
+    if (
+      // If no active tab was declared
+      nextActiveTabIndex < 0 ||
+      // If the declared active tab is the same as the current active tab
+      nextActiveTabIndex === prevActiveTabIndex
+    ) {
+      return null;
+    }
+
+    return {
+      activeTabIndex: nextActiveTabIndex
+    };
+  }
+
+  static defaultProps = {
+    align: alignments.CENTER,
+    onTabChange: () => {}
+  };
+
+  /** @type {TabsState} */
+  state = {
+    activeTabIndex: FIRST_TAB_INDEX
+  };
+
+  /** @returns {TabMeta[]} */
+  getTabs() {
+    return createTabs(this.props.children);
+  }
+
+  /** @returns {TabMeta|undefined} */
+  getActiveTab() {
+    const { activeTabIndex } = this.state;
+
+    return this.getTabs()[activeTabIndex];
+  }
+
+  /**
+   * @param {number} nextActiveTabIndex
+   */
+  setActiveTab(nextActiveTabIndex) {
+    const { activeTabIndex: prevActiveTabIndex } = this.state;
+    const { onTabChange } = this.props;
+
+    if (prevActiveTabIndex === nextActiveTabIndex) return;
+
+    onTabChange(nextActiveTabIndex);
+    this.setState({ activeTabIndex: nextActiveTabIndex });
+  }
+
+  /**
+   * @param {number} index
+   * @returns {Function}
+   */
+  createTabClickHandler(index) {
+    return () => {
+      this.setActiveTab(index);
+    };
+  }
+
+  /**
+   * @param {TabMeta} tab
+   * @param {number} index
+   * @returns {JSX.Element}
+   */
+  renderTab = ({ key, props }, index) => {
+    const { render, label } = props;
+    const { activeTabIndex } = this.state;
+    /** @type {RenderTabPayload} */
+    const payload = {
+      key,
+      label,
+      active: activeTabIndex === index,
+      handleClick: this.createTabClickHandler(index)
+    };
+
+    return render(payload);
+  };
+
+  /**
+   * @returns {JSX.Element}
+   */
+  renderTabs() {
+    return (
+      <TabsPresenter align={this.props.align}>
+        {this.getTabs().map(this.renderTab)}
+      </TabsPresenter>
+    );
+  }
+
+  /** @returns {ReactNode} */
+  renderContent() {
+    const activeTab = this.getActiveTab();
+
+    return activeTab ? activeTab.props.children : null;
+  }
+
+  render() {
+    return (
+      <Fragment data-hig="fragment">
+        {this.renderTabs()}
+        {this.renderContent()}
+      </Fragment>
+    );
+  }
+}
+
+export default polyfill(Tabs);

--- a/packages/tabs/src/Tabs.test.js
+++ b/packages/tabs/src/Tabs.test.js
@@ -1,0 +1,27 @@
+import React from "react";
+import renderer from "react-test-renderer";
+
+import Tab from "./Tab";
+import Tabs from "./Tabs";
+import { alignments } from "./alignments";
+
+describe("tabs/Tabs", () => {
+  it("renders tabs", () => {
+    const wrapper = (
+      <Tabs align={alignments.RIGHT}>
+        <Tab label="foo" onClick={() => {}}>
+          bar
+        </Tab>
+        <Tab label="hello" active>
+          world
+        </Tab>
+        <Tab label="boom" render={({ key }) => <button key={key} />}>
+          bang
+        </Tab>
+      </Tabs>
+    );
+    const tree = renderer.create(wrapper).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/tabs/src/__snapshots__/Tabs.test.js.snap
+++ b/packages/tabs/src/__snapshots__/Tabs.test.js.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`tabs/Tabs renders tabs 1`] = `
+<div
+  data-hig="fragment"
+>
+  <ul
+    className="hig__tabs hig__tabs--align-right"
+  >
+    <li
+      className="hig__tabs__tab"
+    >
+      <span
+        className="hig__tabs__tab-label"
+        onClick={[Function]}
+        role="button"
+        tabIndex="0"
+      >
+        foo
+      </span>
+    </li>
+    <li
+      className="hig__tabs__tab hig__tabs__tab--active"
+    >
+      <span
+        className="hig__tabs__tab-label"
+        onClick={[Function]}
+        role="button"
+        tabIndex="0"
+      >
+        hello
+      </span>
+    </li>
+    <button />
+  </ul>
+  world
+</div>
+`;

--- a/packages/tabs/src/__stories__/infoOptions.js
+++ b/packages/tabs/src/__stories__/infoOptions.js
@@ -1,7 +1,7 @@
 import React from "react";
 import RichText from "@hig/rich-text";
 
-import { Tabs, Tab } from "../index";
+import Tabs, { Tab } from "../index";
 import readme from "../../README.md";
 
 export default {

--- a/packages/tabs/src/__stories__/renderStory.js
+++ b/packages/tabs/src/__stories__/renderStory.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { Tabs } from "../index";
+
+import Tabs from "../index";
 import getKnobs from "./getKnobs";
 
 export default function renderStory(props) {

--- a/packages/tabs/src/__stories__/stories.js
+++ b/packages/tabs/src/__stories__/stories.js
@@ -1,12 +1,24 @@
 import React from "react";
 import RichText from "@hig/rich-text";
+import Button, { types } from "@hig/button";
 import { Tab } from "../index";
+
+/* eslint-disable-next-line react/prop-types */
+function renderCustomTab({ key, label, active, handleClick }) {
+  return (
+    <Button
+      key={key}
+      title={label}
+      type={active ? types.PRIMARY : types.SECONDARY}
+      onClick={handleClick}
+    />
+  );
+}
 
 export default [
   {
     description: "default",
     getProps: () => ({
-      align: "center",
       children: [
         <Tab label="Details" key="details">
           <RichText>Details content</RichText>
@@ -15,6 +27,28 @@ export default [
           <RichText>Activities content</RichText>
         </Tab>,
         <Tab label="Inspector" key="inspector">
+          <RichText>Inspector content</RichText>
+        </Tab>
+      ]
+    })
+  },
+  {
+    description: "custom tab",
+    getProps: () => ({
+      align: "center",
+      children: [
+        <Tab label="Details" key="details" render={renderCustomTab}>
+          <RichText>Details content</RichText>
+        </Tab>,
+        <Tab
+          label="Activities"
+          key="activities"
+          render={renderCustomTab}
+          active
+        >
+          <RichText>Activities content</RichText>
+        </Tab>,
+        <Tab label="Inspector" key="inspector" render={renderCustomTab}>
           <RichText>Inspector content</RichText>
         </Tab>
       ]

--- a/packages/tabs/src/alignments.js
+++ b/packages/tabs/src/alignments.js
@@ -4,4 +4,4 @@ export const alignments = Object.freeze({
   RIGHT: "right"
 });
 
-export const availableAlignments = Object.freeze(Object.values(alignments));
+export const AVAILABLE_ALIGNMENTS = Object.freeze(Object.values(alignments));

--- a/packages/tabs/src/alignments.test.js
+++ b/packages/tabs/src/alignments.test.js
@@ -2,7 +2,7 @@ import * as alignments from "./alignments";
 
 describe("tabs/alignments", () => {
   it("has an array of available alignments", () => {
-    expect(alignments).toHavePropertyOfConstants("availableAlignments");
+    expect(alignments).toHavePropertyOfConstants("AVAILABLE_ALIGNMENTS");
   });
 
   it("has constants for alignments", () => {

--- a/packages/tabs/src/index.js
+++ b/packages/tabs/src/index.js
@@ -1,2 +1,5 @@
-export { default as Tabs } from "./Tabs";
+import "@hig/typography/build/index.css";
+
+export { default } from "./Tabs";
 export { default as Tab } from "./Tab";
+export { alignments, AVAILABLE_ALIGNMENTS } from "./alignments";

--- a/packages/tabs/src/index.test.js
+++ b/packages/tabs/src/index.test.js
@@ -3,12 +3,20 @@ import * as index from "./index";
 describe("tabs/index", () => {
   [
     {
-      name: "Tabs",
+      name: "default",
       value: expect.any(Function)
     },
     {
       name: "Tab",
       value: expect.any(Function)
+    },
+    {
+      name: "alignments",
+      value: expect.any(Object)
+    },
+    {
+      name: "AVAILABLE_ALIGNMENTS",
+      value: expect.any(Array)
     }
   ].forEach(({ name, value }) => {
     it(`exports ${name}`, () => {

--- a/packages/tabs/src/presenters/TabPresenter.js
+++ b/packages/tabs/src/presenters/TabPresenter.js
@@ -1,0 +1,41 @@
+import React from "react";
+import cx from "classnames";
+import PropTypes from "prop-types";
+
+import "./TabPresenter.scss";
+
+/**
+ * @typedef {Object} TabPresenterProps
+ * @property {boolean} [active]
+ * @property {string} label
+ * @property {Function} [onClick]
+ */
+
+/**
+ * @param {TabPresenterProps} props
+ * @returns {JSX.Element}
+ */
+export default function TabPresenter({ active, label, onClick }) {
+  const classes = cx("hig__tabs__tab", {
+    "hig__tabs__tab--active": active
+  });
+
+  return (
+    <li className={classes}>
+      <span
+        className="hig__tabs__tab-label"
+        role="button"
+        tabIndex="0"
+        onClick={onClick}
+      >
+        {label}
+      </span>
+    </li>
+  );
+}
+
+TabPresenter.propTypes = {
+  active: PropTypes.bool,
+  label: PropTypes.string,
+  onClick: PropTypes.func
+};

--- a/packages/tabs/src/presenters/TabPresenter.scss
+++ b/packages/tabs/src/presenters/TabPresenter.scss
@@ -1,0 +1,56 @@
+@import '~@hig/styles/mixins/colors.scss';
+@import '~@hig/styles/mixins/spacing.scss';
+@import '~@hig/styles/mixins/typography.scss';
+
+.hig__tabs__tab {
+  @include typography-large;
+  position: relative;
+  display: flex;
+  align-content: center;
+  justify-content: center;
+  padding: 0 spacing(s);
+  margin: 0;
+
+  border-top: 2px solid transparent;
+  cursor: pointer;
+
+  color: color(hig-gray-70);
+  user-select: none;
+  font-weight: 700;
+  text-align: center;
+
+  &:before {
+    position: absolute;
+    content: '';
+    top: 6px;
+    bottom: 8px;
+    left: 0;
+    border-left: 1px solid color(hig-cool-gray-20);
+  }
+
+  &:first-child {
+    padding-left: 0;
+    &:before {
+      border: none;
+    }
+  }
+
+  &:last-child {
+    padding-right: 0;
+  }
+}
+
+.hig__tabs__tab-label {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-bottom: 2px solid transparent;
+}
+
+.hig__tabs__tab--active {
+  .hig__tabs__tab-label {
+    padding: spacing(xxs) 0;
+    color: color(hig-blue-50);
+    border-bottom-color: color(hig-blue-50);
+  }
+}

--- a/packages/tabs/src/presenters/TabPresenter.test.js
+++ b/packages/tabs/src/presenters/TabPresenter.test.js
@@ -1,0 +1,30 @@
+import React from "react";
+import renderer from "react-test-renderer";
+
+import TabPresenter from "./TabPresenter";
+
+describe("tabs/TabPresenter", () => {
+  const cases = [
+    {
+      description: "renders without props",
+      props: {}
+    },
+    {
+      description: "renders with all props",
+      props: {
+        active: true,
+        label: "Hello World",
+        onClick: function handleClick() {}
+      }
+    }
+  ];
+
+  cases.forEach(({ description, props: { children, ...otherProps } }) => {
+    it(description, () => {
+      const wrapper = <TabPresenter {...otherProps}>{children}</TabPresenter>;
+      const tree = renderer.create(wrapper).toJSON();
+
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/tabs/src/presenters/TabsPresenter.js
+++ b/packages/tabs/src/presenters/TabsPresenter.js
@@ -1,0 +1,28 @@
+import React from "react";
+import cx from "classnames";
+import PropTypes from "prop-types";
+
+import { alignments, AVAILABLE_ALIGNMENTS } from "../alignments";
+
+import "./TabsPresenter.scss";
+
+const modifiersByAlignment = {
+  [alignments.LEFT]: "hig__tabs--align-left",
+  [alignments.CENTER]: "hig__tabs--align-center",
+  [alignments.RIGHT]: "hig__tabs--align-right"
+};
+
+export default function TabsPresenter({ align, children }) {
+  const classes = cx("hig__tabs", modifiersByAlignment[align]);
+
+  return <ul className={classes}>{children}</ul>;
+}
+
+TabsPresenter.propTypes = {
+  align: PropTypes.oneOf(AVAILABLE_ALIGNMENTS),
+  children: PropTypes.node
+};
+
+TabsPresenter.defaultProps = {
+  align: alignments.CENTER
+};

--- a/packages/tabs/src/presenters/TabsPresenter.scss
+++ b/packages/tabs/src/presenters/TabsPresenter.scss
@@ -1,0 +1,22 @@
+@import '~@hig/styles/mixins/base.scss';
+@import '~@hig/styles/mixins/spacing.scss';
+
+.hig__tabs {
+  @include reset;
+  flex-grow: 1;
+  display: flex;
+  line-height: 16px;
+  padding: spacing(xxs) 0 spacing(xs) 0;
+  margin: 0;
+}
+
+.hig__tabs--align-center {
+  justify-content: center;
+}
+
+.hig__tabs--align-left {
+  justify-content: flex-start;
+}
+.hig__tabs--align-right {
+  justify-content: flex-end;
+}

--- a/packages/tabs/src/presenters/TabsPresenter.test.js
+++ b/packages/tabs/src/presenters/TabsPresenter.test.js
@@ -1,0 +1,42 @@
+import React from "react";
+import renderer from "react-test-renderer";
+
+import TabsPresenter from "./TabsPresenter";
+import { alignments } from "../alignments";
+
+describe("tabs/TabsPresenter", () => {
+  const cases = [
+    {
+      description: "renders without props",
+      props: {}
+    },
+    {
+      description: "renders with all props",
+      props: {
+        align: alignments.CENTER,
+        children: "Hello World"
+      }
+    },
+    {
+      description: "renders aligned left",
+      props: {
+        align: alignments.LEFT
+      }
+    },
+    {
+      description: "renders aligned right",
+      props: {
+        align: alignments.RIGHT
+      }
+    }
+  ];
+
+  cases.forEach(({ description, props: { children, ...otherProps } }) => {
+    it(description, () => {
+      const wrapper = <TabsPresenter {...otherProps}>{children}</TabsPresenter>;
+      const tree = renderer.create(wrapper).toJSON();
+
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/tabs/src/presenters/__snapshots__/TabPresenter.test.js.snap
+++ b/packages/tabs/src/presenters/__snapshots__/TabPresenter.test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`tabs/TabPresenter renders with all props 1`] = `
+<li
+  className="hig__tabs__tab hig__tabs__tab--active"
+>
+  <span
+    className="hig__tabs__tab-label"
+    onClick={[Function]}
+    role="button"
+    tabIndex="0"
+  >
+    Hello World
+  </span>
+</li>
+`;
+
+exports[`tabs/TabPresenter renders without props 1`] = `
+<li
+  className="hig__tabs__tab"
+>
+  <span
+    className="hig__tabs__tab-label"
+    onClick={undefined}
+    role="button"
+    tabIndex="0"
+  />
+</li>
+`;

--- a/packages/tabs/src/presenters/__snapshots__/TabsPresenter.test.js.snap
+++ b/packages/tabs/src/presenters/__snapshots__/TabsPresenter.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`tabs/TabsPresenter renders aligned left 1`] = `
+<ul
+  className="hig__tabs hig__tabs--align-left"
+/>
+`;
+
+exports[`tabs/TabsPresenter renders aligned right 1`] = `
+<ul
+  className="hig__tabs hig__tabs--align-right"
+/>
+`;
+
+exports[`tabs/TabsPresenter renders with all props 1`] = `
+<ul
+  className="hig__tabs hig__tabs--align-center"
+>
+  Hello World
+</ul>
+`;
+
+exports[`tabs/TabsPresenter renders without props 1`] = `
+<ul
+  className="hig__tabs hig__tabs--align-center"
+/>
+`;

--- a/packages/tabs/src/tab.scss
+++ b/packages/tabs/src/tab.scss
@@ -1,1 +1,0 @@
-@import "~hig-react/lib/hig-react.css";

--- a/packages/tabs/src/tabs.scss
+++ b/packages/tabs/src/tabs.scss
@@ -1,1 +1,0 @@
-@import "~hig-react/lib/hig-react.css";

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,9 +41,28 @@
     react-lifecycles-compat "^3.0.2"
     react-virtualized "^9.19.1"
 
+"@hig/tabs@^0.1.1-alpha":
+  version "0.1.1-alpha"
+  resolved "https://registry.yarnpkg.com/@hig/tabs/-/tabs-0.1.1-alpha.tgz#e92af8b4aebb0451a56b326ebd20c645a33833ef"
+  dependencies:
+    classnames "^2.2.5"
+    hig-react "^0.29.0"
+    prop-types "^15.6.1"
+    react-lifecycles-compat "^3.0.2"
+
 "@hig/text-field@^0.1.1":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@hig/text-field/-/text-field-0.1.1.tgz#ce7b7c3b655c77f069720b612d9a054da30e2295"
+  dependencies:
+    "@hig/icon-button" "^0.1.1"
+    classnames "^2.2.5"
+    hig-react "^0.29.0"
+    prop-types "^15.6.1"
+    react-lifecycles-compat "^3.0.2"
+
+"@hig/text-field@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@hig/text-field/-/text-field-0.2.0.tgz#d34c031606a7fe6d51819555bce18097016d4b04"
   dependencies:
     "@hig/icon-button" "^0.1.1"
     classnames "^2.2.5"
@@ -11465,6 +11484,10 @@ remark@^5.0.1:
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
+
+render-fragment@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/render-fragment/-/render-fragment-0.1.1.tgz#b231f259b7eee333d34256aee0ef3169be7bef30"
 
 renderkid@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
## Overview

* Remove `hig-react` dependency
* Add support for custom tab styling via a render prop on the `Tab` component
* Improve markup to be more semantic
* Use `React.Fragment` for the outer container when supported

## Related

* Resolves #962
* [Storybook](http://hig-feat-tabs-962.surge.sh/?selectedKind=Tabs)
* [CodeSandbox](https://codesandbox.io/s/4xl2q3kkq4) - custom tab rendering