### PR TITLE
Fix: correct modal a11y

### DIFF
--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -18,6 +18,7 @@
     "build/*"
   ],
   "dependencies": {
+    "@hig/utils": "^0.2.1",
     "classnames": "^2.2.5",
     "prop-types": "^15.6.1",
     "react-lifecycles-compat": "^3.0.4"

--- a/packages/modal/src/Modal.test.js
+++ b/packages/modal/src/Modal.test.js
@@ -1,14 +1,21 @@
 import { mount } from "enzyme";
 import React from "react";
+import { takeSnapshotsOf } from "@hig/jest-preset/helpers";
+
 import Modal from "./Modal";
 
 describe("modal/Modal", () => {
   describe("integration", () => {
-    it("renders correctly", () => {
-      const tree = mount(<Modal title="HIG Modal" open body={"Hi"} />).html();
-
-      expect(tree).toMatchSnapshot();
-    });
+    takeSnapshotsOf(Modal, [
+      {
+        desc: "renders correctly",
+        props: {
+          body: "Hi",
+          open: true,
+          title: "HIG Modal"
+        }
+      }
+    ]);
   });
 
   describe("event handlers", () => {
@@ -34,7 +41,7 @@ describe("modal/Modal", () => {
       });
 
       it("is triggered on change", () => {
-        wrapper.find("a.hig__modal-V1__overlay").simulate("click");
+        wrapper.find(".hig__modal-V1__overlay").simulate("click");
 
         expect(eventHandler).toHaveBeenCalled();
       });

--- a/packages/modal/src/__snapshots__/Modal.test.js.snap
+++ b/packages/modal/src/__snapshots__/Modal.test.js.snap
@@ -1,3 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`modal/Modal integration renders correctly 1`] = `"<div class=\\"hig__modal-V1 hig__modal-V1--open\\"><a class=\\"hig__modal-V1__overlay\\" role=\\"button\\" tabindex=\\"0\\"><a class=\\"hig__modal-V1__window hig__modal-V1__window--standard\\" role=\\"button\\" tabindex=\\"0\\"><header class=\\"hig__modal-V1__header\\"><button class=\\"hig__icon-button hig__icon-button--primary\\" title=\\"Close\\"><span class=\\"hig__icon-button__icon\\"><div class=\\"hig__icon hig__icon--24-size\\"><svg width=\\"19\\" height=\\"19\\" viewBox=\\"0 0 19 19\\" xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" title=\\"x-close-gray-24\\"><g fill=\\"#949DA2\\" fill-rule=\\"evenodd\\"><rect transform=\\"rotate(45 9.192 9.192)\\" x=\\"-2.808\\" y=\\"8.192\\" width=\\"24\\" height=\\"2\\"></rect><rect transform=\\"rotate(135 9.192 9.192)\\" x=\\"-2.808\\" y=\\"8.192\\" width=\\"24\\" height=\\"2\\"></rect></g></svg></div></span></button><span class=\\"hig__modal-V1__header-title\\">HIG Modal</span></header><div class=\\"hig__modal-V1__body\\"><div class=\\"hig__modal-V1__slot\\"></div></div></a></a></div>"`;
+exports[`modal/Modal integration renders correctly 1`] = `
+<div
+  className="hig__modal-V1 hig__modal-V1--open"
+>
+  <div
+    aria-labelledby="modal-title-1"
+    className="hig__modal-V1__overlay"
+    onClick={[Function]}
+    role="dialog"
+    tabIndex="-1"
+  >
+    <article
+      className="hig__modal-V1__window hig__modal-V1__window--standard"
+      onClick={[Function]}
+      role="document"
+    >
+      <header
+        className="hig__modal-V1__header"
+        id="modal-title-1"
+      >
+        <button
+          className="hig__icon-button hig__icon-button--primary"
+          onBlur={undefined}
+          onClick={[Function]}
+          onFocus={undefined}
+          onMouseEnter={undefined}
+          onMouseLeave={undefined}
+          title="Close"
+        >
+          <span
+            className="hig__icon-button__icon"
+          >
+            <div
+              className="hig__icon hig__icon--24-size"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "<svg width=\\"19\\" height=\\"19\\" viewBox=\\"0 0 19 19\\" xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" title=\\"x-close-gray-24\\"><g fill=\\"#949DA2\\" fill-rule=\\"evenodd\\"><rect transform=\\"rotate(45 9.192 9.192)\\" x=\\"-2.808\\" y=\\"8.192\\" width=\\"24\\" height=\\"2\\"/><rect transform=\\"rotate(135 9.192 9.192)\\" x=\\"-2.808\\" y=\\"8.192\\" width=\\"24\\" height=\\"2\\"/></g></svg>",
+                }
+              }
+            />
+          </span>
+        </button>
+        <span
+          className="hig__modal-V1__header-title"
+        >
+          HIG Modal
+        </span>
+      </header>
+      <section
+        className="hig__modal-V1__body"
+      >
+        <div
+          className="hig__modal-V1__slot"
+        />
+      </section>
+    </article>
+  </div>
+</div>
+`;

--- a/packages/modal/src/presenters/ModalHeaderPresenter.js
+++ b/packages/modal/src/presenters/ModalHeaderPresenter.js
@@ -16,6 +16,10 @@ export default class ModalHeaderPresenter extends Component {
      */
     closeButtonAriaLabel: PropTypes.string,
     /**
+     * ID for a11y
+     */
+    id: PropTypes.string,
+    /**
      * Triggers when one clicks the close button
      */
     onCloseClick: PropTypes.func,
@@ -31,17 +35,25 @@ export default class ModalHeaderPresenter extends Component {
 
   renderChildren() {
     return (
-      <header className="hig__modal-V1__header">{this.props.children}</header>
+      <header className="hig__modal-V1__header" id={this.props.id}>
+        {this.props.children}
+      </header>
     );
   }
 
   render() {
-    const { children, closeButtonAriaLabel, onCloseClick, title } = this.props;
+    const {
+      children,
+      closeButtonAriaLabel,
+      id,
+      onCloseClick,
+      title
+    } = this.props;
 
     return children ? (
       this.renderChildren()
     ) : (
-      <header className="hig__modal-V1__header">
+      <header className="hig__modal-V1__header" id={id}>
         <IconButton
           aria-label={closeButtonAriaLabel}
           name={names.X_CLOSE_GRAY}

--- a/packages/modal/src/presenters/ModalPresenter.js
+++ b/packages/modal/src/presenters/ModalPresenter.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
+import { generateId } from "@hig/utils";
 
 import ModalHeaderPresenter from "./ModalHeaderPresenter";
 import { types } from "../types";
@@ -60,6 +61,8 @@ export default class ModalPresenter extends Component {
     this.hasScrolling = element.scrollHeight > element.clientHeight;
   };
 
+  titleId = generateId("modal-title");
+
   render() {
     const {
       children,
@@ -85,33 +88,42 @@ export default class ModalPresenter extends Component {
       }
     ]);
 
+    /*
+     * The "no-noninteractive-element-interactions" rule is disabled for this block.
+     * This is due to the modal being is a special case where its containers are to be considered
+     * as non-interactive, static content by screen-readers, but must also respond to `click` events.
+     * Additionally, even though they respond to `click` events, they're not focusable.
+     */
+    /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
     return (
       <div className={wrapperClasses}>
-        <a
+        <div
+          aria-labelledby={this.titleId}
           className="hig__modal-V1__overlay"
           onClick={onOverlayClick}
-          role="button"
-          tabIndex="0"
+          role="dialog"
+          tabIndex="-1"
         >
-          <a
+          <article
             className={windowClasses}
             onClick={onWindowClick}
-            role="button"
-            tabIndex="0"
+            role="document"
           >
             <ModalHeaderPresenter
+              id={this.titleId}
               closeButtonAriaLabel={closeButtonAriaLabel}
               onCloseClick={onCloseClick}
               title={title}
             >
               {headerChildren}
             </ModalHeaderPresenter>
-            <div className="hig__modal-V1__body">
+            <section className="hig__modal-V1__body">
               <div className="hig__modal-V1__slot">{children}</div>
-            </div>
-          </a>
-        </a>
+            </section>
+          </article>
+        </div>
       </div>
     );
+    /* eslint-enable jsx-a11y/no-noninteractive-element-interactions */
   }
 }

--- a/packages/modal/src/presenters/__snapshots__/ModalHeaderPresenter.test.js.snap
+++ b/packages/modal/src/presenters/__snapshots__/ModalHeaderPresenter.test.js.snap
@@ -3,6 +3,7 @@
 exports[`checkbox/presenters/ModalHeaderPresenter  1`] = `
 <header
   className="hig__modal-V1__header"
+  id={undefined}
 >
   <button
     className="hig__icon-button hig__icon-button--primary"
@@ -35,6 +36,7 @@ exports[`checkbox/presenters/ModalHeaderPresenter  1`] = `
 exports[`checkbox/presenters/ModalHeaderPresenter  2`] = `
 <header
   className="hig__modal-V1__header"
+  id={undefined}
 >
   <p>
     Title
@@ -45,6 +47,7 @@ exports[`checkbox/presenters/ModalHeaderPresenter  2`] = `
 exports[`checkbox/presenters/ModalHeaderPresenter  3`] = `
 <header
   className="hig__modal-V1__header"
+  id={undefined}
 >
   <button
     className="hig__icon-button hig__icon-button--primary"

--- a/packages/modal/src/presenters/__snapshots__/ModalPresenter.test.js.snap
+++ b/packages/modal/src/presenters/__snapshots__/ModalPresenter.test.js.snap
@@ -3,6 +3,7 @@
 exports[`checkbox/presenters/ModalPresenter  1`] = `
 <header
   className="hig__modal-V1__header"
+  id={undefined}
 >
   <button
     className="hig__icon-button hig__icon-button--primary"
@@ -35,6 +36,7 @@ exports[`checkbox/presenters/ModalPresenter  1`] = `
 exports[`checkbox/presenters/ModalPresenter  2`] = `
 <header
   className="hig__modal-V1__header"
+  id={undefined}
 >
   <p>
     Body
@@ -45,6 +47,7 @@ exports[`checkbox/presenters/ModalPresenter  2`] = `
 exports[`checkbox/presenters/ModalPresenter  3`] = `
 <header
   className="hig__modal-V1__header"
+  id={undefined}
 >
   <p>
     Body


### PR DESCRIPTION
## Overview

The `ModalPresenter` was displaying a warning about rendering nested `<a>` elements. This fixes the warning and improves the component's overall accessibility.

## Reference

https://www.w3.org/WAI/GL/wiki/Using_ARIA_role%3Ddialog_to_implement_a_modal_dialog_box
https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-element-interactions.md
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_dialog_role
https://getbootstrap.com/docs/4.0/components/modal/#modal-components