### PR TITLE
Suppress ref check error to account for new validation in Downshift 2.0.20

### DIFF
--- a/packages/dropdown/src/Dropdown.js
+++ b/packages/dropdown/src/Dropdown.js
@@ -183,7 +183,14 @@ export default class Dropdown extends Component {
       selectedItem,
       selectedItems
     } = downshift;
-    const menuProps = getMenuProps({ isOpen });
+    const menuProps = getMenuProps(
+      {
+        isOpen
+      },
+      {
+        suppressRefError: true
+      }
+    );
     const { multiple, options, formatOption } = this.props;
     const children = renderOptions({
       multiple,


### PR DESCRIPTION
Story: https://github.com/Autodesk/hig/issues/1067

Downshift 2.0.20 altered the arguments for *getMenuProps* which we utilize in Dropdown.  The method now requires that a ref be passed in, or that the check be suppressed.  Since it appears that we're not currently utilizing refs in the Dropdown, we've opted for the latter

w/ @wmui51 