### PR TITLE
Fix: call `onChange` handlers when controlled

### DIFF
--- a/packages/checkbox/src/behaviors/CheckboxBehavior.js
+++ b/packages/checkbox/src/behaviors/CheckboxBehavior.js
@@ -1,6 +1,11 @@
 import { Component } from "react";
 import PropTypes from "prop-types";
 
+/**
+ * @typedef {Object} State
+ * @property {boolean} checked
+ */
+
 export default class CheckboxBehavior extends Component {
   static propTypes = {
     /**
@@ -29,32 +34,17 @@ export default class CheckboxBehavior extends Component {
     defaultChecked: false
   };
 
+  /**
+   * @type {State}
+   */
   state = {
     checked: this.props.defaultChecked
   };
 
   /**
-   * @param {boolean} checked
+   * @returns {boolean}
    */
-  setChecked(checked) {
-    const { onChange } = this.props;
-
-    if (onChange) {
-      onChange(checked);
-    }
-
-    this.setState({ checked });
-  }
-
-  toggleChecked() {
-    this.setChecked(!this.state.checked);
-  }
-
-  isControlled() {
-    return this.props.checked !== undefined;
-  }
-
-  isChecked() {
+  getChecked() {
     if (this.isControlled()) {
       return this.props.checked;
     }
@@ -63,32 +53,47 @@ export default class CheckboxBehavior extends Component {
   }
 
   /**
+   * @param {boolean} checked
+   */
+  setChecked(checked) {
+    const { onChange } = this.props;
+
+    if (onChange) onChange(checked);
+
+    if (!this.isControlled()) {
+      this.setState({ checked });
+    }
+  }
+
+  toggleChecked() {
+    this.setChecked(!this.getChecked());
+  }
+
+  isControlled() {
+    return this.props.checked !== undefined;
+  }
+
+  /**
    * @param {MouseEvent} event
    */
   handleClick = event => {
     const { onClick } = this.props;
 
-    if (onClick) {
-      onClick(event);
-    }
+    if (onClick) onClick(event);
 
-    if (!this.isControlled()) {
-      this.toggleChecked();
-    }
+    this.toggleChecked();
   };
 
   /**
    * @param {UIEvent} event
    */
   handleChange = event => {
-    if (!this.isControlled()) {
-      this.setChecked(event.target.checked);
-    }
+    this.setChecked(event.target.checked);
   };
 
   render() {
     const { handleChange, handleClick } = this;
-    const checked = this.isChecked();
+    const checked = this.getChecked();
 
     return this.props.children({
       checked,

--- a/packages/checkbox/src/behaviors/CheckboxBehavior.test.js
+++ b/packages/checkbox/src/behaviors/CheckboxBehavior.test.js
@@ -1,0 +1,155 @@
+import React from "react";
+import { shallow } from "enzyme";
+import { lastCallOfMock } from "@hig/jest-preset/helpers";
+
+import CheckboxBehavior from "./CheckboxBehavior";
+
+describe("checkbox/behaviors/CheckboxBehavior", () => {
+  const children = jest.fn(() => <input />);
+  const onChange = jest.fn();
+  const onClick = jest.fn();
+
+  function render(props) {
+    return shallow(
+      <CheckboxBehavior {...props} onChange={onChange} onClick={onClick}>
+        {children}
+      </CheckboxBehavior>
+    );
+  }
+
+  function getPayload() {
+    return lastCallOfMock(children)[0];
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("render", () => {
+    it("calls the `children` render prop", () => {
+      expect(children).not.toHaveBeenCalled();
+      render();
+      expect(children).toHaveBeenCalledWith({
+        checked: expect.any(Boolean),
+        handleChange: expect.any(Function),
+        handleClick: expect.any(Function)
+      });
+    });
+  });
+
+  describe("props", () => {
+    describe("defaultChecked", () => {
+      describe("when uncontrolled", () => {
+        it("is false by default", () => {
+          render();
+          expect(getPayload()).toHaveProperty("checked", false);
+        });
+
+        it("sets the default input checked value", () => {
+          render({ defaultChecked: true });
+          expect(getPayload()).toHaveProperty("checked", true);
+        });
+      });
+
+      describe("when controlled", () => {
+        it("is ignored", () => {
+          render({ checked: false, defaultChecked: true });
+          expect(getPayload()).toHaveProperty("checked", false);
+        });
+      });
+    });
+  });
+
+  describe("payload", () => {
+    const clickEvent = {};
+    const checkedChangeEvent = { target: { checked: true } };
+
+    function assertOnClickHandler() {
+      const { handleClick } = getPayload();
+
+      expect(onClick).not.toHaveBeenCalled();
+      handleClick(clickEvent);
+      expect(onClick).toHaveBeenCalledWith(clickEvent);
+    }
+
+    function assertOnChangeHandler() {
+      const { handleChange } = getPayload();
+
+      expect(onChange).not.toHaveBeenCalled();
+      handleChange(checkedChangeEvent);
+      expect(onChange).toHaveBeenCalledWith(true);
+    }
+
+    describe("handleChange", () => {
+      describe("when uncontrolled", () => {
+        it("calls the `onChange` handler", () => {
+          render();
+          assertOnChangeHandler();
+        });
+
+        it("updates the checked value", () => {
+          render();
+          expect(getPayload()).toHaveProperty("checked", false);
+          getPayload().handleChange(checkedChangeEvent);
+          expect(getPayload()).toHaveProperty("checked", true);
+        });
+      });
+
+      describe("when controlled", () => {
+        it("calls the `onChange` handler", () => {
+          render({ checked: false });
+          assertOnChangeHandler();
+        });
+
+        it("doesn't update the checked value", () => {
+          render({ checked: false });
+          expect(getPayload()).toHaveProperty("checked", false);
+          getPayload().handleChange(checkedChangeEvent);
+          expect(getPayload()).toHaveProperty("checked", false);
+        });
+      });
+    });
+
+    describe("handleClick", () => {
+      describe("when uncontrolled", () => {
+        it("calls the `onClick` handler", () => {
+          render();
+          assertOnClickHandler();
+        });
+
+        it("calls the `onChange` handler", () => {
+          render();
+          assertOnChangeHandler();
+        });
+
+        it("toggles the checked value", () => {
+          render();
+          expect(getPayload()).toHaveProperty("checked", false);
+          getPayload().handleClick(clickEvent);
+          expect(getPayload()).toHaveProperty("checked", true);
+          getPayload().handleClick(clickEvent);
+          expect(getPayload()).toHaveProperty("checked", false);
+        });
+      });
+
+      describe("when controlled", () => {
+        it("calls the `onClick` handler", () => {
+          render({ checked: false });
+          assertOnClickHandler();
+        });
+
+        it("calls the `onChange` handler with the controlled value", () => {
+          render({ checked: false });
+          assertOnChangeHandler();
+        });
+
+        it("doesn't toggle the checked value", () => {
+          render({ checked: false });
+          expect(getPayload()).toHaveProperty("checked", false);
+          getPayload().handleClick(clickEvent);
+          expect(getPayload()).toHaveProperty("checked", false);
+        });
+      });
+    });
+  });
+});

--- a/packages/slider/src/Slider.js
+++ b/packages/slider/src/Slider.js
@@ -6,6 +6,15 @@ import { generateId } from "@hig/utils";
 import Input from "./presenters/Input";
 import "./slider.scss";
 
+/**
+ * @typedef {string|number} Value
+ */
+
+/**
+ * @typedef {Object} State
+ * @property {Value} value
+ */
+
 export default class Slider extends Component {
   static propTypes = {
     /**
@@ -79,15 +88,14 @@ export default class Slider extends Component {
   };
 
   /**
-   * @type {Object}
-   * @property {string|number} value
+   * @type {State}
    */
   state = {
     value: this.props.defaultValue
   };
 
   /**
-   * @returns {string|number}
+   * @returns {Value}
    */
   getValue() {
     if (this.isControlled()) {
@@ -98,32 +106,27 @@ export default class Slider extends Component {
   }
 
   /**
-   * @returns {boolean}
+   * @param {Value} value
    */
-  isControlled() {
-    return this.props.value !== undefined;
-  }
-
-  /**
-   * @param {string|number} value
-   */
-  updateValue(value) {
+  setValue(value) {
     const { onChange } = this.props;
 
-    if (onChange) {
-      onChange(Number(value));
-    }
+    if (onChange) onChange(Number(value));
 
-    this.setState({ value });
+    if (!this.isControlled()) {
+      this.setState({ value });
+    }
+  }
+
+  isControlled() {
+    return this.props.value !== undefined;
   }
 
   /**
    * @param {event} Event
    */
   handleChange = event => {
-    if (!this.isControlled()) {
-      this.updateValue(event.target.value);
-    }
+    this.setValue(event.target.value);
   };
 
   render() {

--- a/packages/slider/src/Slider.test.js
+++ b/packages/slider/src/Slider.test.js
@@ -4,39 +4,6 @@ import Slider from "./index";
 import Input from "./presenters/Input";
 
 describe("slider/Slider", () => {
-  it("allows value to be changed by onChange", () => {
-    const wrapper = mount(<Slider defaultValue="10" />);
-    const input = wrapper.find("input");
-
-    expect(input.prop("value")).toEqual("10");
-    input.simulate("change", { target: { value: "20" } });
-    expect(input.prop("value")).toEqual("20");
-  });
-
-  describe("id", () => {
-    it("generates an ID when one is not provided", () => {
-      const wrapper = mount(<Slider />);
-      expect(wrapper.find(Input).prop("id")).toEqual(
-        expect.stringMatching("slider-")
-      );
-    });
-
-    it("passes the ID prop to the underlying input", () => {
-      const wrapper = mount(<Slider id="important-field" />);
-      expect(wrapper.find(Input).prop("id")).toEqual("important-field");
-    });
-  });
-
-  describe("event handlers", () => {
-    it("calls onChange when provided", () => {
-      const eventHandler = jest.fn();
-      const wrapper = mount(<Slider onChange={eventHandler} />);
-      wrapper.find("input").simulate("change", { target: { value: "10" } });
-
-      expect(eventHandler).toHaveBeenCalled();
-    });
-  });
-
   it("renders a label when provided", () => {
     const label = "Age";
     const wrapper = mount(<Slider label={label} />);
@@ -54,24 +21,68 @@ describe("slider/Slider", () => {
     const wrapper = mount(<Slider required={requiredMsg} />);
     expect(wrapper.text()).toEqual(expect.stringMatching(requiredMsg));
   });
+  describe("props", () => {
+    describe("id", () => {
+      it("generates an ID when one is not provided", () => {
+        const wrapper = mount(<Slider />);
+        expect(wrapper.find(Input).prop("id")).toEqual(
+          expect.stringMatching("slider-")
+        );
+      });
 
-  describe("when controlled", () => {
-    it("doesn't allow the value to be changed by onChange", () => {
-      const wrapper = mount(<Slider value="10" />);
-      const input = wrapper.find("input");
-
-      expect(input.prop("value")).toEqual("10");
-      input.simulate("change", { target: { value: "20" } });
-      expect(input.prop("value")).toEqual("10");
+      it("passes the ID prop to the underlying input", () => {
+        const wrapper = mount(<Slider id="important-field" />);
+        expect(wrapper.find(Input).prop("id")).toEqual("important-field");
+      });
     });
 
-    it("recognizes changes to the value prop", () => {
-      const wrapper = mount(<Slider value="10" />);
-      const input = wrapper.find("input");
+    describe("onChange", () => {
+      describe("when uncontrolled", () => {
+        it("calls the `onChange`the changed value", () => {
+          const eventHandler = jest.fn();
+          const wrapper = mount(<Slider onChange={eventHandler} />);
+          wrapper.find("input").simulate("change", { target: { value: "10" } });
 
-      expect(input.prop("value")).toEqual("10");
-      wrapper.setProps({ value: "20" });
-      expect(input.prop("value")).toEqual("20");
+          expect(eventHandler).toHaveBeenCalledWith(10);
+        });
+
+        it("allows value to be changed by change events", () => {
+          const wrapper = mount(<Slider defaultValue="10" />);
+          const input = wrapper.find("input");
+
+          expect(input.prop("value")).toEqual("10");
+          input.simulate("change", { target: { value: "20" } });
+          expect(input.prop("value")).toEqual("20");
+        });
+      });
+
+      describe("when controlled", () => {
+        it("calls the `onChange` handler", () => {
+          const eventHandler = jest.fn();
+          const wrapper = mount(<Slider value="8" onChange={eventHandler} />);
+          wrapper.find("input").simulate("change", { target: { value: "10" } });
+
+          expect(eventHandler).toHaveBeenCalledWith(10);
+        });
+
+        it("doesn't allow the value to be changed by change events", () => {
+          const wrapper = mount(<Slider value="10" />);
+          const input = wrapper.find("input");
+
+          expect(input.prop("value")).toEqual("10");
+          input.simulate("change", { target: { value: "20" } });
+          expect(input.prop("value")).toEqual("10");
+        });
+
+        it("recognizes changes to the value prop", () => {
+          const wrapper = mount(<Slider value="10" />);
+          const input = wrapper.find("input");
+
+          expect(input.prop("value")).toEqual("10");
+          wrapper.setProps({ value: "20" });
+          expect(input.prop("value")).toEqual("20");
+        });
+      });
     });
   });
 });

--- a/packages/slider/src/Slider.test.js
+++ b/packages/slider/src/Slider.test.js
@@ -21,6 +21,7 @@ describe("slider/Slider", () => {
     const wrapper = mount(<Slider required={requiredMsg} />);
     expect(wrapper.text()).toEqual(expect.stringMatching(requiredMsg));
   });
+
   describe("props", () => {
     describe("id", () => {
       it("generates an ID when one is not provided", () => {

--- a/packages/text-field/src/behaviors/TextInputBehavior.js
+++ b/packages/text-field/src/behaviors/TextInputBehavior.js
@@ -8,6 +8,11 @@ import PropTypes from "prop-types";
  * @property {function(): void} clear
  */
 
+/**
+ * @typedef {Object} State
+ * @property {string} value
+ */
+
 export default class TextInputBehavior extends Component {
   static propTypes = {
     /**
@@ -32,10 +37,16 @@ export default class TextInputBehavior extends Component {
     value: PropTypes.string
   };
 
+  /**
+   * @type {State}
+   */
   state = {
     value: this.props.defaultValue || ""
   };
 
+  /**
+   * @returns {string}
+   */
   getValue() {
     if (this.isControlled()) {
       return this.props.value;
@@ -44,20 +55,33 @@ export default class TextInputBehavior extends Component {
     return this.state.value;
   }
 
+  /**
+   * @param {string} value
+   */
   setValue(value) {
     const { onChange } = this.props;
 
-    if (onChange) {
-      onChange(value);
-    }
+    if (onChange) onChange(value);
 
-    this.setState({ value });
+    if (!this.isControlled()) {
+      this.setState({ value });
+    }
   }
 
+  isControlled() {
+    return this.props.value !== undefined;
+  }
+
+  /**
+   * @param {event} Event
+   */
   handleChange = event => {
-    this.setValue(this.isControlled() ? this.props.value : event.target.value);
+    this.setValue(event.target.value);
   };
 
+  /**
+   * An action that empties the value
+   */
   clear = () => {
     const { onClear } = this.props;
 
@@ -65,12 +89,8 @@ export default class TextInputBehavior extends Component {
       onClear();
     }
 
-    this.setValue("");
+      this.setValue("");
   };
-
-  isControlled() {
-    return this.props.value !== undefined;
-  }
 
   render() {
     return this.props.children({

--- a/packages/text-field/src/behaviors/TextInputBehavior.js
+++ b/packages/text-field/src/behaviors/TextInputBehavior.js
@@ -37,11 +37,15 @@ export default class TextInputBehavior extends Component {
     value: PropTypes.string
   };
 
+  static defaultProps = {
+    defaultValue: ""
+  };
+
   /**
    * @type {State}
    */
   state = {
-    value: this.props.defaultValue || ""
+    value: this.props.defaultValue
   };
 
   /**

--- a/packages/text-field/src/behaviors/TextInputBehavior.js
+++ b/packages/text-field/src/behaviors/TextInputBehavior.js
@@ -89,7 +89,9 @@ export default class TextInputBehavior extends Component {
       onClear();
     }
 
+    if (!this.isControlled()) {
       this.setValue("");
+    }
   };
 
   render() {

--- a/packages/text-field/src/behaviors/TextInputBehavior.test.js
+++ b/packages/text-field/src/behaviors/TextInputBehavior.test.js
@@ -1,0 +1,140 @@
+import React from "react";
+import { shallow } from "enzyme";
+import { lastCallOfMock } from "@hig/jest-preset/helpers";
+
+import TextInputBehavior from "./TextInputBehavior";
+
+describe("text-field/behaviors/TextInputBehavior", () => {
+  const children = jest.fn(() => <input />);
+  const onChange = jest.fn();
+  const onClear = jest.fn();
+
+  function render(props) {
+    return shallow(
+      <TextInputBehavior {...props} onChange={onChange} onClear={onClear}>
+        {children}
+      </TextInputBehavior>
+    );
+  }
+
+  function getPayload() {
+    return lastCallOfMock(children)[0];
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("render", () => {
+    it("calls the `children` render prop", () => {
+      expect(children).not.toHaveBeenCalled();
+      render();
+      expect(children).toHaveBeenCalledWith({
+        clear: expect.any(Function),
+        handleChange: expect.any(Function),
+        value: expect.any(String)
+      });
+    });
+  });
+
+  describe("props", () => {
+    describe("defaultValue", () => {
+      describe("when uncontrolled", () => {
+        it("is empty by default", () => {
+          render();
+          expect(getPayload()).toHaveProperty("value", "");
+        });
+
+        it("sets the default input value", () => {
+          render({ defaultValue: "foo" });
+          expect(getPayload()).toHaveProperty("value", "foo");
+        });
+      });
+
+      describe("when controlled", () => {
+        it("is ignored", () => {
+          render({ value: "bar", defaultValue: "foo" });
+          expect(getPayload()).toHaveProperty("value", "bar");
+        });
+      });
+    });
+  });
+
+  describe("payload", () => {
+    const changeEvent = { target: { value: "baz" } };
+
+    function assertOnChangeHandler() {
+      const { handleChange } = getPayload();
+
+      expect(onChange).not.toHaveBeenCalled();
+      handleChange(changeEvent);
+      expect(onChange).toHaveBeenCalledWith("baz");
+    }
+
+    describe("handleChange", () => {
+      describe("when uncontrolled", () => {
+        it("calls the `onChange` handler", () => {
+          render();
+          assertOnChangeHandler();
+        });
+
+        it("updates the value value", () => {
+          render();
+          expect(getPayload()).toHaveProperty("value", "");
+          getPayload().handleChange(changeEvent);
+          expect(getPayload()).toHaveProperty("value", "baz");
+        });
+      });
+
+      describe("when controlled", () => {
+        it("calls the `onChange` handler", () => {
+          render({ value: "boom" });
+          assertOnChangeHandler();
+        });
+
+        it("doesn't update the value value", () => {
+          render({ value: "boom" });
+          expect(getPayload()).toHaveProperty("value", "boom");
+          getPayload().handleChange(changeEvent);
+          expect(getPayload()).toHaveProperty("value", "boom");
+        });
+      });
+    });
+
+    describe("clear", () => {
+      function assertOnClearCalled() {
+        expect(onClear).not.toHaveBeenCalled();
+        getPayload().clear();
+        expect(onClear).toHaveBeenCalled();
+      }
+
+      describe("when uncontrolled", () => {
+        it("calls the `onClear` handler", () => {
+          render();
+          assertOnClearCalled();
+        });
+
+        it("empties the value", () => {
+          render({ defaultValue: "bang" });
+          expect(getPayload()).toHaveProperty("value", "bang");
+          getPayload().clear();
+          expect(getPayload()).toHaveProperty("value", "");
+        });
+      });
+
+      describe("when controlled", () => {
+        it("calls the `onClear` handler", () => {
+          render({ value: "boom" });
+          assertOnClearCalled();
+        });
+
+        it("doesn't update the value value", () => {
+          render({ value: "boom" });
+          expect(getPayload()).toHaveProperty("value", "boom");
+          getPayload().clear();
+          expect(getPayload()).toHaveProperty("value", "boom");
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Overview

When the `Checkbox`, `Slider`, and `TextField` are used as controlled components, the given `onChange` handlers will now be called when the components are interacted with.