### PR TITLE
Use semantic typography retry

### DIFF
--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hig/typography",
-  "version": "0.1.5-alpha",
+  "version": "0.1.6-alpha",
   "description": "HIG Typography components",
   "author": "Autodesk Inc.",
   "license": "Apache-2.0",

--- a/packages/typography/src/Typography.js
+++ b/packages/typography/src/Typography.js
@@ -18,6 +18,14 @@ export default class Typography extends Component {
      */
     align: PropTypes.oneOf(AVAILABLE_ALIGNMENTS),
     /**
+     * Enables specifying the semantic element to be rendered by the component
+     * If this prop is not provided, the semantic element will default to matching the variant (e.g. if the component
+     * variant is h1, the element will be `<h1>`) or if there is no semantic element matching the variant, it
+     * will default to `<p>`. You can provide elementType as a string, like "figcaption", or as a function, like
+     * `({children}) => (<figcaption>{children}</figcaption>)`.
+     */
+    elementType: PropTypes.node,
+    /**
      * Text to render
      */
     children: PropTypes.node,
@@ -31,8 +39,25 @@ export default class Typography extends Component {
     variant: PropTypes.oneOf(AVAILABLE_VARIANTS)
   };
 
+  elementType = () => {
+    const { elementType, variant } = this.props;
+
+    if (elementType) {
+      return elementType;
+    }
+
+    return ["h1", "h2", "h3"].includes(variant) ? variant : "p";
+  };
+
   render() {
-    const { align, children, fontWeight, variant, ...otherProps } = this.props;
+    const {
+      align,
+      children,
+      fontWeight,
+      variant,
+      elementType, // we don't want this included in the otherProps that appear in the DOM
+      ...otherProps
+    } = this.props;
 
     return (
       <ThemeContext.Consumer>
@@ -42,9 +67,7 @@ export default class Typography extends Component {
             resolvedRoles
           );
 
-          const ElementType = ["h1", "h2", "h3"].includes(variant)
-            ? variant
-            : "p";
+          const ElementType = this.elementType();
 
           return (
             <ElementType className={css(styles.typography)} {...otherProps}>

--- a/packages/typography/src/Typography.js
+++ b/packages/typography/src/Typography.js
@@ -42,10 +42,14 @@ export default class Typography extends Component {
             resolvedRoles
           );
 
+          const ElementType = ["h1", "h2", "h3"].includes(variant)
+            ? variant
+            : "p";
+
           return (
-            <span className={css(styles.typography)} {...otherProps}>
+            <ElementType className={css(styles.typography)} {...otherProps}>
               {children}
-            </span>
+            </ElementType>
           );
         }}
       </ThemeContext.Consumer>

--- a/packages/typography/src/Typography.test.js
+++ b/packages/typography/src/Typography.test.js
@@ -4,11 +4,16 @@ import { takeSnapshotsOf } from "@hig/jest-preset/helpers";
 import Typography from "./Typography";
 
 describe("Typography", () => {
-  function newProps(variant, ...args) {
+  function props({ ...args }) {
+    const { align, elementType, fontWeight, variant } = args;
     const variantDetails = variant ? `${variant} variant` : "Default";
-    const otherDetails = args.length ? ` with ${args.join(" ")}` : "";
+    const otherDetails =
+      !!align || !!fontWeight || !!elementType
+        ? ` with ${[align, fontWeight, elementType].join(" ")}`
+        : "";
+
     return {
-      variant,
+      ...args,
       children: `${variantDetails} should render nicely${otherDetails}.`
     };
   }
@@ -21,33 +26,35 @@ describe("Typography", () => {
 
   takeSnapshotsOf(Typography, [
     // new API tests
-    { description: "renders default Typography", props: newProps() },
+    { description: "renders default Typography", props: props() },
     {
       description: "renders Typography with align and fontWeight props",
-      props: Object.assign(
-        newProps("body", "align center and fontWeight bold"),
-        { align: "center", fontWeight: "bold" }
-      )
+      props: props({ align: "center", fontWeight: "bold", variant: "body" })
     },
     {
       description: "renders body variant Typography",
-      props: newProps("body")
+      props: props({ variant: "body" })
     },
     {
       description: "renders caption variant Typography",
-      props: newProps("caption")
+      props: props({ variant: "caption" })
     },
     {
       description: "renders h1 variant Typography",
-      props: newProps("h1")
+      props: props({ variant: "h1" })
     },
     {
       description: "renders h2 variant Typography",
-      props: newProps("h2")
+      props: props({ variant: "h2" })
     },
     {
       description: "renders h3 variant Typography",
-      props: newProps("h3")
+      props: props({ variant: "h3" })
+    },
+    {
+      description:
+        "renders h3 variant Typography with any arbitrary semantic element",
+      props: props({ variant: "h3", elementType: "figcaption" })
     }
   ]);
 });

--- a/packages/typography/src/__snapshots__/Typography.test.js.snap
+++ b/packages/typography/src/__snapshots__/Typography.test.js.snap
@@ -34,7 +34,7 @@ exports[`Typography  2`] = `
 <p
   className="emotion-0"
 >
-  body variant should render nicely with align center and fontWeight bold.
+  body variant should render nicely with center bold .
 </p>
 `;
 
@@ -131,4 +131,23 @@ exports[`Typography  7`] = `
 >
   h3 variant should render nicely.
 </h3>
+`;
+
+exports[`Typography  8`] = `
+.emotion-0 {
+  color: #3c3c3c;
+  display: inline-block;
+  font-family: ArtifaktElement,sans-serif;
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 1.4;
+  margin: 0;
+  text-align: initial;
+}
+
+<figcaption
+  className="emotion-0"
+>
+  h3 variant should render nicely with   figcaption.
+</figcaption>
 `;

--- a/packages/typography/src/__snapshots__/Typography.test.js.snap
+++ b/packages/typography/src/__snapshots__/Typography.test.js.snap
@@ -12,11 +12,11 @@ exports[`Typography  1`] = `
   text-align: initial;
 }
 
-<span
+<p
   className="emotion-0"
 >
   Default should render nicely.
-</span>
+</p>
 `;
 
 exports[`Typography  2`] = `
@@ -31,11 +31,11 @@ exports[`Typography  2`] = `
   text-align: center;
 }
 
-<span
+<p
   className="emotion-0"
 >
   body variant should render nicely with align center and fontWeight bold.
-</span>
+</p>
 `;
 
 exports[`Typography  3`] = `
@@ -50,11 +50,11 @@ exports[`Typography  3`] = `
   text-align: initial;
 }
 
-<span
+<p
   className="emotion-0"
 >
   body variant should render nicely.
-</span>
+</p>
 `;
 
 exports[`Typography  4`] = `
@@ -69,11 +69,11 @@ exports[`Typography  4`] = `
   text-align: initial;
 }
 
-<span
+<p
   className="emotion-0"
 >
   caption variant should render nicely.
-</span>
+</p>
 `;
 
 exports[`Typography  5`] = `
@@ -88,11 +88,11 @@ exports[`Typography  5`] = `
   text-align: initial;
 }
 
-<span
+<h1
   className="emotion-0"
 >
   h1 variant should render nicely.
-</span>
+</h1>
 `;
 
 exports[`Typography  6`] = `
@@ -107,11 +107,11 @@ exports[`Typography  6`] = `
   text-align: initial;
 }
 
-<span
+<h2
   className="emotion-0"
 >
   h2 variant should render nicely.
-</span>
+</h2>
 `;
 
 exports[`Typography  7`] = `
@@ -126,9 +126,9 @@ exports[`Typography  7`] = `
   text-align: initial;
 }
 
-<span
+<h3
   className="emotion-0"
 >
   h3 variant should render nicely.
-</span>
+</h3>
 `;

--- a/packages/typography/src/__snapshots__/Typography.test.js.snap
+++ b/packages/typography/src/__snapshots__/Typography.test.js.snap
@@ -136,7 +136,7 @@ exports[`Typography  7`] = `
 exports[`Typography  8`] = `
 .emotion-0 {
   color: #3c3c3c;
-  display: inline-block;
+  display: block;
   font-family: ArtifaktElement,sans-serif;
   font-size: 20px;
   font-weight: 600;


### PR DESCRIPTION
This PR is related to https://github.com/Autodesk/hig/pull/1466, which got merged into this branch (after [another PR](https://github.com/Autodesk/hig/pull/1453) on this branch was closed) instead of development. 

‼️ Note that until we clear up how alpha versioning works while rolling out breaking changes, I wasn't super clear about what to version this as in package.json. We may need to adjust that before merging.

If there is a semantic element that matches the variant provided, use
that semantic element instead of resolving all <Typography> components
to a single type of element. Also, this changes the default element type
from `<span>` to `<p>`.

Migrating from 1.0.0 to 2.0.0

If you need the same behavior that the default <span> provided before,
you can pass in custom styles to achieve that. For instance,
`<Typography style={{display: "inline"}}>Render nicely</Typography>`.

If you want to enable specifying the semantic element to be rendered by
the component, use the elementType prop. If this prop is not provided,
the semantic element will default to matching the variant. If the
component variant is "h1", the element will be `<h1>` or if there is no
semantic element matching the variant, it will default to `<p>`.