### PR TITLE
Give React SkeletonItem its own working styles

### DIFF
--- a/packages/skeleton-item/src/SkeletonItem.js
+++ b/packages/skeleton-item/src/SkeletonItem.js
@@ -20,7 +20,7 @@ export default class SkeletonItem extends Component {
       <ThemeContext.Consumer>
         {({ themeClass }) => (
           <div
-            className={cx("hig__skeleton-item", themeClass)}
+            className={cx("hig__skeleton-itemV1", themeClass)}
             style={{
               maxWidth: this.props.maxWidth,
               marginBottom: this.props.marginBottom,

--- a/packages/skeleton-item/src/skeleton-item.scss
+++ b/packages/skeleton-item/src/skeleton-item.scss
@@ -12,7 +12,7 @@
   }
 }
 
-.hig__skeleton-item {
+.hig__skeleton-itemV1 {
   position: relative;
   overflow: hidden;
   border-radius: 4px;
@@ -33,7 +33,7 @@
 $light-shine-outer: #f2f2f2;
 $light-shine-inner: #f7f7f7;
 .hig--light-theme {
-  .hig__skeleton-item {
+  &.hig__skeleton-itemV1 {
     background-color: $light-shine-outer;
 
     &:after {
@@ -46,7 +46,7 @@ $light-shine-inner: #f7f7f7;
 $dark-blue-shine-outer: #555E6C;
 $dark-blue-shine-inner: #606976;
 .hig--dark-blue-theme {
-  &.hig__skeleton-item {
+  &.hig__skeleton-itemV1 {
     background-color: $dark-blue-shine-outer;
 
     &:after {


### PR DESCRIPTION
In working on https://github.com/Autodesk/hig/issues/1179, I noticed that React-based SkeletonItem is using vanilla JS styles as well as its own.  This branch ensures that React-based SkeletonItem is only using its own styles, and fixes a broken class name in that style