### PR TITLE
Use shared id generator to generate checkbox HTML id

### DIFF
--- a/packages/checkbox/__mocks__/@hig/utils.js
+++ b/packages/checkbox/__mocks__/@hig/utils.js
@@ -1,0 +1,7 @@
+function generateIdMock(key) {
+  return "checkbox-1";
+}
+
+exports = module.exports = {
+  generateId: jest.fn(generateIdMock)
+};

--- a/packages/checkbox/src/CheckboxPresenter/CheckboxPresenter.js
+++ b/packages/checkbox/src/CheckboxPresenter/CheckboxPresenter.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
+import { generateId } from "@hig/utils";
 import CheckPresenter from "../CheckPresenter/CheckPresenter";
 
 import "./CheckboxPresenter.scss";
@@ -95,12 +96,12 @@ export default class CheckboxPresenter extends Component {
       }
     ]);
 
-    const ID = `checkbox-${Math.floor(Math.random() * 100000, 5)}`;
+    const id = generateId("checkbox");
 
     return (
       <div className={wrapperClasses}>
         <input
-          id={ID}
+          id={id}
           checked={checked}
           className="hig__checkbox__input"
           disabled={disabled}
@@ -118,7 +119,7 @@ export default class CheckboxPresenter extends Component {
           disabled={disabled}
           indeterminate={indeterminate}
         />
-        <label htmlFor={ID} className={labelClasses}>
+        <label htmlFor={id} className={labelClasses}>
           {label}
         </label>
       </div>

--- a/packages/checkbox/src/CheckboxPresenter/CheckboxPresenter.test.js
+++ b/packages/checkbox/src/CheckboxPresenter/CheckboxPresenter.test.js
@@ -1,8 +1,13 @@
 import React from "react";
 import renderer from "react-test-renderer";
+import { generateId } from "@hig/utils";
 import CheckboxPresenter from "./CheckboxPresenter";
 
 describe("Checkbox/CheckboxPresenter/CheckboxPresenter", () => {
+  afterEach(() => {
+    generateId.mockReset();
+  });
+
   [
     {
       description: "renders without props",
@@ -13,7 +18,6 @@ describe("Checkbox/CheckboxPresenter/CheckboxPresenter", () => {
       props: {
         checked: true,
         disabled: true,
-        id: "id",
         indeterminate: false,
         label: "HELLO",
         name: "checkbox",

--- a/packages/checkbox/src/CheckboxPresenter/__snapshots__/CheckboxPresenter.test.js.snap
+++ b/packages/checkbox/src/CheckboxPresenter/__snapshots__/CheckboxPresenter.test.js.snap
@@ -8,13 +8,14 @@ exports[`Checkbox/CheckboxPresenter/CheckboxPresenter renders with all props 1`]
     checked={true}
     className="hig__checkbox__input"
     disabled={true}
-    id="checkbox-86089"
+    id={undefined}
     name="checkbox"
     onBlur={[Function]}
     onChange={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
     type="checkbox"
+    value="value"
   />
   <span
     className="hig__checkbox__wrapper hig__checkbox__wrapper--checked hig__checkbox__wrapper--disabled"
@@ -46,7 +47,7 @@ exports[`Checkbox/CheckboxPresenter/CheckboxPresenter renders with all props 1`]
   </span>
   <label
     className="hig__checkbox__label"
-    htmlFor="checkbox-86089"
+    htmlFor={undefined}
   >
     HELLO
   </label>
@@ -61,13 +62,14 @@ exports[`Checkbox/CheckboxPresenter/CheckboxPresenter renders without props 1`] 
     checked={false}
     className="hig__checkbox__input"
     disabled={false}
-    id="checkbox-9606"
+    id="checkbox-1"
     name="checkbox"
     onBlur={undefined}
     onChange={undefined}
     onClick={undefined}
     onFocus={undefined}
     type="checkbox"
+    value="value"
   />
   <span
     className="hig__checkbox__wrapper"
@@ -99,7 +101,7 @@ exports[`Checkbox/CheckboxPresenter/CheckboxPresenter renders without props 1`] 
   </span>
   <label
     className="hig__checkbox__label"
-    htmlFor="checkbox-9606"
+    htmlFor="checkbox-1"
   />
 </div>
 `;

--- a/packages/checkbox/src/__snapshots__/Checkbox.test.js.snap
+++ b/packages/checkbox/src/__snapshots__/Checkbox.test.js.snap
@@ -8,13 +8,14 @@ exports[`Checkbox integration renders correctly 1`] = `
     checked={true}
     className="hig__checkbox__input"
     disabled={false}
-    id="checkbox-15600"
+    id="checkbox-1"
     name="checkbox"
     onBlur={undefined}
     onChange={[Function]}
     onClick={undefined}
     onFocus={undefined}
     type="checkbox"
+    value="value"
   />
   <span
     className="hig__checkbox__wrapper hig__checkbox__wrapper--checked"
@@ -46,7 +47,7 @@ exports[`Checkbox integration renders correctly 1`] = `
   </span>
   <label
     className="hig__checkbox__label"
-    htmlFor="checkbox-15600"
+    htmlFor="checkbox-1"
   >
     HIG Checkbox
   </label>


### PR DESCRIPTION
Currently, there's no way to mock the checkbox HTML id when doing Enzyme snapshot testing.  

This branch updates to use the shared `@hig/utils/generateId` function to generate that ID. 
 Additionally, it adds a Jest mock for that function in the `CheckboxPresenter` test