### PR TITLE
chore: manually bump Typography version to 1.0.0

### DIFF
--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hig/typography",
-  "version": "0.1.6",
+  "version": "1.0.0",
   "description": "HIG Typography components",
   "author": "Autodesk Inc.",
   "license": "Apache-2.0",


### PR DESCRIPTION
This is a change from 0.1.6 -> 1.0.0 so that HIG packages don't pull in the breaking changes from Typography and CI development can pass.