### PR TITLE
fix: resolve versioning issue, Avatar 0.2.0->1.0.0

### DIFF
--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hig/avatar",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "HIG Avatar",
   "author": "Autodesk Inc.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Avatar 1.0.0 was previously published and unpublished. This resulted in
NPM rejecting the latest attempt to release 1.0.0. This commit is an
attempt to trigger semantic release to bump the version to 1.0.1 so
that NPM accepts a new published version.