### PR TITLE
fix: prevent setting invalid props in Dropdown

### DIFF
--- a/packages/dropdown/src/Dropdown.test.js
+++ b/packages/dropdown/src/Dropdown.test.js
@@ -11,35 +11,40 @@ describe("Dropdown", () => {
   };
   const options = Object.keys(i18n).sort();
 
-  const optionSpecificRender = optionProps => {
-    const optionBackgroundColor = props => {
-      if (props.selected) {
-        return "blue";
-      }
-      if (props.highlighted) {
-        return "light-blue";
-      }
-      return "white";
-    };
+  function getOptionBackgroundColor(props) {
+    if (props.selected) {
+      return "blue";
+    }
+    if (props.highlighted) {
+      return "light-blue";
+    }
+    return "white";
+  }
 
+  function renderCustomOption(props) {
     return (
       <div
+        key={props.label}
         style={{
           padding: "2px 4px",
-          backgroundColor: optionBackgroundColor(optionProps)
+          backgroundColor: getOptionBackgroundColor(props)
         }}
       >
         <div
           style={{
-            backgroundColor: optionProps.value,
+            backgroundColor: props.value,
             width: "32px",
             height: "24px"
           }}
         />
-        <p>{optionProps.label}</p>
+        <p>{props.label}</p>
       </div>
     );
-  };
+  }
+
+  function renderCustomOptionWithLabel({ label }) {
+    return <div key={label}>{label.toUpperCase()}</div>;
+  }
 
   const rendererOptions = {
     createNodeMock(element) {
@@ -76,16 +81,16 @@ describe("Dropdown", () => {
       desc: "renders with custom option render function",
       props: {
         options: ["renders", "with", "custom", "option", "render", "function"],
-        renderOption: option => <div>{option.toUpperCase()}</div>
+        renderOption: option => <div key={option}>{option.toUpperCase()}</div>
       }
     },
     {
       desc: "renders with option specific render function",
       props: {
         options: [
-          { label: "Red", value: "#ff0000", render: optionSpecificRender },
-          { label: "Green", value: "#00ff00", render: optionSpecificRender },
-          { label: "Blue", value: "#0000ff", render: optionSpecificRender }
+          { label: "Red", value: "#ff0000", render: renderCustomOption },
+          { label: "Green", value: "#00ff00", render: renderCustomOption },
+          { label: "Blue", value: "#0000ff", render: renderCustomOption }
         ]
       }
     },
@@ -93,11 +98,11 @@ describe("Dropdown", () => {
       desc: "renders with option specific and general option render function",
       props: {
         options: [
-          { label: "Red", value: "#ff0000", render: optionSpecificRender },
+          { label: "Red", value: "#ff0000", render: renderCustomOption },
           { label: "Green", value: "#00ff00" },
           { label: "Blue", value: "#0000ff" }
         ],
-        renderOption: option => <div>{option.label.toUpperCase()}</div>
+        renderOption: renderCustomOptionWithLabel
       }
     },
     {
@@ -105,11 +110,11 @@ describe("Dropdown", () => {
       props: {
         formatOption: option => option.label.toUpperCase(),
         options: [
-          { label: "Red", value: "#ff0000", render: optionSpecificRender },
+          { label: "Red", value: "#ff0000", render: renderCustomOption },
           { label: "Green", value: "#00ff00" },
           { label: "Blue", value: "#0000ff" }
         ],
-        renderOption: option => <div>{option.label.toUpperCase()}</div>
+        renderOption: renderCustomOptionWithLabel
       }
     },
     {

--- a/packages/dropdown/src/__snapshots__/Dropdown.test.js.snap
+++ b/packages/dropdown/src/__snapshots__/Dropdown.test.js.snap
@@ -74,6 +74,7 @@ exports[`Dropdown renders non-undefined values as options 1`] = `
       onMouseDown={[Function]}
       onMouseMove={[Function]}
       role="option"
+      tabIndex="0"
     >
       <span
         className="hig__dropdown-option__label"
@@ -89,6 +90,7 @@ exports[`Dropdown renders non-undefined values as options 1`] = `
       onMouseDown={[Function]}
       onMouseMove={[Function]}
       role="option"
+      tabIndex="0"
     >
       <span
         className="hig__dropdown-option__label"
@@ -104,6 +106,7 @@ exports[`Dropdown renders non-undefined values as options 1`] = `
       onMouseDown={[Function]}
       onMouseMove={[Function]}
       role="option"
+      tabIndex="0"
     >
       <span
         className="hig__dropdown-option__label"
@@ -119,6 +122,7 @@ exports[`Dropdown renders non-undefined values as options 1`] = `
       onMouseDown={[Function]}
       onMouseMove={[Function]}
       role="option"
+      tabIndex="0"
     >
       <span
         className="hig__dropdown-option__label"
@@ -134,6 +138,7 @@ exports[`Dropdown renders non-undefined values as options 1`] = `
       onMouseDown={[Function]}
       onMouseMove={[Function]}
       role="option"
+      tabIndex="0"
     >
       <span
         className="hig__dropdown-option__label"
@@ -161,6 +166,7 @@ exports[`Dropdown renders non-undefined values as options 1`] = `
       onMouseDown={[Function]}
       onMouseMove={[Function]}
       role="option"
+      tabIndex="0"
     >
       <span
         className="hig__dropdown-option__label"
@@ -176,6 +182,7 @@ exports[`Dropdown renders non-undefined values as options 1`] = `
       onMouseDown={[Function]}
       onMouseMove={[Function]}
       role="option"
+      tabIndex="0"
     >
       <span
         className="hig__dropdown-option__label"
@@ -191,6 +198,7 @@ exports[`Dropdown renders non-undefined values as options 1`] = `
       onMouseDown={[Function]}
       onMouseMove={[Function]}
       role="option"
+      tabIndex="0"
     >
       <span
         className="hig__dropdown-option__label"
@@ -276,6 +284,7 @@ exports[`Dropdown renders with a controlled value 1`] = `
       onMouseDown={[Function]}
       onMouseMove={[Function]}
       role="option"
+      tabIndex="0"
     >
       <span
         className="hig__dropdown-option__label"
@@ -291,6 +300,7 @@ exports[`Dropdown renders with a controlled value 1`] = `
       onMouseDown={[Function]}
       onMouseMove={[Function]}
       role="option"
+      tabIndex="0"
     >
       <span
         className="hig__dropdown-option__label"
@@ -306,6 +316,7 @@ exports[`Dropdown renders with a controlled value 1`] = `
       onMouseDown={[Function]}
       onMouseMove={[Function]}
       role="option"
+      tabIndex="0"
     >
       <span
         className="hig__dropdown-option__label"
@@ -481,6 +492,7 @@ exports[`Dropdown renders with custom option formatting 1`] = `
       onMouseDown={[Function]}
       onMouseMove={[Function]}
       role="option"
+      tabIndex="0"
     >
       <span
         className="hig__dropdown-option__label"
@@ -496,6 +508,7 @@ exports[`Dropdown renders with custom option formatting 1`] = `
       onMouseDown={[Function]}
       onMouseMove={[Function]}
       role="option"
+      tabIndex="0"
     >
       <span
         className="hig__dropdown-option__label"
@@ -511,6 +524,7 @@ exports[`Dropdown renders with custom option formatting 1`] = `
       onMouseDown={[Function]}
       onMouseMove={[Function]}
       role="option"
+      tabIndex="0"
     >
       <span
         className="hig__dropdown-option__label"
@@ -684,6 +698,7 @@ exports[`Dropdown renders with default value 1`] = `
       onMouseDown={[Function]}
       onMouseMove={[Function]}
       role="option"
+      tabIndex="0"
     >
       <span
         className="hig__dropdown-option__label"
@@ -699,6 +714,7 @@ exports[`Dropdown renders with default value 1`] = `
       onMouseDown={[Function]}
       onMouseMove={[Function]}
       role="option"
+      tabIndex="0"
     >
       <span
         className="hig__dropdown-option__label"
@@ -714,6 +730,7 @@ exports[`Dropdown renders with default value 1`] = `
       onMouseDown={[Function]}
       onMouseMove={[Function]}
       role="option"
+      tabIndex="0"
     >
       <span
         className="hig__dropdown-option__label"
@@ -811,6 +828,7 @@ exports[`Dropdown renders with multiple selection 1`] = `
       onMouseDown={[Function]}
       onMouseMove={[Function]}
       role="option"
+      tabIndex="0"
     >
       <span
         className="hig__dropdown-option__label"
@@ -826,6 +844,7 @@ exports[`Dropdown renders with multiple selection 1`] = `
       onMouseDown={[Function]}
       onMouseMove={[Function]}
       role="option"
+      tabIndex="0"
     >
       <span
         className="hig__dropdown-option__label"
@@ -841,6 +860,7 @@ exports[`Dropdown renders with multiple selection 1`] = `
       onMouseDown={[Function]}
       onMouseMove={[Function]}
       role="option"
+      tabIndex="0"
     >
       <span
         className="hig__dropdown-option__label"
@@ -919,13 +939,14 @@ exports[`Dropdown renders with multiple selection and a controlled value 1`] = `
     role="listbox"
   >
     <div
-      aria-selected={false}
+      aria-selected={true}
       className="hig__dropdown-option hig__dropdown-option--selected"
       id="downshift-10-item-0"
       onClick={[Function]}
       onMouseDown={[Function]}
       onMouseMove={[Function]}
       role="option"
+      tabIndex="0"
     >
       <span
         className="hig__dropdown-option__label"
@@ -953,6 +974,7 @@ exports[`Dropdown renders with multiple selection and a controlled value 1`] = `
       onMouseDown={[Function]}
       onMouseMove={[Function]}
       role="option"
+      tabIndex="0"
     >
       <span
         className="hig__dropdown-option__label"
@@ -961,13 +983,14 @@ exports[`Dropdown renders with multiple selection and a controlled value 1`] = `
       </span>
     </div>
     <div
-      aria-selected={false}
+      aria-selected={true}
       className="hig__dropdown-option hig__dropdown-option--selected"
       id="downshift-10-item-2"
       onClick={[Function]}
       onMouseDown={[Function]}
       onMouseMove={[Function]}
       role="option"
+      tabIndex="0"
     >
       <span
         className="hig__dropdown-option__label"

--- a/packages/dropdown/src/presenters/OptionPresenter.js
+++ b/packages/dropdown/src/presenters/OptionPresenter.js
@@ -5,6 +5,48 @@ import Icon, { names } from "@hig/icon";
 
 import "./OptionPresenter.scss";
 
+function OptionWrapper(props) {
+  const {
+    children,
+    highlighted,
+    id,
+    onClick,
+    onMouseDown,
+    onMouseMove,
+    selected
+  } = props;
+
+  const classes = cx("hig__dropdown-option", {
+    "hig__dropdown-option--selected": selected,
+    "hig__dropdown-option--highlighted": highlighted
+  });
+
+  return (
+    <div
+      aria-selected={selected}
+      className={classes}
+      id={id}
+      onClick={onClick}
+      onMouseDown={onMouseDown}
+      onMouseMove={onMouseMove}
+      role="option"
+      tabIndex="0"
+    >
+      {children}
+    </div>
+  );
+}
+
+OptionWrapper.propTypes = {
+  children: PropTypes.node,
+  highlighted: PropTypes.bool,
+  id: PropTypes.string,
+  onClick: PropTypes.func,
+  onMouseDown: PropTypes.func,
+  onMouseMove: PropTypes.func,
+  selected: PropTypes.bool
+};
+
 export default class OptionPresenter extends Component {
   static propTypes = {
     /**
@@ -20,10 +62,6 @@ export default class OptionPresenter extends Component {
      */
     onClick: PropTypes.func,
     /**
-     * Called when user moves mouse over the option
-     */
-    onHover: PropTypes.func,
-    /**
      * Called when user begins clicking on an option
      */
     onMouseDown: PropTypes.func,
@@ -32,38 +70,23 @@ export default class OptionPresenter extends Component {
      */
     onMouseMove: PropTypes.func,
     /**
-     * Called when the user selects the option by clicking or keyboard interaction
-     */
-    onSelect: PropTypes.func,
-    /**
      * Indicates the option is currently selected
      */
-    selected: PropTypes.bool,
-    /**
-     * Data represented by the option
-     */
-    value: PropTypes.string
+    selected: PropTypes.bool
   };
 
   render() {
-    const { children, highlighted, selected, ...otherProps } = this.props;
+    const { children, selected, ...otherProps } = this.props;
 
     return (
-      <div
-        className={cx("hig__dropdown-option", {
-          "hig__dropdown-option--selected": selected,
-          "hig__dropdown-option--highlighted": highlighted
-        })}
-        {...otherProps}
-      >
+      <OptionWrapper selected={selected} {...otherProps}>
         <span className="hig__dropdown-option__label">{children}</span>
-
         {selected && (
           <div className="hig__dropdown-option__checkmark">
             <Icon name={names.CHECKMARK_BLUE_DARK} />
           </div>
         )}
-      </div>
+      </OptionWrapper>
     );
   }
 }

--- a/packages/dropdown/src/presenters/OptionPresenter.test.js
+++ b/packages/dropdown/src/presenters/OptionPresenter.test.js
@@ -21,10 +21,7 @@ describe("Dropdown/presenters/OptionPresenter", () => {
         onClick: () => {},
         onMouseDown: () => {},
         onMouseMove: () => {},
-        onHover: () => {},
-        onSelect: () => {},
         selected: true,
-        value: "my value",
         children: <p key="p">hi</p>
       }
     }

--- a/packages/dropdown/src/presenters/__snapshots__/OptionPresenter.test.js.snap
+++ b/packages/dropdown/src/presenters/__snapshots__/OptionPresenter.test.js.snap
@@ -2,13 +2,14 @@
 
 exports[`Dropdown/presenters/OptionPresenter renders with all props 1`] = `
 <div
+  aria-selected={true}
   className="hig__dropdown-option hig__dropdown-option--selected hig__dropdown-option--highlighted"
+  id={undefined}
   onClick={[Function]}
-  onHover={[Function]}
   onMouseDown={[Function]}
   onMouseMove={[Function]}
-  onSelect={[Function]}
-  value="my value"
+  role="option"
+  tabIndex="0"
 >
   <span
     className="hig__dropdown-option__label"
@@ -34,7 +35,14 @@ exports[`Dropdown/presenters/OptionPresenter renders with all props 1`] = `
 
 exports[`Dropdown/presenters/OptionPresenter renders without props 1`] = `
 <div
+  aria-selected={undefined}
   className="hig__dropdown-option"
+  id={undefined}
+  onClick={undefined}
+  onMouseDown={undefined}
+  onMouseMove={undefined}
+  role="option"
+  tabIndex="0"
 >
   <span
     className="hig__dropdown-option__label"


### PR DESCRIPTION
## Overview

Invalid props such as `onHover` and `onSelect` were being applied to the wrapping `<div>` component.