### PR TITLE
Release chg default theme LightGray -> WebLight

### DIFF
--- a/packages/theme-context/package.json
+++ b/packages/theme-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hig/theme-context",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "ThemeContext components to ease adoption of theme data from React components",
   "author": "Autodesk Inc.",
   "license": "Apache-2.0",


### PR DESCRIPTION
When we initially merged the work to change the default theme from LightGray to WebLight, the commit message wasn't formatted to properly trigger a major version bump with semantic-release and was not published to NPM. This resolves that.