### PR TITLE
Fix: add missing keyboard interactions to ProjectAccountSwitcher

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -15,6 +15,7 @@
     "eslint": "^4.19.1"
   },
   "dependencies": {
+    "babel-eslint": "^10.0.1",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-import": "^2.10.0",

--- a/packages/project-account-switcher/src/__gemini__/ProjectAccountSwitcherPresenter.gemini.js
+++ b/packages/project-account-switcher/src/__gemini__/ProjectAccountSwitcherPresenter.gemini.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 gemini.suite("ProjectAccountSwitcherPresenter", () => {
   gemini.suite("default", suite => {
     suite

--- a/packages/project-account-switcher/src/__snapshots__/ProjectAccountSwitcher.test.js.snap
+++ b/packages/project-account-switcher/src/__snapshots__/ProjectAccountSwitcher.test.js.snap
@@ -3,9 +3,6 @@
 exports[`project-account-switcher/ProjectAccountSwitcher integration renders correctly 1`] = `
 <div
   className="hig__project-account-switcher"
-  onClick={[Function]}
-  role="button"
-  tabIndex="0"
 >
   <div
     className="hig__flyout-v1 hig__flyout-v1--hidden hig__flyout-v1--top-left"
@@ -17,8 +14,11 @@ exports[`project-account-switcher/ProjectAccountSwitcher integration renders cor
         className="hig__project-account-switcher__target"
         hasHover={false}
         onClick={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="button"
+        tabIndex="0"
       >
         <div
           className="hig__project-account-switcher__item"
@@ -120,6 +120,7 @@ exports[`project-account-switcher/ProjectAccountSwitcher integration renders cor
                 <li
                   className="hig__project-account-switcher__item hig__project-account-switcher__item--account hig__project-account-switcher__item--active"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
                   role="menuitem"
                   tabIndex="0"
                 >
@@ -141,6 +142,7 @@ exports[`project-account-switcher/ProjectAccountSwitcher integration renders cor
                 <li
                   className="hig__project-account-switcher__item hig__project-account-switcher__item--account hig__project-account-switcher__item--active"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
                   role="menuitem"
                   tabIndex="0"
                 >
@@ -171,6 +173,7 @@ exports[`project-account-switcher/ProjectAccountSwitcher integration renders cor
                 <li
                   className="hig__project-account-switcher__item hig__project-account-switcher__item--project hig__project-account-switcher__item--active"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
                   role="menuitem"
                   tabIndex="0"
                 >
@@ -192,6 +195,7 @@ exports[`project-account-switcher/ProjectAccountSwitcher integration renders cor
                 <li
                   className="hig__project-account-switcher__item hig__project-account-switcher__item--project hig__project-account-switcher__item--active"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
                   role="menuitem"
                   tabIndex="0"
                 >

--- a/packages/project-account-switcher/src/presenters/ProjectAccountSwitcherPresenter.js
+++ b/packages/project-account-switcher/src/presenters/ProjectAccountSwitcherPresenter.js
@@ -1,6 +1,12 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import cx from "classnames";
 import Flyout, { anchorPoints } from "@hig/flyout";
+import {
+  createButtonEventHandlers,
+  memoizeCreateButtonEventHandlers
+} from "@hig/utils";
+import memoize from "lodash.memoize";
 import icons from "@hig/icons";
 import "@hig/flyout/build/index.css";
 
@@ -87,54 +93,78 @@ export default class ProjectAccountSwitcherPresenter extends Component {
     return placeholders.join("/");
   }
 
+  createAccountListItemHandlers = memoize(id =>
+    createButtonEventHandlers(event => this.props.onAccountClick(event, id))
+  );
+
+  createProjectListItemHandlers = memoize(id =>
+    createButtonEventHandlers(event => this.props.onProjectClick(event, id))
+  );
+
   accountsList() {
-    return this.props.accounts.map(({ id, label }) => (
-      <li
-        key={`account-${id}`}
-        className={[
-          "hig__project-account-switcher__item",
-          "hig__project-account-switcher__item--account",
-          "hig__project-account-switcher__item--active"
-        ].join(" ")}
-        role="menuitem"
-        tabIndex="0"
-        onClick={event => this.props.onAccountClick(event, id)}
-      >
-        <span className="hig__project-account-switcher__item__image-wrapper">
-          <span className="hig__project-account-switcher__item__image-placeholder">
-            {constructPlaceholder(label)}
+    const classes = cx(
+      "hig__project-account-switcher__item",
+      "hig__project-account-switcher__item--account",
+      "hig__project-account-switcher__item--active"
+    );
+
+    return this.props.accounts.map(({ id, label }) => {
+      const { handleClick, handleKeyDown } = this.createAccountListItemHandlers(
+        id
+      );
+
+      return (
+        <li
+          key={`account-${id}`}
+          className={classes}
+          role="menuitem"
+          tabIndex="0"
+          onClick={handleClick}
+          onKeyDown={handleKeyDown}
+        >
+          <span className="hig__project-account-switcher__item__image-wrapper">
+            <span className="hig__project-account-switcher__item__image-placeholder">
+              {constructPlaceholder(label)}
+            </span>
           </span>
-        </span>
-        <span className="hig__project-account-switcher__item__label">
-          {label}
-        </span>
-      </li>
-    ));
+          <span className="hig__project-account-switcher__item__label">
+            {label}
+          </span>
+        </li>
+      );
+    });
   }
 
   projectsList() {
-    return this.props.projects.map(({ id, label }) => (
-      <li
-        key={`project-${id}`}
-        className={[
-          "hig__project-account-switcher__item",
-          "hig__project-account-switcher__item--project",
-          "hig__project-account-switcher__item--active"
-        ].join(" ")}
-        role="menuitem"
-        tabIndex="0"
-        onClick={event => this.props.onProjectClick(event, id)}
-      >
-        <span className="hig__project-account-switcher__item__image-wrapper">
-          <span className="hig__project-account-switcher__item__image-placeholder">
-            {constructPlaceholder(label)}
+    return this.props.projects.map(({ id, label }) => {
+      const { handleClick, handleKeyDown } = this.createProjectListItemHandlers(
+        id
+      );
+
+      return (
+        <li
+          key={`project-${id}`}
+          className={cx(
+            "hig__project-account-switcher__item",
+            "hig__project-account-switcher__item--project",
+            "hig__project-account-switcher__item--active"
+          )}
+          role="menuitem"
+          tabIndex="0"
+          onClick={handleClick}
+          onKeyDown={handleKeyDown}
+        >
+          <span className="hig__project-account-switcher__item__image-wrapper">
+            <span className="hig__project-account-switcher__item__image-placeholder">
+              {constructPlaceholder(label)}
+            </span>
           </span>
-        </span>
-        <span className="hig__project-account-switcher__item__label">
-          {label}
-        </span>
-      </li>
-    ));
+          <span className="hig__project-account-switcher__item__label">
+            {label}
+          </span>
+        </li>
+      );
+    });
   }
 
   flyoutContent() {
@@ -175,8 +205,11 @@ export default class ProjectAccountSwitcherPresenter extends Component {
     return "";
   }
 
+  createTargetHandlers = memoizeCreateButtonEventHandlers();
+
   render() {
     if (this.componentHasNoLists()) {
+      /* eslint-disable-next-line no-console */
       console.warn("You must provide a list of accounts or projects");
       return null;
     }
@@ -184,13 +217,14 @@ export default class ProjectAccountSwitcherPresenter extends Component {
     const activeLabel = this.props.activeLabel
       ? this.props.activeLabel
       : this.constructLabel();
+
+    const {
+      handleClick: handleTargetClick,
+      handleKeyDown: handleTargetKeyDown
+    } = this.createTargetHandlers(this.props.onTargetClick);
+
     return (
-      <div
-        role="button"
-        tabIndex="0"
-        className="hig__project-account-switcher"
-        onClick={this.props.onTargetClick}
-      >
+      <div className="hig__project-account-switcher">
         <Flyout
           anchorPoint={anchorPoints.TOP_RIGHT}
           open={this.props.open}
@@ -202,7 +236,13 @@ export default class ProjectAccountSwitcherPresenter extends Component {
             </Flyout.Panel>
           )}
         >
-          <div className="hig__project-account-switcher__target">
+          <div
+            className="hig__project-account-switcher__target"
+            onClick={handleTargetClick}
+            onKeyDown={handleTargetKeyDown}
+            role="button"
+            tabIndex="0"
+          >
             <div className="hig__project-account-switcher__item">
               <span className="hig__project-account-switcher__item__image-wrapper">
                 <img

--- a/packages/project-account-switcher/src/presenters/ProjectAccountSwitcherPresenter.test.js
+++ b/packages/project-account-switcher/src/presenters/ProjectAccountSwitcherPresenter.test.js
@@ -3,6 +3,7 @@ import ProjectAccountSwitcherPresenter from "./ProjectAccountSwitcherPresenter";
 
 describe("project-account-switcher/presenters/ProjectAccountSwitcherPresenter", () => {
   beforeAll(() => {
+    /* eslint-disable-next-line no-console */
     console.warn = jest.fn();
   });
 

--- a/packages/project-account-switcher/src/presenters/__snapshots__/ProjectAccountSwitcherPresenter.test.js.snap
+++ b/packages/project-account-switcher/src/presenters/__snapshots__/ProjectAccountSwitcherPresenter.test.js.snap
@@ -5,9 +5,6 @@ exports[`project-account-switcher/presenters/ProjectAccountSwitcherPresenter  1`
 exports[`project-account-switcher/presenters/ProjectAccountSwitcherPresenter  2`] = `
 <div
   className="hig__project-account-switcher"
-  onClick={undefined}
-  role="button"
-  tabIndex="0"
 >
   <div
     className="hig__flyout-v1 hig__flyout-v1--hidden hig__flyout-v1--top-left"
@@ -19,8 +16,11 @@ exports[`project-account-switcher/presenters/ProjectAccountSwitcherPresenter  2`
         className="hig__project-account-switcher__target"
         hasHover={false}
         onClick={[Function]}
+        onKeyDown={undefined}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
+        role="button"
+        tabIndex="0"
       >
         <div
           className="hig__project-account-switcher__item"
@@ -122,6 +122,7 @@ exports[`project-account-switcher/presenters/ProjectAccountSwitcherPresenter  2`
                 <li
                   className="hig__project-account-switcher__item hig__project-account-switcher__item--account hig__project-account-switcher__item--active"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
                   role="menuitem"
                   tabIndex="0"
                 >
@@ -143,6 +144,7 @@ exports[`project-account-switcher/presenters/ProjectAccountSwitcherPresenter  2`
                 <li
                   className="hig__project-account-switcher__item hig__project-account-switcher__item--account hig__project-account-switcher__item--active"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
                   role="menuitem"
                   tabIndex="0"
                 >
@@ -173,6 +175,7 @@ exports[`project-account-switcher/presenters/ProjectAccountSwitcherPresenter  2`
                 <li
                   className="hig__project-account-switcher__item hig__project-account-switcher__item--project hig__project-account-switcher__item--active"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
                   role="menuitem"
                   tabIndex="0"
                 >
@@ -194,6 +197,7 @@ exports[`project-account-switcher/presenters/ProjectAccountSwitcherPresenter  2`
                 <li
                   className="hig__project-account-switcher__item hig__project-account-switcher__item--project hig__project-account-switcher__item--active"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
                   role="menuitem"
                   tabIndex="0"
                 >

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,15 +2,45 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.0.0-beta.35":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.0.0-beta.35":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
   dependencies:
     "@babel/highlight" "^7.0.0"
 
+"@babel/generator@^7.0.0":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.1.2.tgz#fde75c072575ce7abbd97322e8fef5bae67e4630"
+  dependencies:
+    "@babel/types" "^7.1.2"
+    jsesc "^2.5.1"
+    lodash "^4.17.10"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
+"@babel/helper-function-name@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz#a0ceb01685f73355d4360c1247f582bfafc8ff53"
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.0.0"
+    "@babel/template" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-get-function-arity@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz#83572d4320e2a4657263734113c42868b64e49c3"
+  dependencies:
+    "@babel/types" "^7.0.0"
+
 "@babel/helper-module-imports@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz#96081b7111e486da4d2cd971ad1a4fe216cc2e3d"
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-split-export-declaration@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz#3aae285c0311c2ab095d997b8c9a94cad547d813"
   dependencies:
     "@babel/types" "^7.0.0"
 
@@ -26,7 +56,33 @@
   version "7.0.0-beta.53"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.0.0-beta.53.tgz#1f45eb617bf9463d482b2c04d349d9e4edbf4892"
 
-"@babel/types@^7.0.0":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.1.2":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.1.2.tgz#85c5c47af6d244fab77bce6b9bd830e38c978409"
+
+"@babel/template@^7.1.0":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.1.2.tgz#090484a574fef5a2d2d7726a674eceda5c5b5644"
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.1.2"
+    "@babel/types" "^7.1.2"
+
+"@babel/traverse@^7.0.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.1.0.tgz#503ec6669387efd182c3888c4eec07bcc45d91b2"
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.0.0"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.0.0"
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+    debug "^3.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.10"
+
+"@babel/types@^7.0.0", "@babel/types@^7.1.2":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.1.2.tgz#183e7952cf6691628afdc2e2b90d03240bac80c0"
   dependencies:
@@ -1121,6 +1177,17 @@ babel-core@^6.0.0, babel-core@^6.26.0, babel-core@^6.26.3:
     slash "^1.0.0"
     source-map "^0.5.7"
 
+babel-eslint@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.1.tgz#919681dc099614cd7d31d45c8908695092a1faed"
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    eslint-scope "3.7.1"
+    eslint-visitor-keys "^1.0.0"
+
 babel-generator@^6.18.0, babel-generator@^6.26.0:
   version "6.26.1"
   resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.1.tgz#1844408d3b8f0d35a404ea7ac180f087a601bd90"
@@ -2157,8 +2224,8 @@ boom@5.x.x:
     hoek "4.x.x"
 
 bottleneck@^2.0.1:
-  version "2.11.1"
-  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.11.1.tgz#432d075ea2ee74802666f2556f0f07f12a84e618"
+  version "2.11.2"
+  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.11.2.tgz#e1690e14f664cc3e37096863252061da8600fe47"
 
 boundary@^1.0.1:
   version "1.0.1"
@@ -4476,6 +4543,13 @@ eslint-restricted-globals@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz#35f0d5cbc64c2e3ed62e93b4b1a7af05ba7ed4d7"
 
+eslint-scope@3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
 eslint-scope@^3.7.1:
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.3.tgz#bb507200d3d17f60247636160b4826284b108535"
@@ -5553,7 +5627,7 @@ global@^4.3.2:
     min-document "^2.19.0"
     process "~0.5.1"
 
-globals@^11.0.1:
+globals@^11.0.1, globals@^11.1.0:
   version "11.8.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.8.0.tgz#c1ef45ee9bed6badf0663c5cb90e8d1adec1321d"
 
@@ -7071,6 +7145,10 @@ jsdom@^11.5.1:
 jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
+
+jsesc@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.1.tgz#e421a2a8e20d6b0819df28908f782526b96dd1fe"
 
 jsesc@~0.5.0:
   version "0.5.0"
@@ -11068,7 +11146,7 @@ source-map@^0.4.2:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.0, source-map@~0.5.1, source-map@~0.5.3:
+source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.0, source-map@~0.5.1, source-map@~0.5.3:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 


### PR DESCRIPTION
## Overview

> This is a feature branch PR working towards the removal of legacy packages. It is expected that this branch will fail CI.

Adds missing keyboard interactions to project account switcher actions for improved a11y.

## Related

Contributes to #1208