### PR TITLE
chore(storybook): improve dynamic storybook domain generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,7 @@ jobs:
           command: yarn run extract
       - run:
           name: Deploy Storybook
-          command: yarn storybook-deploy --domain `echo hig-$CIRCLE_BRANCH.surge.sh | awk 'echo gsub(/\//, "-")'`
+          command: yarn storybook-deploy-ci
           working_directory: packages/storybook
   packages-deploy:
     <<: *defaults

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -17,6 +17,7 @@
     "storybook": "start-storybook -p 9001 -c .storybook/development",
     "storybook-build": "build-storybook -c .storybook/development",
     "storybook-deploy": "build-storybook -c .storybook/development && surge --project storybook-static",
+    "storybook-deploy-ci": "yarn storybook-deploy --domain `bash ./scripts/storybookDomain.sh`",
     "storybook-test": "start-storybook -p 9876 -c .storybook/test",
     "storybook-test-build": "build-storybook -c .storybook/test -o storybook-gemini-test",
     "storybook-test-serve": "http-server storybook-gemini-test -p 9876"

--- a/packages/storybook/scripts/storybookDomain.sh
+++ b/packages/storybook/scripts/storybookDomain.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Using the branch name
-# 1. Remove all characters that are not non-alphanumeric, hyphens, periods, or forward slashes
+# 1. Remove all characters that are not alphanumeric, hyphens, periods, or forward slashes
 # 2. Replace forward slashes and periods with hyphens
 # 3. Translate characters to lowercase
 storybookSubDomainSuffix() {

--- a/packages/storybook/scripts/storybookDomain.sh
+++ b/packages/storybook/scripts/storybookDomain.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Using the branch name
+# 1. Remove all characters that are not non-alphanumeric, hyphens, periods, or forward slashes
+# 2. Replace forward slashes and periods with hyphens
+# 3. Translate characters to lowercase
+storybookSubDomainSuffix() {
+  echo $CIRCLE_BRANCH | awk '{ gsub(/[^a-zA-Z0-9-.\/]/, ""); gsub(/[\/.]/, "-"); $0=tolower($0); print }'
+}
+
+echo "hig-$(storybookSubDomainSuffix).surge.sh"


### PR DESCRIPTION
## Overview

CI builds were failing for branches created by Greenkeeper. This was due to invalid subdomains being generated for the branch storybooks.

## Related

Resolves #1299