### PR TITLE
Dropdown/InputPresenter should only import presenter from TextField

### DIFF
--- a/packages/dropdown/src/presenters/InputPresenter.js
+++ b/packages/dropdown/src/presenters/InputPresenter.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import Icon from "@hig/icon";
-import TextFieldPresenter from "@hig/text-field";
+import { TextFieldPresenter } from "@hig/text-field";
 import "@hig/icon/build/index.css";
 import "@hig/text-field/build/index.css";
 import PropTypes from "prop-types";


### PR DESCRIPTION
@nfiniteset reports that he's seeing an error when using dropdown

<img width="1281" alt="screen shot 2018-08-29 at 5 23 55 pm" src="https://user-images.githubusercontent.com/140873/44879955-1c436800-ac79-11e8-9393-73e947814be0.png">

This branch resolves the error by narrowing the Dropdown's InputPresenter's import to only the presenter from TextField