### PR TITLE
Feat: cleanup slider for release

### DIFF
--- a/packages/dropdown/src/__stories__/getKnobs.js
+++ b/packages/dropdown/src/__stories__/getKnobs.js
@@ -1,5 +1,6 @@
 import { action } from "@storybook/addon-actions";
 import { boolean, object, text } from "@storybook/addon-knobs/react";
+import { controlledObject } from "@hig/storybook/utils";
 
 const knobGroupIds = {
   basic: "Basic",
@@ -38,10 +39,10 @@ export default function getKnobs(props) {
    * We're using `text` instead of `object` so that we can provide `undefined`
    * when an empty string is given.
    */
-  const valueText = text(knobLabels.value, value, knobGroupIds.advanced);
 
   return {
     ...otherProps,
+    value: controlledObject(knobLabels.value, value, knobGroupIds.advanced),
     label: text(knobLabels.label, label, knobGroupIds.basic),
     instructions: text(
       knobLabels.instructions,
@@ -56,7 +57,6 @@ export default function getKnobs(props) {
     onChange: action(knobLabels.onChange),
     onClickOutside: action(knobLabels.onClickOutside),
     onFocus: action(knobLabels.onFocus),
-    options: object(knobLabels.options, options, knobGroupIds.basic),
-    value: valueText ? JSON.parse(valueText) : undefined
+    options: object(knobLabels.options, options, knobGroupIds.basic)
   };
 }

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hig/slider",
-  "version": "0.1.1-alpha",
+  "version": "0.1.0",
   "description": "HIG Slider",
   "author": "Autodesk Inc.",
   "license": "Apache-2.0",

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -18,6 +18,7 @@
     "build/*"
   ],
   "dependencies": {
+    "@hig/utils": "^0.1.0",
     "classnames": "^2.2.5",
     "prop-types": "^15.6.1"
   },

--- a/packages/slider/src/Slider.js
+++ b/packages/slider/src/Slider.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import cx from "classnames";
 import { generateId } from "@hig/utils";
 
+import Input from "./presenters/Input";
 import "./slider.scss";
 
 export default class Slider extends Component {
@@ -70,19 +71,59 @@ export default class Slider extends Component {
   };
 
   static defaultProps = {
-    id: generatedId(),
+    defaultValue: "",
+    id: generateId("slider"),
     min: "0",
     max: "100",
     step: "1"
   };
 
+  /**
+   * @type {Object}
+   * @property {string|number} value
+   */
   state = {
-    value: this.props.defaultValue || this.props.value
+    value: this.props.defaultValue
   };
 
+  /**
+   * @returns {string|number}
+   */
+  getValue() {
+    if (this.isControlled()) {
+      return this.props.value;
+    }
+
+    return this.state.value;
+  }
+
+  /**
+   * @returns {boolean}
+   */
+  isControlled() {
+    return this.props.value !== undefined;
+  }
+
+  /**
+   * @param {string|number} value
+   */
+  updateValue(value) {
+    const { onChange } = this.props;
+
+    if (onChange) {
+      onChange(value);
+    }
+
+    this.setState({ value });
+  }
+
+  /**
+   * @param {event} Event
+   */
   handleChange = event => {
-    this.setState({ value: event.target.value });
-    if (this.props.onChange) this.props.onChange(event);
+    if (!this.isControlled()) {
+      this.updateValue(event.target.value);
+    }
   };
 
   render() {
@@ -100,7 +141,7 @@ export default class Slider extends Component {
       onFocus,
       onInput
     } = this.props;
-    const { value } = this.state;
+    const value = this.getValue();
 
     return (
       <div

--- a/packages/slider/src/Slider.js
+++ b/packages/slider/src/Slider.js
@@ -111,7 +111,7 @@ export default class Slider extends Component {
     const { onChange } = this.props;
 
     if (onChange) {
-      onChange(value);
+      onChange(Number(value));
     }
 
     this.setState({ value });

--- a/packages/slider/src/Slider.js
+++ b/packages/slider/src/Slider.js
@@ -1,13 +1,9 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
-import Input from "./presenters/Input";
+import { generateId } from "@hig/utils";
 
 import "./slider.scss";
-
-function generatedId() {
-  return `slider-${Math.floor(Math.random() * 100000, 5)}`;
-}
 
 export default class Slider extends Component {
   static propTypes = {

--- a/packages/slider/src/Slider.test.js
+++ b/packages/slider/src/Slider.test.js
@@ -3,23 +3,14 @@ import { mount } from "enzyme";
 import Slider from "./index";
 import Input from "./presenters/Input";
 
-describe("Slider", () => {
+describe("slider/Slider", () => {
   it("allows value to be changed by onChange", () => {
-    const wrapper = mount(<Slider value="10" />);
+    const wrapper = mount(<Slider defaultValue="10" />);
     const input = wrapper.find("input");
 
     expect(input.prop("value")).toEqual("10");
     input.simulate("change", { target: { value: "20" } });
     expect(input.prop("value")).toEqual("20");
-  });
-
-  it("ignores changes to the value prop", () => {
-    const wrapper = mount(<Slider value="10" />);
-    const input = wrapper.find("input");
-
-    expect(input.prop("value")).toEqual("10");
-    wrapper.setProps({ value: "20" });
-    expect(input.prop("value")).toEqual("10");
   });
 
   describe("id", () => {
@@ -62,5 +53,25 @@ describe("Slider", () => {
     const requiredMsg = "You must provide your age.";
     const wrapper = mount(<Slider required={requiredMsg} />);
     expect(wrapper.text()).toEqual(expect.stringMatching(requiredMsg));
+  });
+
+  describe("when controlled", () => {
+    it("doesn't allow the value to be changed by onChange", () => {
+      const wrapper = mount(<Slider value="10" />);
+      const input = wrapper.find("input");
+
+      expect(input.prop("value")).toEqual("10");
+      input.simulate("change", { target: { value: "20" } });
+      expect(input.prop("value")).toEqual("10");
+    });
+
+    it("recognizes changes to the value prop", () => {
+      const wrapper = mount(<Slider value="10" />);
+      const input = wrapper.find("input");
+
+      expect(input.prop("value")).toEqual("10");
+      wrapper.setProps({ value: "20" });
+      expect(input.prop("value")).toEqual("20");
+    });
   });
 });

--- a/packages/slider/src/__stories__/getKnobs.js
+++ b/packages/slider/src/__stories__/getKnobs.js
@@ -1,5 +1,6 @@
 import { action } from "@storybook/addon-actions";
 import { boolean, number, text } from "@storybook/addon-knobs/react";
+import { controlledText } from "@hig/storybook/utils";
 
 const knobGroupIds = {
   basic: "Basic",
@@ -58,6 +59,6 @@ export default function getKnobs(props) {
     onInput: action(knobLabels.onInput),
     required: text(knobLabels.required, required, knobGroupIds.basic),
     step: number(knobLabels.step, step, knobGroupIds.basic),
-    value: text(knobLabels.value, value, knobGroupIds.form)
+    value: controlledText(knobLabels.value, value, knobGroupIds.form)
   };
 }

--- a/packages/storybook/utils/controlledObject.js
+++ b/packages/storybook/utils/controlledObject.js
@@ -1,0 +1,14 @@
+import { text } from "@storybook/addon-knobs/react";
+
+/**
+ * Knob for controlled JSON props
+ * @param {string} label
+ * @param {string|undefined} defaultValue
+ * @param {string} group
+ * @returns {string|undefined}
+ */
+export default function controlledObject(label, defaultValue, group) {
+  const result = text(label, defaultValue, group);
+
+  return result ? JSON.parse(result) : undefined;
+}

--- a/packages/storybook/utils/controlledText.js
+++ b/packages/storybook/utils/controlledText.js
@@ -1,0 +1,14 @@
+import { text } from "@storybook/addon-knobs/react";
+
+/**
+ * Knob for controlled string props
+ * @param {string} label
+ * @param {string|undefined} defaultValue
+ * @param {string} group
+ * @returns {string|undefined}
+ */
+export default function controlledText(label, defaultValue, group) {
+  const result = text(label, defaultValue, group);
+
+  return result || undefined;
+}

--- a/packages/storybook/utils/index.js
+++ b/packages/storybook/utils/index.js
@@ -1,3 +1,5 @@
 export { default as controlledBool } from "./controlledBool";
+export { default as controlledObject } from "./controlledObject";
+export { default as controlledText } from "./controlledText";
 export { default as makeSelectOptions } from "./makeSelectOptions";
 export { default as translate } from "./translate";


### PR DESCRIPTION
## Overview

The Slider component was migrated from vanilla (was called Range before), but was never published. This corrects the controlled behavior and prepares `@hig/slider` for release.