### PR TITLE
Dropdown behavior prop types should match Dropdown API

### DIFF
--- a/packages/dropdown/src/behaviors/TextInputBehavior.js
+++ b/packages/dropdown/src/behaviors/TextInputBehavior.js
@@ -23,9 +23,12 @@ export default class TextInputBehavior extends Component {
      */
     onChange: PropTypes.func,
     /**
-     * Initial value of the field
+     * An object or array of objects to choose from
      */
-    value: PropTypes.string
+    value: PropTypes.oneOfType([
+      PropTypes.any,
+      PropTypes.arrayOf(PropTypes.any)
+    ])
   };
 
   state = {


### PR DESCRIPTION
https://github.com/Autodesk/hig/issues/1073 introduced the wrong prop types for `Dropdown.TextInputBehavior` `defaultValue` and `value`.  

This branch migrates them from String to Any and also enables arrays for multi-select

