### PR TITLE
Add optional text entry to Dropdown

### DIFF
--- a/packages/dropdown/src/Dropdown.test.js
+++ b/packages/dropdown/src/Dropdown.test.js
@@ -120,6 +120,14 @@ describe("Dropdown", () => {
       }
     },
     {
+      desc: "renders with text entry",
+      props: {
+        options,
+        hasTextEntry: true,
+        onTextEntryChange: () => {}
+      }
+    },
+    {
       desc: "renders with multiple selection",
       props: {
         options,

--- a/packages/dropdown/src/__snapshots__/Dropdown.test.js.snap
+++ b/packages/dropdown/src/__snapshots__/Dropdown.test.js.snap
@@ -206,7 +206,7 @@ exports[`Dropdown renders with a controlled value 1`] = `
 <div
   aria-expanded={false}
   aria-haspopup="listbox"
-  aria-labelledby="downshift-9-label"
+  aria-labelledby="downshift-10-label"
   aria-owns={null}
   className="hig__dropdown"
   role="combobox"
@@ -230,11 +230,11 @@ exports[`Dropdown renders with a controlled value 1`] = `
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls={null}
-              aria-labelledby="downshift-9-label"
+              aria-labelledby="downshift-10-label"
               autoComplete="off"
               className="hig__text-field-v1__input"
               disabled={undefined}
-              id="downshift-9"
+              id="downshift-10"
               onBlur={[Function]}
               onChange={[Function]}
               onClick={[Function]}
@@ -263,15 +263,15 @@ exports[`Dropdown renders with a controlled value 1`] = `
     </span>
   </div>
   <div
-    aria-labelledby="downshift-9-label"
+    aria-labelledby="downshift-10-label"
     className="hig__dropdown-v1__menu"
-    id="downshift-9-menu"
+    id="downshift-10-menu"
     role="listbox"
   >
     <div
       aria-selected={false}
       className="hig__dropdown-option"
-      id="downshift-9-item-0"
+      id="downshift-10-item-0"
       onClick={[Function]}
       onMouseDown={[Function]}
       onMouseMove={[Function]}
@@ -286,7 +286,7 @@ exports[`Dropdown renders with a controlled value 1`] = `
     <div
       aria-selected={false}
       className="hig__dropdown-option"
-      id="downshift-9-item-1"
+      id="downshift-10-item-1"
       onClick={[Function]}
       onMouseDown={[Function]}
       onMouseMove={[Function]}
@@ -301,7 +301,7 @@ exports[`Dropdown renders with a controlled value 1`] = `
     <div
       aria-selected={true}
       className="hig__dropdown-option hig__dropdown-option--selected"
-      id="downshift-9-item-2"
+      id="downshift-10-item-2"
       onClick={[Function]}
       onMouseDown={[Function]}
       onMouseMove={[Function]}
@@ -741,7 +741,7 @@ exports[`Dropdown renders with multiple selection 1`] = `
 <div
   aria-expanded={false}
   aria-haspopup="listbox"
-  aria-labelledby="downshift-8-label"
+  aria-labelledby="downshift-9-label"
   aria-owns={null}
   className="hig__dropdown"
   role="combobox"
@@ -765,11 +765,11 @@ exports[`Dropdown renders with multiple selection 1`] = `
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls={null}
-              aria-labelledby="downshift-8-label"
+              aria-labelledby="downshift-9-label"
               autoComplete="off"
               className="hig__text-field-v1__input hig__text-field-v1__input--no-value"
               disabled={undefined}
-              id="downshift-8"
+              id="downshift-9"
               onBlur={[Function]}
               onChange={[Function]}
               onClick={[Function]}
@@ -798,15 +798,15 @@ exports[`Dropdown renders with multiple selection 1`] = `
     </span>
   </div>
   <div
-    aria-labelledby="downshift-8-label"
+    aria-labelledby="downshift-9-label"
     className="hig__dropdown-v1__menu"
-    id="downshift-8-menu"
+    id="downshift-9-menu"
     role="listbox"
   >
     <div
       aria-selected={false}
       className="hig__dropdown-option"
-      id="downshift-8-item-0"
+      id="downshift-9-item-0"
       onClick={[Function]}
       onMouseDown={[Function]}
       onMouseMove={[Function]}
@@ -821,7 +821,7 @@ exports[`Dropdown renders with multiple selection 1`] = `
     <div
       aria-selected={false}
       className="hig__dropdown-option"
-      id="downshift-8-item-1"
+      id="downshift-9-item-1"
       onClick={[Function]}
       onMouseDown={[Function]}
       onMouseMove={[Function]}
@@ -836,7 +836,7 @@ exports[`Dropdown renders with multiple selection 1`] = `
     <div
       aria-selected={false}
       className="hig__dropdown-option"
-      id="downshift-8-item-2"
+      id="downshift-9-item-2"
       onClick={[Function]}
       onMouseDown={[Function]}
       onMouseMove={[Function]}
@@ -856,7 +856,7 @@ exports[`Dropdown renders with multiple selection and a controlled value 1`] = `
 <div
   aria-expanded={false}
   aria-haspopup="listbox"
-  aria-labelledby="downshift-10-label"
+  aria-labelledby="downshift-11-label"
   aria-owns={null}
   className="hig__dropdown"
   role="combobox"
@@ -880,11 +880,11 @@ exports[`Dropdown renders with multiple selection and a controlled value 1`] = `
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls={null}
-              aria-labelledby="downshift-10-label"
+              aria-labelledby="downshift-11-label"
               autoComplete="off"
               className="hig__text-field-v1__input"
               disabled={undefined}
-              id="downshift-10"
+              id="downshift-11"
               onBlur={[Function]}
               onChange={[Function]}
               onClick={[Function]}
@@ -913,15 +913,15 @@ exports[`Dropdown renders with multiple selection and a controlled value 1`] = `
     </span>
   </div>
   <div
-    aria-labelledby="downshift-10-label"
+    aria-labelledby="downshift-11-label"
     className="hig__dropdown-v1__menu"
-    id="downshift-10-menu"
+    id="downshift-11-menu"
     role="listbox"
   >
     <div
       aria-selected={false}
       className="hig__dropdown-option hig__dropdown-option--selected"
-      id="downshift-10-item-0"
+      id="downshift-11-item-0"
       onClick={[Function]}
       onMouseDown={[Function]}
       onMouseMove={[Function]}
@@ -948,7 +948,7 @@ exports[`Dropdown renders with multiple selection and a controlled value 1`] = `
     <div
       aria-selected={false}
       className="hig__dropdown-option"
-      id="downshift-10-item-1"
+      id="downshift-11-item-1"
       onClick={[Function]}
       onMouseDown={[Function]}
       onMouseMove={[Function]}
@@ -963,7 +963,7 @@ exports[`Dropdown renders with multiple selection and a controlled value 1`] = `
     <div
       aria-selected={false}
       className="hig__dropdown-option hig__dropdown-option--selected"
-      id="downshift-10-item-2"
+      id="downshift-11-item-2"
       onClick={[Function]}
       onMouseDown={[Function]}
       onMouseMove={[Function]}
@@ -1313,6 +1313,120 @@ exports[`Dropdown renders with option specific, general and format rendering 1`]
     </div>
     <div>
       BLUE
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Dropdown renders with text entry 1`] = `
+<div
+  aria-expanded={false}
+  aria-haspopup="listbox"
+  aria-labelledby="downshift-8-label"
+  aria-owns={null}
+  className="hig__dropdown"
+  role="combobox"
+>
+  <div
+    className="hig__dropdown__input-wrapper"
+  >
+    <div
+      className="hig__text-field-v1"
+    >
+      <div
+        className="hig__text-field-v1__content"
+      >
+        <div
+          className="hig__text-field-v1__input-wrapper"
+        >
+          <div
+            className="hig__text-field-v1__input-row"
+          >
+            <input
+              aria-activedescendant={null}
+              aria-autocomplete="list"
+              aria-controls={null}
+              aria-labelledby="downshift-8-label"
+              autoComplete="off"
+              className="hig__text-field-v1__input hig__text-field-v1__input--no-value"
+              disabled={undefined}
+              id="downshift-8"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              placeholder={undefined}
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <span
+      className="hig__dropdown__input-caret"
+    >
+      <div
+        className="hig__icon hig__icon--24-size"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "<svg width=\\"10\\" height=\\"6\\" viewBox=\\"0 0 10 6\\" xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" title=\\"caret-24\\"><polyline transform=\\"rotate(45 9.828 3)\\" points=\\"8 2 8 8 2 8\\" stroke=\\"#2E4258\\" stroke-width=\\"1.15\\" fill=\\"none\\" fill-rule=\\"evenodd\\" stroke-linecap=\\"round\\" stroke-linejoin=\\"round\\"/></svg>",
+          }
+        }
+      />
+    </span>
+  </div>
+  <div
+    aria-labelledby="downshift-8-label"
+    className="hig__dropdown-v1__menu"
+    id="downshift-8-menu"
+    role="listbox"
+  >
+    <div
+      aria-selected={false}
+      className="hig__dropdown-option"
+      id="downshift-8-item-0"
+      onClick={[Function]}
+      onMouseDown={[Function]}
+      onMouseMove={[Function]}
+      role="option"
+    >
+      <span
+        className="hig__dropdown-option__label"
+      >
+        bar
+      </span>
+    </div>
+    <div
+      aria-selected={false}
+      className="hig__dropdown-option"
+      id="downshift-8-item-1"
+      onClick={[Function]}
+      onMouseDown={[Function]}
+      onMouseMove={[Function]}
+      role="option"
+    >
+      <span
+        className="hig__dropdown-option__label"
+      >
+        baz
+      </span>
+    </div>
+    <div
+      aria-selected={false}
+      className="hig__dropdown-option"
+      id="downshift-8-item-2"
+      onClick={[Function]}
+      onMouseDown={[Function]}
+      onMouseMove={[Function]}
+      role="option"
+    >
+      <span
+        className="hig__dropdown-option__label"
+      >
+        foo
+      </span>
     </div>
   </div>
 </div>

--- a/packages/dropdown/src/__stories__/getKnobs.js
+++ b/packages/dropdown/src/__stories__/getKnobs.js
@@ -9,6 +9,7 @@ const knobGroupIds = {
 
 const knobLabels = {
   label: "Label",
+  hasTextEntry: "Has Text Entry",
   instructions: "Instructions",
   placeholder: "Placeholder",
   disabled: "Disabled",
@@ -18,6 +19,7 @@ const knobLabels = {
   onChange: "onChange",
   onClickOutside: "onClickOutside",
   onFocus: "onFocus",
+  onTextEntryChange: "onTextEntryChange",
   options: "Options",
   value: "Value"
 };
@@ -25,6 +27,7 @@ const knobLabels = {
 export default function getKnobs(props) {
   const {
     label = "",
+    hasTextEntry = false,
     instructions = "",
     placeholder = "",
     disabled = false,
@@ -52,11 +55,17 @@ export default function getKnobs(props) {
     placeholder: text(knobLabels.placeholder, placeholder, knobGroupIds.basic),
     disabled: boolean(knobLabels.disabled, disabled, knobGroupIds.basic),
     required: text(knobLabels.required, required, knobGroupIds.basic),
+    hasTextEntry: boolean(
+      knobLabels.hasTextEntry,
+      hasTextEntry,
+      knobGroupIds.basic
+    ),
     multiple: boolean(knobLabels.multiple, multiple, knobGroupIds.basic),
     onBlur: action(knobLabels.onBlur),
     onChange: action(knobLabels.onChange),
     onClickOutside: action(knobLabels.onClickOutside),
     onFocus: action(knobLabels.onFocus),
+    onTextEntryChange: action(knobLabels.onTextEntryChange),
     options: object(knobLabels.options, options, knobGroupIds.basic)
   };
 }

--- a/packages/dropdown/src/__stories__/stories.js
+++ b/packages/dropdown/src/__stories__/stories.js
@@ -2,10 +2,10 @@ export default [
   {
     description: "default",
     getProps: () => ({
-      label: "HIG Theme",
       instructions: "Choose one HIG theme to apply to your entire app.",
-      placeholder: "Select a theme",
-      options: ["HIG Light Theme", "HIG Dark Blue Theme", "Matrix Theme"]
+      label: "HIG Theme",
+      options: ["HIG Light Theme", "HIG Dark Blue Theme", "Matrix Theme"],
+      placeholder: "Select a theme"
     })
   }
 ];

--- a/packages/dropdown/src/behaviors/TextInputBehavior.js
+++ b/packages/dropdown/src/behaviors/TextInputBehavior.js
@@ -1,0 +1,67 @@
+import { Component } from "react";
+import PropTypes from "prop-types";
+
+/**
+ * @typedef {Object} TextInputBehaviorPayload
+ * @property {string} value
+ * @property {function(UIEvent): void} handleChange
+ * @property {function(): void} clear
+ */
+
+export default class TextInputBehavior extends Component {
+  static propTypes = {
+    /**
+     * Render prop
+     */
+    children: PropTypes.func,
+    /**
+     * Initial value of the field
+     */
+    defaultValue: PropTypes.string,
+    /**
+     * Called after user changes the value of the field
+     */
+    onChange: PropTypes.func,
+    /**
+     * Initial value of the field
+     */
+    value: PropTypes.string
+  };
+
+  state = {
+    value: this.props.defaultValue || ""
+  };
+
+  getValue() {
+    if (this.isControlled()) {
+      return this.props.value;
+    }
+
+    return this.state.value;
+  }
+
+  setValue(value) {
+    this.setState({ value });
+  }
+
+  handleChange = event => {
+    const { onChange } = this.props;
+
+    if (onChange) {
+      onChange(event);
+    }
+
+    this.setValue(this.isControlled() ? this.props.value : event.target.value);
+  };
+
+  isControlled() {
+    return this.props.value !== undefined;
+  }
+
+  render() {
+    return this.props.children({
+      value: this.getValue(),
+      handleChange: this.handleChange
+    });
+  }
+}

--- a/packages/dropdown/src/behaviors/TextInputBehavior.test.js
+++ b/packages/dropdown/src/behaviors/TextInputBehavior.test.js
@@ -1,0 +1,17 @@
+import React from "react";
+import { mount } from "enzyme";
+import TextInputBehavior from "./TextInputBehavior";
+
+describe("Dropdown/behaviors/TextInputBehavior", () => {
+  it("renders children", () => {
+    const renderMock = jest.fn(({ handleChange, value }) => (
+      <input onChange={handleChange} value={value} />
+    ));
+    mount(<TextInputBehavior value="test">{renderMock}</TextInputBehavior>);
+
+    expect(renderMock).toHaveBeenCalledWith({
+      handleChange: expect.any(Function),
+      value: "test"
+    });
+  });
+});

--- a/packages/dropdown/src/presenters/InputPresenter.js
+++ b/packages/dropdown/src/presenters/InputPresenter.js
@@ -1,27 +1,112 @@
-import React from "react";
+import React, { Component } from "react";
 import Icon from "@hig/icon";
-import { TextFieldPresenter } from "@hig/text-field";
+import TextFieldPresenter from "@hig/text-field";
 import "@hig/icon/build/index.css";
 import "@hig/text-field/build/index.css";
+import PropTypes from "prop-types";
 
 import "./InputPresenter.scss";
 
-export default function InputPresenter(props) {
-  return (
-    <div className="hig__dropdown__input-wrapper">
-      <TextFieldPresenter {...props} type="button" readOnly />
-      <span className="hig__dropdown__input-caret">
-        {/* @TODO: there are variations of the TextField with multiple icons at the end of the input. These icon nodes should be passed as props to TextField. */}
-        <Icon name="caret" />
-      </span>
-    </div>
-  );
+export default class InputPresenter extends Component {
+  static propTypes = {
+    /**
+     * Prevents user actions on the field
+     */
+    disabled: PropTypes.bool,
+    /**
+     * Error text for the field. Setting this value applies error styling to the entire component.
+     */
+    errors: PropTypes.string,
+    /**
+     * Allows managing field's focus via prop. Setting this value overrides the internal focus state management.
+     */
+    focused: PropTypes.bool,
+    /**
+     * Prevents user actions on the field
+     */
+    hasTextEntry: PropTypes.bool,
+    /**
+     * When true, displays passed error text. When false, displays instructions with error styling.
+     */
+    hideInstructionsOnErrors: PropTypes.bool,
+    /**
+     * HTML ID attribute
+     */
+    id: PropTypes.string,
+    /**
+     * Icon element that precedes the input.
+     */
+    icon: PropTypes.node,
+    /**
+     * Instructional text for the field
+     */
+    instructions: PropTypes.string,
+    /**
+     * Text describing what the field represents
+     */
+    label: PropTypes.string,
+    /**
+     * Name of the field when submitted with a form
+     */
+    name: PropTypes.string,
+    /**
+     * Called when user moves focus from the field
+     */
+    onBlur: PropTypes.func,
+    /**
+     * Called after user changes the value of the field
+     */
+    onChange: PropTypes.func,
+    /**
+     * Called when user clicks the clear button
+     */
+    onClearButtonClick: PropTypes.func,
+    /**
+     * Called when user puts focus onto the field
+     */
+    onFocus: PropTypes.func,
+    /**
+     * Called as user changes the value of the field
+     */
+    onInput: PropTypes.func,
+    /**
+     * Example of what the user should type into the field
+     */
+    placeholder: PropTypes.string,
+    /**
+     * Text describing why the field is required
+     */
+    required: PropTypes.string,
+    /**
+     * When true, causes the clear button to appear
+     */
+    showClearButton: PropTypes.bool,
+    /**
+     * Value of the field
+     */
+    value: PropTypes.string
+  };
+
+  render() {
+    let textFieldPresenter;
+    const { hasTextEntry, ...inputProps } = this.props;
+
+    if (hasTextEntry) {
+      textFieldPresenter = <TextFieldPresenter {...inputProps} type="text" />;
+    } else {
+      textFieldPresenter = (
+        <TextFieldPresenter {...inputProps} type="button" readOnly />
+      );
+    }
+
+    return (
+      <div className="hig__dropdown__input-wrapper">
+        {textFieldPresenter}
+        <span className="hig__dropdown__input-caret">
+          {/* @TODO: there are variations of the TextField with multiple icons at the end of the input. These icon nodes should be passed as props to TextField. */}
+          <Icon name="caret" />
+        </span>
+      </div>
+    );
+  }
 }
-
-function createPropTypes() {
-  const { type, readOnly, ...otherPropTypes } = TextFieldPresenter.propTypes;
-
-  return otherPropTypes;
-}
-
-InputPresenter.propTypes = createPropTypes();

--- a/packages/dropdown/src/presenters/InputPresenter.test.js
+++ b/packages/dropdown/src/presenters/InputPresenter.test.js
@@ -24,8 +24,10 @@ describe("Dropdown/presenters/InputPresenter", () => {
         disabled: true,
         required: "this is required",
         onBlur: () => {},
+        onChange: () => {},
         onFocus: () => {},
-        onClick: () => {}
+        onClick: () => {},
+        value: "the selected item's value"
       }
     }
   ];

--- a/packages/dropdown/src/presenters/__snapshots__/InputPresenter.test.js.snap
+++ b/packages/dropdown/src/presenters/__snapshots__/InputPresenter.test.js.snap
@@ -17,7 +17,7 @@ exports[`Dropdown/presenters/InputPresenter renders with all props (that dropdow
           className="hig__text-field-v1__label-spacer"
         />
         <label
-          className="hig__text-field-v1__label hig__text-field-v1__label--required"
+          className="hig__text-field-v1__label hig__text-field-v1__label--required hig__text-field-v1__label--with-value"
           htmlFor="id"
         >
           label
@@ -26,15 +26,17 @@ exports[`Dropdown/presenters/InputPresenter renders with all props (that dropdow
           className="hig__text-field-v1__input-row"
         >
           <input
-            className="hig__text-field-v1__input hig__text-field-v1__input--no-value"
+            className="hig__text-field-v1__input"
             disabled={true}
             id="id"
             onBlur={[Function]}
+            onChange={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
             placeholder="placeholder"
             readOnly={true}
             type="button"
+            value="the selected item's value"
           />
         </div>
       </div>
@@ -85,9 +87,11 @@ exports[`Dropdown/presenters/InputPresenter renders without props 1`] = `
             className="hig__text-field-v1__input hig__text-field-v1__input--no-value"
             id="text-field-1"
             onBlur={[Function]}
+            onChange={[Function]}
             onFocus={[Function]}
             readOnly={true}
             type="button"
+            value=""
           />
         </div>
       </div>


### PR DESCRIPTION
Issue: https://github.com/Autodesk/hig/issues/1073
Storybook: http://dreary-rub.surge.sh

Adds optional text entry to dropdown for custom filters and other functionality

To accomplish this, the following props are added to dropdown:

* **hasTextEntry** (bool): Enables user to focus and type into the dropdown text field
* **onTextEntryChange** (func): Called when user types into the dropdown text field
