### PR TITLE
Add onMouseEnter, onMouseLeave events to Button

### DIFF
--- a/packages/button/src/Button.js
+++ b/packages/button/src/Button.js
@@ -43,6 +43,14 @@ export default class Button extends Component {
      */
     onHover: PropTypes.func,
     /**
+     * Triggers when the user's mouse is over the button
+     */
+    onMouseEnter: PropTypes.func,
+    /**
+     * Triggers when the user's mouse is no longer over the button
+     */
+    onMouseLeave: PropTypes.func,
+    /**
      * Specifies size of button
      */
     size: PropTypes.oneOf(availableSizes),
@@ -80,6 +88,8 @@ export default class Button extends Component {
       onClick,
       onFocus,
       onHover,
+      onMouseEnter,
+      onMouseLeave,
       size,
       target,
       title,
@@ -114,6 +124,8 @@ export default class Button extends Component {
             onBlur={onBlur}
             onClick={onClick}
             onFocus={onFocus}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
             onMouseOver={onHover}
           >
             {icon && (

--- a/packages/button/src/Button.test.js
+++ b/packages/button/src/Button.test.js
@@ -56,6 +56,30 @@ describe("Button", () => {
         expect(eventHandler).toBeCalled();
       });
     });
+
+    describe("onMouseEnter", () => {
+      beforeEach(() => {
+        eventHandler = jest.fn();
+        wrapper = subject({ onMouseEnter: eventHandler });
+      });
+
+      it("is triggered on mouse enter", () => {
+        wrapper.simulate("mouseenter");
+        expect(eventHandler).toBeCalled();
+      });
+    });
+
+    describe("onMouseLeave", () => {
+      beforeEach(() => {
+        eventHandler = jest.fn();
+        wrapper = subject({ onMouseLeave: eventHandler });
+      });
+
+      it("is triggered on mouse leave", () => {
+        wrapper.simulate("mouseleave");
+        expect(eventHandler).toBeCalled();
+      });
+    });
   });
 
   describe("the element rendered", () => {

--- a/packages/button/src/__stories__/getKnobs.js
+++ b/packages/button/src/__stories__/getKnobs.js
@@ -21,6 +21,8 @@ const knobLabels = {
   onClick: "onClick",
   onFocus: "onFocus",
   onHover: "onHover",
+  onMouseEnter: "onMouseEnter",
+  onMouseLeave: "onMouseLeave",
   size: "Size",
   target: "Target",
   title: "Title",
@@ -48,6 +50,8 @@ export default function getKnobs(props) {
     onClick: action(knobLabels.onClick),
     onFocus: action(knobLabels.onFocus),
     onHover: action(knobLabels.onHover),
+    onMouseEnter: action(knobLabels.onMouseEnter),
+    onMouseLeave: action(knobLabels.onMouseLeave),
     size: select(knobLabels.size, sizeOptions, size, knobGroupIds.basic),
     target: select(
       knobLabels.target,

--- a/packages/flyout/src/__snapshots__/Flyout.test.js.snap
+++ b/packages/flyout/src/__snapshots__/Flyout.test.js.snap
@@ -66,6 +66,8 @@ exports[`flyout/Flyout snapshots renders a custom pointer 1`] = `
       onBlur={undefined}
       onClick={[Function]}
       onFocus={undefined}
+      onMouseEnter={undefined}
+      onMouseLeave={undefined}
       onMouseOver={undefined}
     >
       <span
@@ -134,6 +136,8 @@ exports[`flyout/Flyout snapshots renders children from the given render function
       onBlur={undefined}
       onClick={[Function]}
       onFocus={undefined}
+      onMouseEnter={undefined}
+      onMouseLeave={undefined}
       onMouseOver={undefined}
     >
       <span
@@ -213,6 +217,8 @@ exports[`flyout/Flyout snapshots renders content from the given render function 
       onBlur={undefined}
       onClick={[Function]}
       onFocus={undefined}
+      onMouseEnter={undefined}
+      onMouseLeave={undefined}
       onMouseOver={undefined}
     >
       <span
@@ -292,6 +298,8 @@ exports[`flyout/Flyout snapshots renders the panel from a basic render function 
       onBlur={undefined}
       onClick={[Function]}
       onFocus={undefined}
+      onMouseEnter={undefined}
+      onMouseLeave={undefined}
       onMouseOver={undefined}
     >
       <span
@@ -355,6 +363,8 @@ exports[`flyout/Flyout snapshots renders the panel from a complex render functio
       onBlur={undefined}
       onClick={[Function]}
       onFocus={undefined}
+      onMouseEnter={undefined}
+      onMouseLeave={undefined}
       onMouseOver={undefined}
     >
       <span
@@ -439,6 +449,8 @@ exports[`flyout/Flyout snapshots renders with a basic set of props 1`] = `
       onBlur={undefined}
       onClick={[Function]}
       onFocus={undefined}
+      onMouseEnter={undefined}
+      onMouseLeave={undefined}
       onMouseOver={undefined}
     >
       <span

--- a/packages/flyout/src/presenters/__snapshots__/FlyoutPresenter.test.js.snap
+++ b/packages/flyout/src/presenters/__snapshots__/FlyoutPresenter.test.js.snap
@@ -12,6 +12,8 @@ exports[`flyout/FlyoutPresenter/FlyoutPresenter renders with all props 1`] = `
       onBlur={undefined}
       onClick={undefined}
       onFocus={undefined}
+      onMouseEnter={undefined}
+      onMouseLeave={undefined}
       onMouseOver={undefined}
     >
       <span


### PR DESCRIPTION
Story: https://github.com/Autodesk/hig/issues/1177

Flyout has an `onHover` event that utilizes `onMouseEnter`, however there is no equivalent `onMouseLeave`.  Both events will be needed to enable Tooltip's hover functionality.  

This branch adds `onMouseEnter` and `onMouseLeave` to Button.  

It preserves the existing `onHover` for backwards compatibility.  If both `onHover` and `onMouseOver` are provided, both will be triggered