### PR TITLE
Release new Typography API

### DIFF
--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hig/typography",
-  "version": "0.1.6-alpha",
+  "version": "0.1.6",
   "description": "HIG Typography components",
   "author": "Autodesk Inc.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Once this commit makes it to master, semantic release on CI will bump the version to 1.0.0 and publish the new package version. After the new package version is published, Greenkeeper will notify us about which consuming HIG packages could be updated by opening PRs. We will want to update those packages 1-by-1 as we make their components themable.