### PR TITLE
Chore/flyout sizes 957

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,9 @@ nohup.out
 # VS Code
 .vscode/
 
+# Intellij
+.idea/
+
 # compiled build stuff
 build/
 storybook-static/

--- a/packages/flyout/src/Flyout.js
+++ b/packages/flyout/src/Flyout.js
@@ -24,7 +24,9 @@ class Flyout extends Component {
     /** Function called when the flyout panel is scrolled */
     onScroll: PropTypes.func,
     /** When provided, it overrides the flyout's open state */
-    open: PropTypes.bool
+    open: PropTypes.bool,
+    /** Width of the flyout content with one of the supported modifiers */
+    size: PropTypes.oneOf(Object.freeze(["small", "medium", "large"])),
   };
 
   static defaultProps = {
@@ -142,7 +144,7 @@ class Flyout extends Component {
   }
 
   createPresenterProps(transitionStatus) {
-    const { content, maxHeight, onScroll } = this.props;
+    const { content, maxHeight, onScroll, size } = this.props;
     const { refContainer, refPanel, refAction, refWrapper } = this;
     const {
       anchorPoint,
@@ -156,6 +158,7 @@ class Flyout extends Component {
       leftOffset,
       content,
       maxHeight,
+      size,
       refAction,
       refContainer,
       refPanel,

--- a/packages/flyout/src/Flyout.js
+++ b/packages/flyout/src/Flyout.js
@@ -26,7 +26,7 @@ class Flyout extends Component {
     /** When provided, it overrides the flyout's open state */
     open: PropTypes.bool,
     /** Width of the flyout content with one of the supported modifiers */
-    size: PropTypes.oneOf(Object.freeze(["small", "medium", "large"])),
+    size: PropTypes.oneOf(Object.freeze(["small", "medium", "large"]))
   };
 
   static defaultProps = {

--- a/packages/flyout/src/Flyout.test.js
+++ b/packages/flyout/src/Flyout.test.js
@@ -1,9 +1,18 @@
 import React from "react";
 import renderer from "react-test-renderer";
+import PropTypes from "prop-types";
 import Button from "@hig/button";
 
 import { anchorPoints } from "./anchorPoints";
 import Flyout from "./Flyout";
+
+const FakeComponent = ({ handleClick }) => (
+  <Button onClick={handleClick} title="Render prop" />
+);
+
+FakeComponent.propTypes = {
+  handleClick: PropTypes.func
+};
 
 describe("flyout/Flyout", () => {
   [
@@ -26,9 +35,7 @@ describe("flyout/Flyout", () => {
     {
       description: "renders children from the given render function",
       props: {
-        children: ({ handleClick }) => (
-          <Button onClick={handleClick} title="Render prop" />
-        )
+        children: FakeComponent
       }
     }
   ].forEach(({ description, props: { children, ...otherProps } }) => {

--- a/packages/flyout/src/FlyoutPresenter/FlyoutPresenter.js
+++ b/packages/flyout/src/FlyoutPresenter/FlyoutPresenter.js
@@ -38,6 +38,7 @@ export default function FlyoutPresenter(props) {
     anchorPoint,
     content,
     maxHeight,
+    size,
     topOffset,
     leftOffset,
     refAction,
@@ -69,7 +70,7 @@ export default function FlyoutPresenter(props) {
       >
         <div className="hig__flyout-v1__chevron" />
         <div
-          className="hig__flyout-v1__panel"
+          className={cx("hig__flyout-v1__panel", { [`hig__flyout-v1__panel--${size}`]: !!size })}
           ref={refPanel}
           style={panelStyle}
           onScroll={onScroll}

--- a/packages/flyout/src/FlyoutPresenter/FlyoutPresenter.js
+++ b/packages/flyout/src/FlyoutPresenter/FlyoutPresenter.js
@@ -70,7 +70,9 @@ export default function FlyoutPresenter(props) {
       >
         <div className="hig__flyout-v1__chevron" />
         <div
-          className={cx("hig__flyout-v1__panel", { [`hig__flyout-v1__panel--${size}`]: !!size })}
+          className={cx("hig__flyout-v1__panel", {
+            [`hig__flyout-v1__panel--${size}`]: !!size
+          })}
           ref={refPanel}
           style={panelStyle}
           onScroll={onScroll}
@@ -108,6 +110,8 @@ FlyoutPresenter.propTypes = {
   refWrapper: PropTypes.func,
   /** Function called when the flyout panel is scrolled */
   onScroll: PropTypes.func,
+  /** Width of the flyout content with one of the supported modifiers */
+  size: PropTypes.oneOf(Object.freeze(["small", "medium", "large"])),
   /** The status of the container transition */
   transitionStatus: PropTypes.oneOf(availableTransitionStatuses).isRequired,
   /** Target component to open the flyout */

--- a/packages/flyout/src/FlyoutPresenter/FlyoutPresenter.test.js
+++ b/packages/flyout/src/FlyoutPresenter/FlyoutPresenter.test.js
@@ -35,7 +35,7 @@ describe("flyout/FlyoutPresenter/FlyoutPresenter", () => {
         anchorPoint: anchorPoints.TOP_CENTER,
         content: "World",
         maxHeight: 150,
-        size: 'medium',
+        size: "medium",
         topOffset: 42,
         leftOffset: 42,
         refAction: function refAction() {},

--- a/packages/flyout/src/FlyoutPresenter/FlyoutPresenter.test.js
+++ b/packages/flyout/src/FlyoutPresenter/FlyoutPresenter.test.js
@@ -13,11 +13,29 @@ describe("flyout/FlyoutPresenter/FlyoutPresenter", () => {
       props: {}
     },
     {
+      description: "renders without size prop",
+      props: {
+        anchorPoint: anchorPoints.TOP_CENTER,
+        content: "World",
+        maxHeight: 150,
+        topOffset: 42,
+        leftOffset: 42,
+        refAction: function refAction() {},
+        refContainer: function refContainer() {},
+        refPanel: function refPanel() {},
+        refWrapper: function refWrapper() {},
+        onScroll: function onScroll() {},
+        transitionStatus: ENTERED,
+        children: <Button title="Hello" />
+      }
+    },
+    {
       description: "renders with all props",
       props: {
         anchorPoint: anchorPoints.TOP_CENTER,
         content: "World",
         maxHeight: 150,
+        size: 'medium',
         topOffset: 42,
         leftOffset: 42,
         refAction: function refAction() {},

--- a/packages/flyout/src/FlyoutPresenter/__snapshots__/FlyoutPresenter.test.js.snap
+++ b/packages/flyout/src/FlyoutPresenter/__snapshots__/FlyoutPresenter.test.js.snap
@@ -34,7 +34,7 @@ exports[`flyout/FlyoutPresenter/FlyoutPresenter renders with all props 1`] = `
       className="hig__flyout-v1__chevron"
     />
     <div
-      className="hig__flyout-v1__panel"
+      className="hig__flyout-v1__panel hig__flyout-v1__panel--medium"
       onScroll={[Function]}
       style={
         Object {
@@ -76,6 +76,54 @@ exports[`flyout/FlyoutPresenter/FlyoutPresenter renders without props 1`] = `
         }
       }
     />
+  </div>
+</div>
+`;
+
+exports[`flyout/FlyoutPresenter/FlyoutPresenter renders without size prop 1`] = `
+<div
+  className="hig__flyout-v1 hig__flyout-v1--top-center"
+>
+  <div
+    className="hig__flyout-v1__action"
+  >
+    <button
+      className="hig--light-theme hig__button-v1 hig__button-v1--size-standard hig__button-v1--type-primary hig__button-v1--width-shrink"
+      onBlur={undefined}
+      onClick={undefined}
+      onFocus={undefined}
+      onMouseOver={undefined}
+    >
+      <span
+        className="hig__button__title"
+      >
+        Hello
+      </span>
+    </button>
+  </div>
+  <div
+    className="hig__flyout-v1__container"
+    style={
+      Object {
+        "left": 42,
+        "top": 42,
+      }
+    }
+  >
+    <div
+      className="hig__flyout-v1__chevron"
+    />
+    <div
+      className="hig__flyout-v1__panel"
+      onScroll={[Function]}
+      style={
+        Object {
+          "maxHeight": 150,
+        }
+      }
+    >
+      World
+    </div>
   </div>
 </div>
 `;

--- a/packages/flyout/src/FlyoutPresenter/flyout.scss
+++ b/packages/flyout/src/FlyoutPresenter/flyout.scss
@@ -90,6 +90,16 @@
   border: $panel-border-width solid color(hig-cool-gray-20);
   background-color: $panel-background-color;
   border-radius: $panel-border-radius;
+
+  &.hig__flyout-v1__panel--small {
+    width: 200px;
+  }
+  &.hig__flyout-v1__panel--medium {
+    width: 300px;
+  }
+  &.hig__flyout-v1__panel--large {
+    width: 400px;
+  }
 }
 
 .hig__flyout-v1__chevron {

--- a/packages/react/src/elements/components/Flyout.test.js
+++ b/packages/react/src/elements/components/Flyout.test.js
@@ -11,6 +11,13 @@ describe("<Flyout />", () => {
     });
   });
 
+  describe("with a width", () => {
+    it("passes width", () => {
+      const wrapper = shallow(<Flyout width="small" />);
+      expect(wrapper.find(FlyoutAdapter)).toHaveProp("width", "small");
+    });
+  });
+
   describe("toggleFlyout", () => {
     it("alternates between opening and closing the FlyoutAdapter", () => {
       const wrapper = shallow(<Flyout />);

--- a/packages/scripts/bin/lint.sh
+++ b/packages/scripts/bin/lint.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-eslint src --color --ext .js,.jsx
+eslint src --color --ext .js,.jsx --fix

--- a/packages/scripts/bin/test.sh
+++ b/packages/scripts/bin/test.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-jest
+jest $@


### PR DESCRIPTION
Adds small: `200px`, medium: `300px`, and large: `400px` enums for the `size` prop of `Flyout` to allow for fixed width flyouts.