### PR TITLE
chore: fix yarn lock after greenkeeper dependency update

### DIFF
--- a/packages/dropdown/src/presenters/InputPresenter.js
+++ b/packages/dropdown/src/presenters/InputPresenter.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { Caret24 } from "@hig/icons";
 import { TextFieldPresenter } from "@hig/text-field";
-import "@hig/icon/build/index.css";
 import "@hig/text-field/build/index.css";
 
 import "./InputPresenter.scss";

--- a/packages/notifications-toast/src/NotificationsToast.js
+++ b/packages/notifications-toast/src/NotificationsToast.js
@@ -4,7 +4,6 @@ import cx from "classnames";
 import IconButton from "@hig/icon-button";
 import { CloseNotification24 } from "@hig/icons";
 import RichText from "@hig/rich-text";
-import "@hig/icon/build/index.css";
 import "@hig/icon-button/build/index.css";
 import "@hig/rich-text/build/index.css";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -143,42 +143,6 @@
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.2.tgz#63985d3d8b02530e0869962f4da09142ee8e200e"
 
-"@hig/dropdown@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@hig/dropdown/-/dropdown-0.3.0.tgz#bd764146a2d3b196021ecac323dc7fa5b7500d1e"
-  dependencies:
-    "@hig/icon" "^0.2.0"
-    "@hig/multi-downshift" "^0.1.0"
-    "@hig/text-field" "^0.4.2"
-    classnames "^2.2.5"
-    downshift "^2.0.12"
-    prop-types "^15.6.1"
-    react-lifecycles-compat "^3.0.4"
-
-"@hig/icon-button@^0.2.1":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@hig/icon-button/-/icon-button-0.2.2.tgz#3a98c563306c73bc719cc40b2a73f4077de25a9f"
-  integrity sha512-G9xjDMq0tgqmBvwkA/Aph0qhEi+0+utaFcAefYLJt3yV7IytJry1iuWTSS4qowYx+x68NmNQ77RepBpPkULdcg==
-  dependencies:
-    "@hig/icon" "^0.2.1"
-    "@hig/icons" "^0.2.1"
-    classnames "^2.2.5"
-    prop-types "^15.6.1"
-
-"@hig/icon@^0.2.0", "@hig/icon@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@hig/icon/-/icon-0.2.1.tgz#a6cc07a66ee824a678de5738640b1c157e544c77"
-  integrity sha512-qaIYUB/lzc5sBnhNjQGT0/Hy5ll8+QfSzv74c12f4gTag74W0VH2zajcrzOBsFLyHGQO8UDV7Oqzm/+AwiGEBw==
-  dependencies:
-    "@hig/icons" "^0.2.1"
-    classnames "^2.2.5"
-    prop-types "^15.6.1"
-
-"@hig/icons@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@hig/icons/-/icons-0.2.1.tgz#9a29bc9add5e3fe549c6a07e4b57fe8e9b3af813"
-  integrity sha512-6sW3jUeHI9dbmW30p03p0gBIlAdcwmF0eIZEbfFA6mby9UMYVC5GjnxKlyTtlStctGNh/FphLjvjxkOZVdKMzA==
-
 "@hig/skeleton-item@^0.3.0":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@hig/skeleton-item/-/skeleton-item-0.3.1.tgz#9729eb499d40ff61996558a179608862338193b7"
@@ -190,16 +154,6 @@
 "@hig/styles@^0.2.3":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@hig/styles/-/styles-0.2.3.tgz#675631d008c1861921d6148ecf15b140c04cc5b4"
-
-"@hig/text-field@^0.4.2":
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/@hig/text-field/-/text-field-0.4.5.tgz#299648be902619b35088cf6496e6f0aac547511d"
-  dependencies:
-    "@hig/icon-button" "^0.2.1"
-    "@hig/utils" "^0.3.0"
-    classnames "^2.2.5"
-    prop-types "^15.6.1"
-    react-lifecycles-compat "^3.0.4"
 
 "@hig/theme-data-poc@^0.0.8-alpha":
   version "0.0.8-alpha"
@@ -3091,7 +3045,7 @@ compress-commons@^1.2.0:
     normalize-path "^2.0.0"
     readable-stream "^2.0.0"
 
-compute-scroll-into-view@^1.0.2, compute-scroll-into-view@^1.0.9:
+compute-scroll-into-view@^1.0.9:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.11.tgz#7ff0a57f9aeda6314132d8994cce7aeca794fecf"
 
@@ -4122,13 +4076,6 @@ dotenv-webpack@^1.5.5:
 dotenv@^5.0.1:
   version "5.0.1"
   resolved "http://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz#a5317459bd3d79ab88cff6e44057a6a3fbb1fcef"
-
-downshift@^2.0.12:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-2.2.3.tgz#85187568455134e72025fbddd40bb9cf96c55eed"
-  dependencies:
-    compute-scroll-into-view "^1.0.2"
-    prop-types "^15.6.0"
 
 downshift@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
also removes leftover `icon` css dependencies.