### PR TITLE
feat: add theme data for text link

### DIFF
--- a/packages/theme-data/src/baseTheme/components/textLink.js
+++ b/packages/theme-data/src/baseTheme/components/textLink.js
@@ -2,15 +2,21 @@ import { COLOR, LENGTH } from "../../consts/types";
 
 export default {
   "textLink.textColor": {
-    type: COLOR
+    type: COLOR,
+    value: "#006EAF"
   },
   "textLink.hover.underline.color": {
-    type: COLOR
+    type: COLOR,
+    value: "#006EAF"
   },
   "textLink.focus.halo.color": {
-    type: COLOR
+    type: COLOR,
+    value: {
+      ref: "basics.colors.autodeskBlue500"
+    }
   },
   "textLink.focus.halo.width": {
-    type: LENGTH
+    type: LENGTH,
+    value: "2px"
   }
 };

--- a/packages/theme-data/src/baseTheme/components/textLink.js
+++ b/packages/theme-data/src/baseTheme/components/textLink.js
@@ -1,0 +1,16 @@
+import { COLOR, LENGTH } from "../../consts/types";
+
+export default {
+  "textLink.textColor": {
+    type: COLOR
+  },
+  "textLink.hover.underline.color": {
+    type: COLOR
+  },
+  "textLink.focus.halo.color": {
+    type: COLOR
+  },
+  "textLink.focus.halo.width": {
+    type: LENGTH
+  }
+};

--- a/packages/theme-data/src/baseTheme/components/textLink.js
+++ b/packages/theme-data/src/baseTheme/components/textLink.js
@@ -3,11 +3,15 @@ import { COLOR, LENGTH } from "../../consts/types";
 export default {
   "textLink.textColor": {
     type: COLOR,
-    value: "#006EAF"
+    value: {
+      ref: "basics.colors.textLinkAgainstLight"
+    }
   },
   "textLink.hover.underline.color": {
     type: COLOR,
-    value: "#006EAF"
+    value: {
+      ref: "basics.colors.textLinkAgainstLight"
+    }
   },
   "textLink.focus.halo.color": {
     type: COLOR,

--- a/packages/theme-data/src/baseTheme/unresolvedRoles.js
+++ b/packages/theme-data/src/baseTheme/unresolvedRoles.js
@@ -18,6 +18,7 @@ import skeletonItem from "./components/skeletonItem";
 import slider from "./components/slider";
 import textarea from "./components/textarea";
 import tooltip from "./components/tooltip";
+import textLink from "./components/textLink";
 import typography from "./components/typography";
 
 const baseThemeConfig = extendTheme(
@@ -50,6 +51,7 @@ const baseThemeConfig = extendTheme(
     slider,
     textarea,
     tooltip,
+    textLink,
     typography
   )
 );

--- a/packages/theme-data/src/basics/colors.js
+++ b/packages/theme-data/src/basics/colors.js
@@ -152,5 +152,8 @@ export default {
   // Alert colors
   error: { value: "#ec4a41", type: COLOR },
   success: { value: "#87b340", type: COLOR },
-  warning: { value: "#faa21b", type: COLOR }
+  warning: { value: "#faa21b", type: COLOR },
+
+  textLinkAgainstLight: { value: "#006EAF", type: COLOR },
+  textLinkAgainstDark: { value: "#6DD2FF", type: COLOR }
 };

--- a/packages/theme-data/src/colorSchemes/darkBlue/components/textLink.js
+++ b/packages/theme-data/src/colorSchemes/darkBlue/components/textLink.js
@@ -1,0 +1,16 @@
+export default {
+  "textLink.textColor": {
+    value: "#6DD2FF"
+  },
+  "textLink.hover.underline.color": {
+    value: "#6DD2FF"
+  },
+  "textLink.focus.halo.color": {
+    value: {
+      ref: "basics.colors.autodeskBlue400"
+    }
+  },
+  "textLink.focus.halo.width": {
+    value: "2px"
+  }
+};

--- a/packages/theme-data/src/colorSchemes/darkBlue/components/textLink.js
+++ b/packages/theme-data/src/colorSchemes/darkBlue/components/textLink.js
@@ -1,16 +1,17 @@
 export default {
   "textLink.textColor": {
-    value: "#6DD2FF"
+    value: {
+      ref: "basics.colors.textLinkAgainstDark"
+    }
   },
   "textLink.hover.underline.color": {
-    value: "#6DD2FF"
+    value: {
+      ref: "basics.colors.textLinkAgainstDark"
+    }
   },
   "textLink.focus.halo.color": {
     value: {
       ref: "basics.colors.autodeskBlue400"
     }
-  },
-  "textLink.focus.halo.width": {
-    value: "2px"
   }
 };

--- a/packages/theme-data/src/colorSchemes/darkBlue/unresolvedRoles.js
+++ b/packages/theme-data/src/colorSchemes/darkBlue/unresolvedRoles.js
@@ -12,6 +12,7 @@ import progressBar from "./components/progressBar";
 import skeletonItem from "./components/skeletonItem";
 import slider from "./components/slider";
 import tooltip from "./components/tooltip";
+import textLink from "./components/textLink";
 
 const darkBlueThemeConfig = extendTheme(
   baseTheme.unresolvedRoles,
@@ -27,7 +28,8 @@ const darkBlueThemeConfig = extendTheme(
     progressBar,
     skeletonItem,
     slider,
-    tooltip
+    tooltip,
+    textLink
   )
 );
 

--- a/packages/theme-data/src/colorSchemes/darkBlue/unresolvedRoles.js
+++ b/packages/theme-data/src/colorSchemes/darkBlue/unresolvedRoles.js
@@ -11,8 +11,8 @@ import label from "./components/label";
 import progressBar from "./components/progressBar";
 import skeletonItem from "./components/skeletonItem";
 import slider from "./components/slider";
-import tooltip from "./components/tooltip";
 import textLink from "./components/textLink";
+import tooltip from "./components/tooltip";
 
 const darkBlueThemeConfig = extendTheme(
   baseTheme.unresolvedRoles,
@@ -28,8 +28,8 @@ const darkBlueThemeConfig = extendTheme(
     progressBar,
     skeletonItem,
     slider,
-    tooltip,
-    textLink
+    textLink,
+    tooltip
   )
 );
 

--- a/packages/theme-data/src/colorSchemes/webLight/components/_oldColors.js
+++ b/packages/theme-data/src/colorSchemes/webLight/components/_oldColors.js
@@ -6,8 +6,11 @@ export default {
   "hig-cool-gray-30": "#BEC8D2",
   "hig-blue-20": "#CCEAF9",
   "hig-blue-40": "#66BFE9",
+  "hig-blue-50": "#0696D7",
   "hig-blue-60": "#0671A1",
+  "hig-blue-70": "#024B6C",
   "hig-gray-60": "#393939",
+  "hig-gray-70": "#000000",
   "hig-slate-40": "#7993B0",
   "hig-indigo-30": "#D1DDEE"
 };

--- a/packages/theme-data/src/colorSchemes/webLight/components/_oldColors.js
+++ b/packages/theme-data/src/colorSchemes/webLight/components/_oldColors.js
@@ -8,9 +8,7 @@ export default {
   "hig-blue-40": "#66BFE9",
   "hig-blue-50": "#0696D7",
   "hig-blue-60": "#0671A1",
-  "hig-blue-70": "#024B6C",
   "hig-gray-60": "#393939",
-  "hig-gray-70": "#000000",
   "hig-slate-40": "#7993B0",
   "hig-indigo-30": "#D1DDEE"
 };

--- a/packages/theme-data/src/colorSchemes/webLight/components/textLink.js
+++ b/packages/theme-data/src/colorSchemes/webLight/components/textLink.js
@@ -1,0 +1,13 @@
+import oldColors from "./_oldColors";
+
+export default {
+  "textLink.textColor": {
+    value: oldColors["hig-blue-50"]
+  },
+  "textLink.hover.underline.color": {
+    value: "transparent"
+  },
+  "textLink.focus.halo.width": {
+    value: "0"
+  }
+};

--- a/packages/theme-data/src/colorSchemes/webLight/unresolvedRoles.js
+++ b/packages/theme-data/src/colorSchemes/webLight/unresolvedRoles.js
@@ -6,6 +6,7 @@ import flyout from "./components/flyout";
 import input from "./components/input";
 import label from "./components/label";
 import progressBar from "./components/progressBar";
+import textLink from "./components/textLink";
 import tooltip from "./components/tooltip";
 
 const webLightThemeConfig = extendTheme(
@@ -23,6 +24,7 @@ const webLightThemeConfig = extendTheme(
     input,
     label,
     progressBar,
+    textLink,
     tooltip
   )
 );


### PR DESCRIPTION
as a developer
I can have theme data describing a text link
so I can build one that adheres to HIG design specs