### PR TITLE
Util function to generate IDs for components

### DIFF
--- a/packages/utils/src/generateId.js
+++ b/packages/utils/src/generateId.js
@@ -1,0 +1,8 @@
+/**
+ * Generates a unique ID
+ * @param {string} key
+ * @returns {string} A generated id
+ */
+export default function generateId(key) {
+  return `${key}-${Math.floor(Math.random() * 100000, 5)}`;
+}

--- a/packages/utils/src/generateId.test.js
+++ b/packages/utils/src/generateId.test.js
@@ -1,0 +1,16 @@
+import generateId from "./generateId";
+
+describe("utils/generateId", () => {
+  it("returns a string", () => {
+    expect(generateId("key")).toEqual(expect.any(String));
+  });
+
+  it("last token is a number", () => {
+    const id = generateId("key");
+    const tokens = id.split("-");
+    const lastToken = tokens[tokens.length - 1];
+    const number = Number.parseInt(lastToken, 10);
+
+    expect(number).toBeGreaterThan(0);
+  });
+});

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -1,2 +1,3 @@
 /* eslint-disable import/prefer-default-export */
 export { default as combineEventHandlers } from "./combineEventHandlers";
+export { default as generateId } from "./generateId";

--- a/packages/utils/src/index.test.js
+++ b/packages/utils/src/index.test.js
@@ -4,4 +4,7 @@ describe("utils/index", () => {
   it(`exports combineEventHandlers`, () => {
     expect(index).toHaveProperty("combineEventHandlers", expect.any(Function));
   });
+  it(`exports generateId`, () => {
+    expect(index).toHaveProperty("generateId", expect.any(Function));
+  });
 });


### PR DESCRIPTION
Having component presenters generate their own HTML ids has created difficulty in enzyme snapshot testing. The ID is random and is generated on each render

This branch extracts the logic that's used by the pure React checkbox component (https://github.com/Autodesk/hig/pull/1025) to generate its ID into a new `utils` module `utils/generateId`

This branch doesn't implement the function - will roll it out in the above Checkbox branch as well as Radio Button in https://github.com/Autodesk/hig/pull/1043