### PR TITLE
chore: storybook knobbed theme provider default is all 4 themes

### DIFF
--- a/packages/avatar/src/__stories__/renderStory.js
+++ b/packages/avatar/src/__stories__/renderStory.js
@@ -1,7 +1,5 @@
 import React from "react";
-import KnobbedThemeProvider, {
-  THEMES
-} from "@hig/storybook/storybook-support/decorators/KnobbedThemeProvider";
+import KnobbedThemeProvider from "@hig/storybook/storybook-support/decorators/KnobbedThemeProvider";
 import DefaultExport from "../index";
 import getKnobs from "./getKnobs";
 
@@ -9,9 +7,7 @@ export default function renderStory(props) {
   const { children, theme, ...otherProps } = getKnobs(props);
 
   return (
-    <KnobbedThemeProvider
-      supportedThemes={[THEMES.WEB_LIGHT, THEMES.DARK_BLUE, THEMES.LIGHT_GRAY]}
-    >
+    <KnobbedThemeProvider>
       <DefaultExport {...otherProps}>{children}</DefaultExport>
     </KnobbedThemeProvider>
   );

--- a/packages/button/src/__stories__/renderStory.js
+++ b/packages/button/src/__stories__/renderStory.js
@@ -1,7 +1,5 @@
 import React from "react";
-import KnobbedThemeProvider, {
-  THEMES
-} from "@hig/storybook/storybook-support/decorators/KnobbedThemeProvider";
+import KnobbedThemeProvider from "@hig/storybook/storybook-support/decorators/KnobbedThemeProvider";
 import DefaultExport from "../index";
 import getKnobs from "./getKnobs";
 
@@ -9,9 +7,7 @@ export default function renderStory(props) {
   const { children, theme, ...otherProps } = getKnobs(props);
 
   return (
-    <KnobbedThemeProvider
-      supportedThemes={[THEMES.WEB_LIGHT, THEMES.LIGHT_GRAY, THEMES.DARK_BLUE]}
-    >
+    <KnobbedThemeProvider>
       <DefaultExport {...otherProps}>{children}</DefaultExport>
     </KnobbedThemeProvider>
   );

--- a/packages/flyout/src/__stories__/renderStory.js
+++ b/packages/flyout/src/__stories__/renderStory.js
@@ -1,8 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-import KnobbedThemeProvider, {
-  THEMES
-} from "@hig/storybook/storybook-support/decorators/KnobbedThemeProvider";
+import KnobbedThemeProvider from "@hig/storybook/storybook-support/decorators/KnobbedThemeProvider";
 import Flyout from "../index";
 import getKnobs from "./getKnobs";
 
@@ -25,9 +23,7 @@ export default function renderStory(props) {
   const { children, ...otherProps } = getKnobs(props);
 
   return (
-    <KnobbedThemeProvider
-      supportedThemes={[THEMES.WEB_LIGHT, THEMES.DARK_BLUE, THEMES.LIGHT_GRAY]}
-    >
+    <KnobbedThemeProvider>
       <Wrapper>
         <Flyout {...otherProps}>{children}</Flyout>
       </Wrapper>

--- a/packages/input/src/__stories__/renderStory.js
+++ b/packages/input/src/__stories__/renderStory.js
@@ -1,8 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import KnobbedThemeProvider, {
-  THEMES
-} from "@hig/storybook/storybook-support/decorators/KnobbedThemeProvider";
+import KnobbedThemeProvider from "@hig/storybook/storybook-support/decorators/KnobbedThemeProvider";
 import Input from "../index";
 import getKnobs from "./getKnobs";
 
@@ -10,9 +8,7 @@ export default function renderStory(props) {
   const { theme, ...otherProps } = getKnobs(props);
 
   return (
-    <KnobbedThemeProvider
-      supportedThemes={[THEMES.LIGHT_GRAY, THEMES.WEB_LIGHT, THEMES.DARK_BLUE]}
-    >
+    <KnobbedThemeProvider>
       <Input {...otherProps} />
     </KnobbedThemeProvider>
   );

--- a/packages/label/src/__stories__/withThemeProvider.js
+++ b/packages/label/src/__stories__/withThemeProvider.js
@@ -1,13 +1,9 @@
 import React from "react";
-import KnobbedThemeProvider, {
-  THEMES
-} from "@hig/storybook/storybook-support/decorators/KnobbedThemeProvider";
+import KnobbedThemeProvider from "@hig/storybook/storybook-support/decorators/KnobbedThemeProvider";
 
 export default function renderStory(children) {
   return (
-    <KnobbedThemeProvider
-      supportedThemes={[THEMES.LIGHT_GRAY, THEMES.WEB_LIGHT, THEMES.DARK_BLUE]}
-    >
+    <KnobbedThemeProvider>
       <div>{children}</div>
     </KnobbedThemeProvider>
   );

--- a/packages/skeleton-item/src/__stories__/renderStory.js
+++ b/packages/skeleton-item/src/__stories__/renderStory.js
@@ -1,7 +1,5 @@
 import React from "react";
-import KnobbedThemeProvider, {
-  THEMES
-} from "@hig/storybook/storybook-support/decorators/KnobbedThemeProvider";
+import KnobbedThemeProvider from "@hig/storybook/storybook-support/decorators/KnobbedThemeProvider";
 import DefaultExport from "../index";
 import getKnobs from "./getKnobs";
 
@@ -9,9 +7,7 @@ export default function renderStory(props) {
   const { children, theme, ...otherProps } = getKnobs(props);
 
   return (
-    <KnobbedThemeProvider
-      supportedThemes={[THEMES.WEB_LIGHT, THEMES.DARK_BLUE]}
-    >
+    <KnobbedThemeProvider>
       <DefaultExport {...otherProps}>{children}</DefaultExport>
     </KnobbedThemeProvider>
   );

--- a/packages/spacer/src/__stories__/renderStory.js
+++ b/packages/spacer/src/__stories__/renderStory.js
@@ -1,7 +1,5 @@
 import React from "react";
-import KnobbedThemeProvider, {
-  THEMES
-} from "@hig/storybook/storybook-support/decorators/KnobbedThemeProvider";
+import KnobbedThemeProvider from "@hig/storybook/storybook-support/decorators/KnobbedThemeProvider";
 import DefaultExport from "../index";
 import getKnobs from "./getKnobs";
 
@@ -9,9 +7,7 @@ export default function renderStory(props) {
   const { children, theme, ...otherProps } = getKnobs(props);
 
   return (
-    <KnobbedThemeProvider
-      supportedThemes={[THEMES.WEB_LIGHT, THEMES.DARK_BLUE]}
-    >
+    <KnobbedThemeProvider>
       <div
         style={{ width: "100px", height: "100px", backgroundColor: "blue" }}
       />

--- a/packages/storybook/storybook-support/decorators/KnobbedThemeProvider.js
+++ b/packages/storybook/storybook-support/decorators/KnobbedThemeProvider.js
@@ -79,10 +79,11 @@ Surface.propTypes = {
 };
 
 const KnobbedThemeProvider = ({ children, supportedThemes }) => {
+  const storybookThemes = supportedThemes ? supportedThemes : Object.values(COLOR_THEME_IDS);
   const knobGroup = "Theme";
   const themeId = select(
     "Color scheme",
-    themeOptions(supportedThemes),
+    themeOptions(storybookThemes),
     DEFAULT_THEME_ID,
     knobGroup
   );
@@ -93,7 +94,6 @@ const KnobbedThemeProvider = ({ children, supportedThemes }) => {
     knobGroup
   );
   const theme = themes[densityId][themeId];
-
   return (
     <ThemeContext.Provider value={theme}>
       <Surface>{children}</Surface>
@@ -109,7 +109,6 @@ KnobbedThemeProvider.propTypes = {
 };
 
 KnobbedThemeProvider.defaultProps = {
-  supportedThemes: [DEFAULT_THEME_ID],
   supportedDensities: [DEFAULT_DENSITY_ID]
 };
 

--- a/packages/theme-data/src/__stories__/ThemeData.stories.js
+++ b/packages/theme-data/src/__stories__/ThemeData.stories.js
@@ -3,9 +3,7 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import { withInfo } from "@storybook/addon-info";
 import RichText from "@hig/rich-text";
-import KnobbedThemeProvider, {
-  THEMES
-} from "@hig/storybook/storybook-support/decorators/KnobbedThemeProvider";
+import KnobbedThemeProvider from "@hig/storybook/storybook-support/decorators/KnobbedThemeProvider";
 import { ThemeContext } from "@hig/theme-context";
 import "@hig/rich-text/build/index.css";
 
@@ -45,13 +43,7 @@ stories.forEach(({ description, schema, readme }) => {
         <RichText dangerouslySetInnerHTML={{ __html: readme }} />
       ) : null
     })(() => (
-      <KnobbedThemeProvider
-        supportedThemes={[
-          THEMES.LIGHT_GRAY,
-          THEMES.WEB_LIGHT,
-          THEMES.DARK_BLUE
-        ]}
-      >
+      <KnobbedThemeProvider>
         <ThemeContext.Consumer>
           {({ resolvedRoles, metadata }) => (
             <div>


### PR DESCRIPTION
Resolves: https://github.com/Autodesk/hig/issues/1449. Now in `storybook` if you just use `KnobbedThemeProvider` without a `supportedThemes` prop then it will by default show web light, dark blue, light gray, and dark gray. If you want it to show only certain themes or a custom theme, then you would supply them through the `supportedThemes` prop like before.