### PR TITLE
Theme data for icons

### DIFF
--- a/packages/theme-data/src/baseTheme/system/colorScheme.js
+++ b/packages/theme-data/src/baseTheme/system/colorScheme.js
@@ -12,5 +12,6 @@ export default {
   textColor: { type: COLOR },
   textColorDim: { type: COLOR },
   lowShadowColor: { type: COLOR },
-  highShadowColor: { type: COLOR }
+  highShadowColor: { type: COLOR },
+  iconColor: { type: COLOR }
 };

--- a/packages/theme-data/src/baseTheme/system/colorScheme.js
+++ b/packages/theme-data/src/baseTheme/system/colorScheme.js
@@ -1,17 +1,17 @@
 import { COLOR } from "../../consts/types";
 
 export default {
+  accentColor: { type: COLOR },
+  baseColor: { type: COLOR },
+  highShadowColor: { type: COLOR },
+  iconColor: { type: COLOR },
+  lowShadowColor: { type: COLOR },
   surfaceLevel100Color: { type: COLOR },
   surfaceLevel200Color: { type: COLOR },
   surfaceLevel250Color: { type: COLOR },
   surfaceLevel300Color: { type: COLOR },
   surfaceLevel350Color: { type: COLOR },
-  baseColor: { type: COLOR },
-  accentColor: { type: COLOR },
   "component.backgroundColor": { type: COLOR },
   textColor: { type: COLOR },
-  textColorDim: { type: COLOR },
-  lowShadowColor: { type: COLOR },
-  highShadowColor: { type: COLOR },
-  iconColor: { type: COLOR }
+  textColorDim: { type: COLOR }
 };

--- a/packages/theme-data/src/basics/colors.js
+++ b/packages/theme-data/src/basics/colors.js
@@ -5,16 +5,6 @@ export default {
   white: { value: "#ffffff", type: COLOR },
 
   // Primary colors
-  charcoal100: { value: "#eeeeee", type: COLOR },
-  charcoal200: { value: "#dcdcdc", type: COLOR },
-  charcoal300: { value: "#cccccc", type: COLOR },
-  charcoal400: { value: "#bbbbbb", type: COLOR },
-  charcoal500: { value: "#999999", type: COLOR },
-  charcoal600: { value: "#808080", type: COLOR },
-  charcoal700: { value: "#666666", type: COLOR },
-  charcoal800: { value: "#4d4d4d", type: COLOR },
-  charcoal900: { value: "#3c3c3c", type: COLOR },
-
   autodeskBlue100: { value: "#cdeaf7", type: COLOR },
   autodeskBlue200: { value: "#9bd5ef", type: COLOR },
   autodeskBlue300: { value: "#6ac0e7", type: COLOR },
@@ -24,6 +14,16 @@ export default {
   autodeskBlue700: { value: "#0571a1", type: COLOR },
   autodeskBlue800: { value: "#034b6c", type: COLOR },
   autodeskBlue900: { value: "#022c40", type: COLOR },
+
+  charcoal100: { value: "#eeeeee", type: COLOR },
+  charcoal200: { value: "#dcdcdc", type: COLOR },
+  charcoal300: { value: "#cccccc", type: COLOR },
+  charcoal400: { value: "#bbbbbb", type: COLOR },
+  charcoal500: { value: "#999999", type: COLOR },
+  charcoal600: { value: "#808080", type: COLOR },
+  charcoal700: { value: "#666666", type: COLOR },
+  charcoal800: { value: "#4d4d4d", type: COLOR },
+  charcoal900: { value: "#3c3c3c", type: COLOR },
 
   // Secondary colors
   darkBlue100: { value: "#e1ebf7", type: COLOR },
@@ -35,16 +35,6 @@ export default {
   darkBlue700: { value: "#12437f", type: COLOR },
   darkBlue800: { value: "#0e3666", type: COLOR },
   darkBlue900: { value: "#0c2c54", type: COLOR },
-
-  turquoise100: { value: "#d6f2ef", type: COLOR },
-  turquoise200: { value: "#ade4de", type: COLOR },
-  turquoise300: { value: "#84d7ce", type: COLOR },
-  turquoise400: { value: "#5bc9bd", type: COLOR },
-  turquoise500: { value: "#32bcad", type: COLOR },
-  turquoise600: { value: "#23a597", type: COLOR },
-  turquoise700: { value: "#268d82", type: COLOR },
-  turquoise800: { value: "#20756c", type: COLOR },
-  turquoise900: { value: "#195e57", type: COLOR },
 
   green100: { value: "#e7f2d9", type: COLOR },
   green200: { value: "#cfe4b3", type: COLOR },
@@ -60,16 +50,6 @@ export default {
   iconDarkBlueColor: { value: "#a2a6b0", type: COLOR },
   iconDarkGrayColor: { value: "#b0b0b0", type: COLOR },
 
-  yellowOrange100: { value: "#feecd1", type: COLOR },
-  yellowOrange200: { value: "#fddaa4", type: COLOR },
-  yellowOrange300: { value: "#fcc776", type: COLOR },
-  yellowOrange400: { value: "#fbb549", type: COLOR },
-  yellowOrange500: { value: "#faa21b", type: COLOR },
-  yellowOrange600: { value: "#bb7a14", type: COLOR },
-  yellowOrange700: { value: "#916010", type: COLOR },
-  yellowOrange800: { value: "#7d510e", type: COLOR },
-  yellowOrange900: { value: "#523609", type: COLOR },
-
   red100: { value: "#ffd9d9", type: COLOR },
   red200: { value: "#f8d3d3", type: COLOR },
   red300: { value: "#f1a7a7", type: COLOR },
@@ -80,16 +60,36 @@ export default {
   red800: { value: "#6f1111", type: COLOR },
   red900: { value: "#630f0f", type: COLOR },
 
+  turquoise100: { value: "#d6f2ef", type: COLOR },
+  turquoise200: { value: "#ade4de", type: COLOR },
+  turquoise300: { value: "#84d7ce", type: COLOR },
+  turquoise400: { value: "#5bc9bd", type: COLOR },
+  turquoise500: { value: "#32bcad", type: COLOR },
+  turquoise600: { value: "#23a597", type: COLOR },
+  turquoise700: { value: "#268d82", type: COLOR },
+  turquoise800: { value: "#20756c", type: COLOR },
+  turquoise900: { value: "#195e57", type: COLOR },
+
+  yellowOrange100: { value: "#feecd1", type: COLOR },
+  yellowOrange200: { value: "#fddaa4", type: COLOR },
+  yellowOrange300: { value: "#fcc776", type: COLOR },
+  yellowOrange400: { value: "#fbb549", type: COLOR },
+  yellowOrange500: { value: "#faa21b", type: COLOR },
+  yellowOrange600: { value: "#bb7a14", type: COLOR },
+  yellowOrange700: { value: "#916010", type: COLOR },
+  yellowOrange800: { value: "#7d510e", type: COLOR },
+  yellowOrange900: { value: "#523609", type: COLOR },
+
   // Tertiary colors
-  slate100: { value: "#e9f0f7", type: COLOR },
-  slate200: { value: "#dce7f3", type: COLOR },
-  slate300: { value: "#c1cedc", type: COLOR },
-  slate400: { value: "#a7bacf", type: COLOR },
-  slate500: { value: "#7993b0", type: COLOR },
-  slate600: { value: "#6784a6", type: COLOR },
-  slate700: { value: "#4b6b8f", type: COLOR },
-  slate800: { value: "#354d67", type: COLOR },
-  slate900: { value: "#2c3e53", type: COLOR },
+  pink100: { value: "#ffebf5", type: COLOR },
+  pink200: { value: "#ffd6eb", type: COLOR },
+  pink300: { value: "#ffb8db", type: COLOR },
+  pink400: { value: "#ff8cc6", type: COLOR },
+  pink500: { value: "#fc56a9", type: COLOR },
+  pink600: { value: "#e84396", type: COLOR },
+  pink700: { value: "#c72877", type: COLOR },
+  pink800: { value: "#991f5c", type: COLOR },
+  pink900: { value: "#781848", type: COLOR },
 
   purple100: { value: "#f4edfd", type: COLOR },
   purple200: { value: "#eadcfd", type: COLOR },
@@ -101,16 +101,6 @@ export default {
   purple800: { value: "#5f3e8e", type: COLOR },
   purple900: { value: "#482f6b", type: COLOR },
 
-  pink100: { value: "#ffebf5", type: COLOR },
-  pink200: { value: "#ffd6eb", type: COLOR },
-  pink300: { value: "#ffb8db", type: COLOR },
-  pink400: { value: "#ff8cc6", type: COLOR },
-  pink500: { value: "#fc56a9", type: COLOR },
-  pink600: { value: "#e84396", type: COLOR },
-  pink700: { value: "#c72877", type: COLOR },
-  pink800: { value: "#991f5c", type: COLOR },
-  pink900: { value: "#781848", type: COLOR },
-
   salmon100: { value: "#ffefec", type: COLOR },
   salmon200: { value: "#fcded9", type: COLOR },
   salmon300: { value: "#ffbeb3", type: COLOR },
@@ -121,14 +111,17 @@ export default {
   salmon800: { value: "#853729", type: COLOR },
   salmon900: { value: "#66251a", type: COLOR },
 
-  // Surface colors
-  surfaceLightGrayLevel100: { value: "#ffffff", type: COLOR },
-  surfaceLightGrayLevel200: { value: "#f5f5f5", type: COLOR },
-  surfaceLightGrayLevel250: { value: "#eeeeee", type: COLOR },
-  surfaceLightGrayLevel300: { value: "#d9d9d9", type: COLOR },
-  surfaceLightGrayLevel350: { value: "#cccccc", type: COLOR },
-  surfaceLightGrayShadow: { value: "#000000", type: COLOR },
+  slate100: { value: "#e9f0f7", type: COLOR },
+  slate200: { value: "#dce7f3", type: COLOR },
+  slate300: { value: "#c1cedc", type: COLOR },
+  slate400: { value: "#a7bacf", type: COLOR },
+  slate500: { value: "#7993b0", type: COLOR },
+  slate600: { value: "#6784a6", type: COLOR },
+  slate700: { value: "#4b6b8f", type: COLOR },
+  slate800: { value: "#354d67", type: COLOR },
+  slate900: { value: "#2c3e53", type: COLOR },
 
+  // Surface colors
   surfaceDarkBlueLevel100: { value: "#464e61", type: COLOR },
   surfaceDarkBlueLevel200: { value: "#3b4453", type: COLOR },
   surfaceDarkBlueLevel250: { value: "#2e3440", type: COLOR },
@@ -143,12 +136,19 @@ export default {
   surfaceDarkGrayLevel350: { value: "#202020", type: COLOR },
   surfaceDarkGrayShadow: { value: "#000000", type: COLOR },
 
+  surfaceLightGrayLevel100: { value: "#ffffff", type: COLOR },
+  surfaceLightGrayLevel200: { value: "#f5f5f5", type: COLOR },
+  surfaceLightGrayLevel250: { value: "#eeeeee", type: COLOR },
+  surfaceLightGrayLevel300: { value: "#d9d9d9", type: COLOR },
+  surfaceLightGrayLevel350: { value: "#cccccc", type: COLOR },
+  surfaceLightGrayShadow: { value: "#000000", type: COLOR },
+
   // Text colors
-  textAgainstLight: { value: "#3c3c3c", type: COLOR },
   textAgainstDark: { value: "#f5f5f5", type: COLOR },
+  textAgainstLight: { value: "#3c3c3c", type: COLOR },
 
   // Alert colors
+  error: { value: "#ec4a41", type: COLOR },
   success: { value: "#87b340", type: COLOR },
-  warning: { value: "#faa21b", type: COLOR },
-  error: { value: "#ec4a41", type: COLOR }
+  warning: { value: "#faa21b", type: COLOR }
 };

--- a/packages/theme-data/src/basics/colors.js
+++ b/packages/theme-data/src/basics/colors.js
@@ -56,6 +56,10 @@ export default {
   green800: { value: "#4c6b24", type: COLOR },
   green900: { value: "#445e20", type: COLOR },
 
+  iconLightGrayColor: { value: "#808080", type: COLOR },
+  iconDarkBlueColor: { value: "#a2a6b0", type: COLOR },
+  iconDarkGrayColor: { value: "#b0b0b0", type: COLOR },
+
   yellowOrange100: { value: "#feecd1", type: COLOR },
   yellowOrange200: { value: "#fddaa4", type: COLOR },
   yellowOrange300: { value: "#fcc776", type: COLOR },

--- a/packages/theme-data/src/colorSchemes/darkBlue/system/colorScheme.js
+++ b/packages/theme-data/src/colorSchemes/darkBlue/system/colorScheme.js
@@ -67,5 +67,8 @@ export default {
     transform: {
       alpha: 0.6
     }
+  },
+  iconColor: {
+    value: { ref: "basics.colors.iconDarkBlueColor" }
   }
 };

--- a/packages/theme-data/src/colorSchemes/darkBlue/system/colorScheme.js
+++ b/packages/theme-data/src/colorSchemes/darkBlue/system/colorScheme.js
@@ -1,4 +1,38 @@
 export default {
+  accentColor: {
+    value: {
+      ref: "basics.colors.autodeskBlue500"
+    }
+  },
+  baseColor: {
+    value: {
+      ref: "basics.colors.charcoal600"
+    }
+  },
+  "component.backgroundColor": {
+    value: {
+      ref: "basics.colors.surfaceDarkBlueLevel200"
+    }
+  },
+  highShadowColor: {
+    value: {
+      ref: "basics.colors.surfaceDarkBlueShadow"
+    },
+    transform: {
+      alpha: 0.5
+    }
+  },
+  iconColor: {
+    value: { ref: "basics.colors.iconDarkBlueColor" }
+  },
+  lowShadowColor: {
+    value: {
+      ref: "basics.colors.surfaceDarkBlueShadow"
+    },
+    transform: {
+      alpha: 0.8
+    }
+  },
   surfaceLevel100Color: {
     value: {
       ref: "basics.colors.surfaceDarkBlueLevel100"
@@ -24,37 +58,6 @@ export default {
       ref: "basics.colors.surfaceDarkBlueLevel350"
     }
   },
-  lowShadowColor: {
-    value: {
-      ref: "basics.colors.surfaceDarkBlueShadow"
-    },
-    transform: {
-      alpha: 0.8
-    }
-  },
-  highShadowColor: {
-    value: {
-      ref: "basics.colors.surfaceDarkBlueShadow"
-    },
-    transform: {
-      alpha: 0.5
-    }
-  },
-  baseColor: {
-    value: {
-      ref: "basics.colors.charcoal600"
-    }
-  },
-  accentColor: {
-    value: {
-      ref: "basics.colors.autodeskBlue500"
-    }
-  },
-  "component.backgroundColor": {
-    value: {
-      ref: "basics.colors.surfaceDarkBlueLevel200"
-    }
-  },
   textColor: {
     value: {
       ref: "basics.colors.textAgainstDark"
@@ -67,8 +70,5 @@ export default {
     transform: {
       alpha: 0.6
     }
-  },
-  iconColor: {
-    value: { ref: "basics.colors.iconDarkBlueColor" }
   }
 };

--- a/packages/theme-data/src/colorSchemes/lightGray/system/colorScheme.js
+++ b/packages/theme-data/src/colorSchemes/lightGray/system/colorScheme.js
@@ -1,4 +1,38 @@
 export default {
+  accentColor: {
+    value: {
+      ref: "basics.colors.autodeskBlue500"
+    }
+  },
+  baseColor: {
+    value: {
+      ref: "basics.colors.charcoal600"
+    }
+  },
+  "component.backgroundColor": {
+    value: {
+      ref: "basics.colors.white"
+    }
+  },
+  highShadowColor: {
+    value: {
+      ref: "basics.colors.surfaceLightGrayShadow"
+    },
+    transform: {
+      alpha: 0.25
+    }
+  },
+  iconColor: {
+    value: { ref: "basics.colors.iconLightGrayColor" }
+  },
+  lowShadowColor: {
+    value: {
+      ref: "basics.colors.surfaceLightGrayShadow"
+    },
+    transform: {
+      alpha: 0.25
+    }
+  },
   surfaceLevel100Color: {
     value: {
       ref: "basics.colors.surfaceLightGrayLevel100"
@@ -24,32 +58,6 @@ export default {
       ref: "basics.colors.surfaceLightGrayLevel350"
     }
   },
-  lowShadowColor: {
-    value: {
-      ref: "basics.colors.surfaceLightGrayShadow"
-    },
-    transform: {
-      alpha: 0.25
-    }
-  },
-  highShadowColor: {
-    value: {
-      ref: "basics.colors.surfaceLightGrayShadow"
-    },
-    transform: {
-      alpha: 0.25
-    }
-  },
-  baseColor: {
-    value: {
-      ref: "basics.colors.charcoal600"
-    }
-  },
-  accentColor: {
-    value: {
-      ref: "basics.colors.autodeskBlue500"
-    }
-  },
   textColor: {
     value: {
       ref: "basics.colors.textAgainstLight"
@@ -62,13 +70,5 @@ export default {
     transform: {
       alpha: 0.6
     }
-  },
-  "component.backgroundColor": {
-    value: {
-      ref: "basics.colors.white"
-    }
-  },
-  iconColor: {
-    value: { ref: "basics.colors.iconLightGrayColor" }
   }
 };

--- a/packages/theme-data/src/colorSchemes/lightGray/system/colorScheme.js
+++ b/packages/theme-data/src/colorSchemes/lightGray/system/colorScheme.js
@@ -67,5 +67,8 @@ export default {
     value: {
       ref: "basics.colors.white"
     }
+  },
+  iconColor: {
+    value: { ref: "basics.colors.iconLightGrayColor" }
   }
 };


### PR DESCRIPTION
Resolves #1369 

# Validation
1. `yarn build` at project root
1. run storybook and see that...
 a. ...under Theme data > Color scheme that `colorScheme.iconColor` is defined and that you can switch the knob between light gray and dark blue
 b. ...under Theme data > Basics - Colors that `basics.colors.iconLightGrayColor`, `basics.colors.iconDarkBlueColor`, `basics.colors.iconDarkGrayColor` are defined