### PR TITLE
Fix: call `onDismiss` when notifications are dismissed

### DIFF
--- a/packages/notifications-flyout/src/Notification.js
+++ b/packages/notifications-flyout/src/Notification.js
@@ -30,19 +30,12 @@ export default class Notification extends Component {
     hideFlyout: () => {}
   };
 
-  dismiss = () => {
-    const { onDismiss } = this.props;
-
-    if (onDismiss) onDismiss();
-  };
-
   /**
    * @param {NotificationShape} shape
    * @returns {import("react").ReactElement}
    */
   renderChildren() {
-    const { children, hideFlyout } = this.props;
-    const { dismiss } = this;
+    const { children, hideFlyout, onDismiss: dismiss } = this.props;
 
     if (typeof children !== "function") {
       return children;

--- a/packages/notifications-flyout/src/NotificationsFlyout.js
+++ b/packages/notifications-flyout/src/NotificationsFlyout.js
@@ -1,9 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 
+import { combineEventHandlers } from "@hig/utils";
 import Flyout, { anchorPoints, AVAILABLE_ANCHOR_POINTS } from "@hig/flyout";
 import "@hig/flyout/build/index.css";
-import { combineEventHandlers } from "@hig/utils";
 
 import EmptyStatePresenter from "./presenters/EmptyStatePresenter";
 import IndicatorPresenter from "./presenters/IndicatorPresenter";
@@ -12,16 +12,43 @@ import NotificationFlyoutBehavior from "./behaviors/NotificationFlyoutBehavior";
 import Notification from "./Notification";
 import Panel from "./Panel";
 
+/** @typedef {import("./behaviors/parseNotifications").ParsedNotification} ParsedNotification */
+
+/**
+ * @param {Object} payload
+ * @returns {function(ParsedNotification): JSX}
+ */
 function createNotificationRenderer({ hideFlyout, dismissNotification }) {
   /* eslint-disable-next-line react/prop-types */
-  return function renderNotification({ id, key, content, ...otherProps }) {
+  return function renderNotification(notification) {
+    const {
+      content,
+      featured,
+      id,
+      image,
+      key,
+      onDismiss,
+      showDismissButton,
+      timestamp,
+      type,
+      unread
+    } = notification;
+
+    const handleDismiss = combineEventHandlers(onDismiss, () =>
+      dismissNotification(id)
+    );
+
     return (
       <Notification
-        {...otherProps}
+        featured={featured}
         hideFlyout={hideFlyout}
-        id={id}
+        image={image}
         key={key}
-        onDismiss={() => dismissNotification(id)}
+        onDismiss={handleDismiss}
+        showDismissButton={showDismissButton}
+        timestamp={timestamp}
+        type={type}
+        unread={unread}
       >
         {content}
       </Notification>

--- a/packages/notifications-flyout/src/NotificationsFlyout.test.js
+++ b/packages/notifications-flyout/src/NotificationsFlyout.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-
+import { mount } from "enzyme";
 import { anchorPoints } from "@hig/flyout";
 import { takeSnapshotsOf } from "@hig/jest-preset/helpers";
 
@@ -42,4 +42,43 @@ describe("notifications-flyout/NotificationsFlyout", () => {
       }
     }
   ]);
+
+  describe("notification rendering props", () => {
+    describe("handleDismiss", () => {
+      const onDismiss = jest.fn();
+      let wrapper;
+
+      beforeEach(() => {
+        wrapper = mount(
+          <NotificationsFlyout>
+            <Notification onDismiss={onDismiss} />
+          </NotificationsFlyout>
+        );
+
+        jest.clearAllMocks();
+      });
+
+      it("removes the notification from the list", () => {
+        expect(wrapper.find(Notification)).toHaveLength(1);
+
+        wrapper
+          .find(Notification)
+          .props()
+          .onDismiss();
+
+        expect(wrapper.find(Notification)).toHaveLength(0);
+      });
+
+      it("calls the notification `onDismiss` event handler", () => {
+        expect(onDismiss).not.toHaveBeenCalled();
+
+        wrapper
+          .find(Notification)
+          .props()
+          .onDismiss();
+
+        expect(onDismiss).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
 });

--- a/packages/notifications-flyout/src/__fixtures__/createSampleNotifications.js
+++ b/packages/notifications-flyout/src/__fixtures__/createSampleNotifications.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import React from "react";
+import { action } from "@storybook/addon-actions";
 import Avatar, { sizes } from "@hig/avatar";
 import TextLink from "@hig/text-link";
 import Timestamp from "@hig/timestamp";
@@ -23,6 +24,7 @@ export default function createSampleNotifications() {
       id: "featured",
       featured: true,
       unread: true,
+      onDismiss: action("Notification dismissed"),
       timestamp: <Timestamp timestamp={new Date(updatedDate1).toISOString()} />,
       image: (
         <Avatar

--- a/packages/notifications-flyout/src/behaviors/NotificationBehavior.js
+++ b/packages/notifications-flyout/src/behaviors/NotificationBehavior.js
@@ -39,18 +39,14 @@ export default class NotificationBehavior extends Component {
   };
 
   handleExit = () => {
-    this.dismiss();
+    const { onDismiss } = this.props;
+
+    if (onDismiss) onDismiss();
   };
 
   handleDismissButtonClick = () => {
     this.hide();
   };
-
-  dismiss() {
-    const { onDismiss } = this.props;
-
-    if (onDismiss) onDismiss();
-  }
 
   /**
    * Sets the current height of the notification


### PR DESCRIPTION
## Overview

Call `onDismiss` by combining event handlers and add missing test coverage.

## Related

Addresses #1244