### PR TITLE
Fix: fix missing dependencies

### DIFF
--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -18,6 +18,7 @@
     "build/*"
   ],
   "dependencies": {
+    "@hig/icon-button": "^0.2.0",
     "@hig/utils": "^0.2.1",
     "classnames": "^2.2.5",
     "prop-types": "^15.6.1",

--- a/packages/modal/src/presenters/ModalHeaderPresenter.js
+++ b/packages/modal/src/presenters/ModalHeaderPresenter.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import IconButton, { names } from "@hig/icon-button";
+import "@hig/icon-button/build/index.css";
 
 import "./ModalHeaderPresenter.scss";
 

--- a/packages/notifications-toast/src/NotificationsToast.js
+++ b/packages/notifications-toast/src/NotificationsToast.js
@@ -4,6 +4,9 @@ import cx from "classnames";
 import Icon, { sizes as iconSizes } from "@hig/icon";
 import IconButton from "@hig/icon-button";
 import RichText from "@hig/rich-text";
+import "@hig/icon/build/index.css";
+import "@hig/icon-button/build/index.css";
+import "@hig/rich-text/build/index.css";
 
 import { STATUS_ICONS, AVAILABLE_STATUSES } from "./statuses";
 

--- a/packages/tooltip/src/Tooltip.js
+++ b/packages/tooltip/src/Tooltip.js
@@ -4,6 +4,8 @@ import Flyout, {
   dislocateContainer,
   AVAILABLE_ANCHOR_POINTS
 } from "@hig/flyout";
+import "@hig/flyout/build/index.css";
+
 import PanelPresenter from "./presenters/PanelPresenter";
 import PointerPresenter from "./presenters/PointerPresenter";
 


### PR DESCRIPTION
## Overview

* Fix dependency issues with `@hig/tooltip`, `@hig/modal`, and `@hig/notifications-toast`
* ~I found unexpected behavior in testing `@hig/notifications-toast`, so I'm putting it on pre-release until the issue is resolved.~