### PR TITLE
Fix: exclude only `node_modules` from transpilation

### DIFF
--- a/docs/package-example/package.json
+++ b/docs/package-example/package.json
@@ -23,7 +23,7 @@
     "react-lifecycles-compat": "^3.0.4"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -26,7 +26,7 @@
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/babel-preset/build.js
+++ b/packages/babel-preset/build.js
@@ -1,12 +1,7 @@
 module.exports = function createBuildPreset() {
   return {
     exclude: [
-      "**/node_modules/**",
-      "**/*.css",
-      "**/*.scss",
-      "**/*.html",
-      "**/*.svg",
-      "**/*.json"
+      "**/node_modules/**"
     ],
     presets: [
       [

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@hig/babel-preset",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "HIG Babel preset",
   "author": "Autodesk Inc.",
   "license": "Apache-2.0",

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -28,7 +28,7 @@
     "react-lifecycles-compat": "^3.0.4"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -23,7 +23,7 @@
     "prop-types": "^15.6.1"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -27,7 +27,7 @@
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -54,7 +54,7 @@
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -30,7 +30,7 @@
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/flyout/package.json
+++ b/packages/flyout/package.json
@@ -26,7 +26,7 @@
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/icon-button/package.json
+++ b/packages/icon-button/package.json
@@ -25,7 +25,7 @@
     "prop-types": "^15.6.1"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -24,7 +24,7 @@
     "prop-types": "^15.6.1"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -18,7 +18,7 @@
     "build/*"
   ],
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -26,7 +26,7 @@
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/label/package.json
+++ b/packages/label/package.json
@@ -25,7 +25,7 @@
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -28,7 +28,7 @@
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/multi-downshift/package.json
+++ b/packages/multi-downshift/package.json
@@ -22,7 +22,7 @@
     "prop-types": "^15.6.1"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"

--- a/packages/notifications-flyout/package.json
+++ b/packages/notifications-flyout/package.json
@@ -30,7 +30,7 @@
     "react-transition-group": "^2.3.0"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/notifications-toast/package.json
+++ b/packages/notifications-toast/package.json
@@ -29,7 +29,7 @@
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/profile-flyout/package.json
+++ b/packages/profile-flyout/package.json
@@ -28,7 +28,7 @@
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -25,7 +25,7 @@
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/progress-ring/package.json
+++ b/packages/progress-ring/package.json
@@ -27,7 +27,7 @@
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/project-account-switcher/package.json
+++ b/packages/project-account-switcher/package.json
@@ -28,7 +28,7 @@
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/radio-button/package.json
+++ b/packages/radio-button/package.json
@@ -27,7 +27,7 @@
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -23,7 +23,7 @@
     "prop-types": "^15.6.1"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -14,7 +14,7 @@
     "hig-scripts-is-stable-package": "bin/is-stable-package.js"
   },
   "dependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "babel-eslint": "^10.0.1",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-env": "^1.6.1",

--- a/packages/semantic-release-config/package.json
+++ b/packages/semantic-release-config/package.json
@@ -22,7 +22,7 @@
     "upgrade-dependents": "^1.0.0"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/side-nav/package.json
+++ b/packages/side-nav/package.json
@@ -28,7 +28,7 @@
     "prop-types": "^15.6.1"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/skeleton-item/package.json
+++ b/packages/skeleton-item/package.json
@@ -24,7 +24,7 @@
     "prop-types": "^15.6.1"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -26,7 +26,7 @@
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/spacer/package.json
+++ b/packages/spacer/package.json
@@ -22,7 +22,7 @@
     "prop-types": "^15.6.1"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -20,7 +20,7 @@
     "tokens/*"
   ],
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -30,7 +30,7 @@
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -29,7 +29,7 @@
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -26,7 +26,7 @@
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/text-field/package.json
+++ b/packages/text-field/package.json
@@ -28,7 +28,7 @@
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/text-link/package.json
+++ b/packages/text-link/package.json
@@ -27,7 +27,7 @@
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/theme-data/package.json
+++ b/packages/theme-data/package.json
@@ -25,7 +25,7 @@
     "lint": "hig-scripts-lint"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -22,7 +22,7 @@
     "prop-types": "^15.6.1"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/timestamp/package.json
+++ b/packages/timestamp/package.json
@@ -23,7 +23,7 @@
     "prop-types": "^15.6.1"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -27,7 +27,7 @@
     "react": "^15.4.1 || ^16.3.2"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/top-nav/package.json
+++ b/packages/top-nav/package.json
@@ -27,7 +27,7 @@
     "prop-types": "^15.6.1"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -23,7 +23,7 @@
     "prop-types": "^15.6.1"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -20,7 +20,7 @@
     "lodash.memoize": "^4.1.2"
   },
   "devDependencies": {
-    "@hig/babel-preset": "^0.1.0",
+    "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",


### PR DESCRIPTION
## Overview

This PR allows Babel to transpile all imported modules except those from `node_modules`.

Specifically, this prevents `rollup-plugin-react-svg` from producing syntax that's invalid for older browsers (e.g. IE11).