### PR TITLE
Revert "Dropdown: Correct variable names for Downshift onChange event"

### DIFF
--- a/packages/dropdown/src/Dropdown.js
+++ b/packages/dropdown/src/Dropdown.js
@@ -192,7 +192,7 @@ export default class Dropdown extends Component {
       onFocus
     });
 
-    const { onChange: downshiftOnChange } = inputProps;
+    const { downshiftOnChange } = inputProps;
     const onChange = combineEventHandlers(
       downshiftOnChange,
       handleTextEntryChange


### PR DESCRIPTION
Reverts Autodesk/hig#1160