### PR TITLE
Pass optional HTML id prop to Input

### DIFF
--- a/packages/input/src/Input.js
+++ b/packages/input/src/Input.js
@@ -47,6 +47,7 @@ function Input(props) {
             disabled={props.disabled}
             hasFocus={hasFocus}
             hasHover={hasHover}
+            id={props.id}
             inputMode={props.inputMode}
             maxLength={props.maxLength}
             minLength={props.minLength}
@@ -83,6 +84,10 @@ Input.propTypes = {
    * Prevents the user from interacting with the input
    */
   disabled: PropTypes.bool,
+  /**
+   * HTML ID attribute
+   */
+  id: PropTypes.string,
   /**
    * A hint to browsers for which virtual keyboard to display
    */
@@ -140,13 +145,13 @@ Input.propTypes = {
    */
   tabIndex: PropTypes.string,
   /**
-   * The visual variant of the input
-   */
-  variant: PropTypes.oneOf(availableVariants),
-  /**
    * The value of the control
    */
-  value: PropTypes.string
+  value: PropTypes.string,
+  /**
+   * The visual variant of the input
+   */
+  variant: PropTypes.oneOf(availableVariants)
 };
 
 Input.defaultProps = {

--- a/packages/input/src/presenters/InputPresenter.js
+++ b/packages/input/src/presenters/InputPresenter.js
@@ -13,6 +13,7 @@ export default function InputPresenter({
   disabled,
   hasFocus,
   hasHover,
+  id,
   inputMode,
   maxLength,
   minLength,
@@ -45,6 +46,7 @@ export default function InputPresenter({
             className={css(styles.input)}
             defaultValue={defaultValue}
             disabled={disabled}
+            id={id}
             inputMode={inputMode}
             maxLength={maxLength}
             minLength={minLength}
@@ -74,6 +76,7 @@ InputPresenter.propTypes = {
   disabled: PropTypes.bool,
   hasFocus: PropTypes.bool,
   hasHover: PropTypes.bool,
+  id: PropTypes.string,
   inputMode: PropTypes.oneOf(availableInputModes),
   maxLength: PropTypes.string,
   minLength: PropTypes.string,

--- a/packages/input/src/presenters/InputPresenter.test.js
+++ b/packages/input/src/presenters/InputPresenter.test.js
@@ -15,6 +15,12 @@ describe("InputPresenter", () => {
     expect(renderer.create(<InputPresenter />).toJSON()).toMatchSnapshot();
   });
 
+  it("renders with id", () => {
+    expect(
+      renderer.create(<InputPresenter id="my_id" />).toJSON()
+    ).toMatchSnapshot();
+  });
+
   it("renders with hover", () => {
     expect(
       renderer.create(<InputPresenter hasHover />).toJSON()

--- a/packages/input/src/presenters/__snapshots__/InputPresenter.test.js.snap
+++ b/packages/input/src/presenters/__snapshots__/InputPresenter.test.js.snap
@@ -31,6 +31,7 @@ exports[`InputPresenter renders by default 1`] = `
   className="emotion-0"
   defaultValue={undefined}
   disabled={undefined}
+  id={undefined}
   inputMode={undefined}
   maxLength={undefined}
   minLength={undefined}
@@ -81,6 +82,7 @@ exports[`InputPresenter renders when disabled 1`] = `
   className="emotion-0"
   defaultValue={undefined}
   disabled={undefined}
+  id={undefined}
   inputMode={undefined}
   maxLength={undefined}
   minLength={undefined}
@@ -131,6 +133,7 @@ exports[`InputPresenter renders with focus 1`] = `
   className="emotion-0"
   defaultValue={undefined}
   disabled={undefined}
+  id={undefined}
   inputMode={undefined}
   maxLength={undefined}
   minLength={undefined}
@@ -181,6 +184,58 @@ exports[`InputPresenter renders with hover 1`] = `
   className="emotion-0"
   defaultValue={undefined}
   disabled={undefined}
+  id={undefined}
+  inputMode={undefined}
+  maxLength={undefined}
+  minLength={undefined}
+  name={undefined}
+  onBlur={undefined}
+  onChange={undefined}
+  onFocus={undefined}
+  onInput={undefined}
+  onMouseEnter={undefined}
+  onMouseLeave={undefined}
+  pattern={undefined}
+  readOnly={undefined}
+  required={undefined}
+  spellCheck={undefined}
+  tabIndex={undefined}
+  value={undefined}
+/>
+`;
+
+exports[`InputPresenter renders with id 1`] = `
+.emotion-0 {
+  background-color: transparent;
+  box-sizing: border-box;
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  min-height: 24px;
+  padding-top: 5px;
+  padding-right: 0;
+  padding-bottom: 5px;
+  padding-left: 0;
+  outline: none;
+  font-size: 14px;
+  font-family: ArtifaktElement,sans-serif;
+  font-weight: 600;
+  line-height: 1.4;
+  width: 100%;
+  color: #3c3c3c;
+  -webkit-transition-property: color;
+  transition-property: color;
+  -webkit-transition-duration: 0.3s;
+  transition-duration: 0.3s;
+}
+
+<input
+  autoComplete={undefined}
+  className="emotion-0"
+  defaultValue={undefined}
+  disabled={undefined}
+  id="my_id"
   inputMode={undefined}
   maxLength={undefined}
   minLength={undefined}


### PR DESCRIPTION
Issue: https://github.com/Autodesk/hig/issues/1078

As described in https://github.com/Autodesk/hig/issues/1078, we'd like to link form element components with Label components.  The Input element doesn't support passing in an ID for its HTML id.  

This branch adds the `id` prop to Input and updates tests accordingly