### PR TITLE
Convert theme data to SCSS variables

### DIFF
--- a/packages/theme-data/package.json
+++ b/packages/theme-data/package.json
@@ -27,7 +27,8 @@
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",
     "@hig/typography": "^0.1.3",
-    "babel-cli": "^6.26.0"
+    "babel-cli": "^6.26.0",
+    "style-dictionary": "^2.4.0"
   },
   "dependencies": {
     "tinycolor2": "^1.4.1"

--- a/packages/theme-data/package.json
+++ b/packages/theme-data/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "test": "hig-scripts-test",
-    "build": "hig-scripts-build && babel-node scripts/buildThemes",
+    "build": "hig-scripts-build && babel-node scripts/buildThemes && node scripts/buildSCSS.js",
     "lint": "hig-scripts-lint"
   },
   "devDependencies": {

--- a/packages/theme-data/scripts/buildSCSS.js
+++ b/packages/theme-data/scripts/buildSCSS.js
@@ -1,0 +1,53 @@
+// node build-themes.js
+const fs = require("fs");
+
+const BUILD_DIRECTORY = "build";
+const DICTIONARY_DIRECTORY = `${BUILD_DIRECTORY}/dictionary`;
+const SCSS_DIRECTORY = `${BUILD_DIRECTORY}/scss`;
+const SCSS_VARIABLES_DIRECTORY = `${SCSS_DIRECTORY}/variables/`;
+
+const buildFiles = fs.readdirSync(`${BUILD_DIRECTORY}/`);
+const themeFiles = buildFiles.filter((buildFile) => buildFile.match(/.*Theme\.json/));
+
+try {
+  fs.mkdirSync(DICTIONARY_DIRECTORY);
+} catch (err) {
+  if (err.code !== 'EEXIST') {
+    throw err;
+  }
+}
+
+themeFiles.forEach((themeFile) => {
+  const themeName = themeFile.replace(/\.json$/g, "");
+  const destination = `_${themeName}.scss`;
+
+  const StyleDictionary = require("style-dictionary").extend({
+    "source": [`${DICTIONARY_DIRECTORY}/${themeFile}`],
+    "platforms": {
+      "scss": {
+        "buildPath": SCSS_VARIABLES_DIRECTORY,
+        "files": [{
+          "destination": destination,
+          "format": "scss/variables"
+        }]
+      }
+    }
+  });
+
+  const content = fs.readFileSync(`${BUILD_DIRECTORY}/${themeFile}`, "utf8");
+  const theme = JSON.parse(content);
+  const themeFormatted = {};
+
+  Object.keys(theme).forEach((key) => {
+    const formattedKey = key.replace(/\./g, "-")
+    themeFormatted[formattedKey] = { value: theme[key] }
+  });
+
+  const output = JSON.stringify(themeFormatted);
+
+  fs.writeFile(`${DICTIONARY_DIRECTORY}/${themeFile}`, output, function(err) {
+    console.log(err);
+  });
+
+  StyleDictionary.buildAllPlatforms();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5856,7 +5856,7 @@ fs-extra@^5.0.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^6.0.0:
+fs-extra@^6.0.0, fs-extra@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-6.0.1.tgz#8abc128f7946e310135ddc93b98bddb410e7a34b"
   dependencies:
@@ -13205,6 +13205,18 @@ structured-source@^3.0.2:
   resolved "https://registry.yarnpkg.com/structured-source/-/structured-source-3.0.2.tgz#dd802425e0f53dc4a6e7aca3752901a1ccda7af5"
   dependencies:
     boundary "^1.0.1"
+
+style-dictionary@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/style-dictionary/-/style-dictionary-2.4.0.tgz#fae92adeeca1839940b61f6cf3e458afecdbb79d"
+  dependencies:
+    chalk "^2.4.1"
+    commander "^2.9.0"
+    fs-extra "^6.0.1"
+    glob "^7.1.1"
+    lodash "^4.16.4"
+    resolve-cwd "^2.0.0"
+    tinycolor2 "^1.4.1"
 
 style-inject@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
Issue: https://github.com/Autodesk/hig/issues/1211

Developers building a non-React app may wish to use HIG themes.  As one effort to allow them to do so, this branch adds a script to compile theme-data build files into SCSS.