### PR TITLE
fix: remove padding based on density spacing

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -23,7 +23,7 @@
     "@hig/button": "^1.2.0",
     "@hig/checkbox": "^2.0.0",
     "@hig/dropdown": "^1.0.1",
-    "@hig/flyout": "^0.8.0",
+    "@hig/flyout": "^0.8.1",
     "@hig/icon-button": "^1.0.1",
     "@hig/icons": "^1.0.0",
     "@hig/modal": "^1.0.1",

--- a/packages/flyout/package.json
+++ b/packages/flyout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hig/flyout",
-  "version": "0.8.1",
+  "version": "1.0.0",
   "description": "HIG Flyout",
   "author": "Autodesk Inc.",
   "license": "Apache-2.0",

--- a/packages/flyout/src/Flyout.js
+++ b/packages/flyout/src/Flyout.js
@@ -101,17 +101,6 @@ export default class Flyout extends Component {
     window.document.body.addEventListener("click", this.handleBodyClick);
   }
 
-  componentDidUpdate() {
-    setTimeout(() => {
-      const { containerPosition, pointerPosition } = this.getCoordinates();
-      const { panelWrapperRef, pointerRef } = this.state;
-      panelWrapperRef.style.top = `${containerPosition.top}px`;
-      panelWrapperRef.style.left = `${containerPosition.left}px`;
-      pointerRef.style.top = `${pointerPosition.top}px`;
-      pointerRef.style.left = `${pointerPosition.left}px`;
-    }, 100);
-  }
-
   componentWillUnmount() {
     window.document.body.removeEventListener("click", this.handleBodyClick);
   }
@@ -236,13 +225,6 @@ export default class Flyout extends Component {
   };
 
   /**
-   * @param {HTMLElement} panelWrapperRef
-   */
-  refPanelWrapper = panelWrapperRef => {
-    this.setState({ panelWrapperRef });
-  };
-
-  /**
    * @param {HTMLDivElement} wrapperRef
    */
   refWrapper = wrapperRef => {
@@ -322,12 +304,15 @@ export default class Flyout extends Component {
       handleChildMouseLeave,
       refAction,
       refPointer,
-      refWrapper,
-      refPanelWrapper
+      refWrapper
     } = this;
     const { openOnHoverDelay, pointer } = this.props;
     const panel = this.renderPanel({ transitionStatus });
-    const { anchorPoint } = this.getCoordinates();
+    const {
+      anchorPoint,
+      containerPosition,
+      pointerPosition
+    } = this.getCoordinates();
 
     return (
       <DelayedHoverBehavior
@@ -338,10 +323,11 @@ export default class Flyout extends Component {
         {({ onMouseEnter, onMouseLeave }) => (
           <FlyoutPresenter
             anchorPoint={anchorPoint}
+            containerPosition={containerPosition}
             panel={panel}
             pointer={pointer}
+            pointerPosition={pointerPosition}
             refAction={refAction}
-            refPanelWrapper={refPanelWrapper}
             refPointer={refPointer}
             refWrapper={refWrapper}
             transitionStatus={transitionStatus}

--- a/packages/flyout/src/__snapshots__/Flyout.test.js.snap
+++ b/packages/flyout/src/__snapshots__/Flyout.test.js.snap
@@ -186,12 +186,23 @@ exports[`flyout/Flyout snapshots renders a custom pointer 1`] = `
   </div>
   <div
     className="emotion-6"
+    style={
+      Object {
+        "left": "0px",
+        "top": "0px",
+      }
+    }
   >
     <div
       aria-hidden="true"
       className="emotion-2"
       role="presentation"
-      style={undefined}
+      style={
+        Object {
+          "left": "0px",
+          "top": "0px",
+        }
+      }
     >
       <span>
         my custom pointer
@@ -360,12 +371,23 @@ exports[`flyout/Flyout snapshots renders children from the given render function
   </div>
   <div
     className="emotion-8"
+    style={
+      Object {
+        "left": "0px",
+        "top": "0px",
+      }
+    }
   >
     <div
       aria-hidden="true"
       className="emotion-4"
       role="presentation"
-      style={undefined}
+      style={
+        Object {
+          "left": "0px",
+          "top": "0px",
+        }
+      }
     >
       <svg
         height="24"
@@ -545,12 +567,23 @@ exports[`flyout/Flyout snapshots renders content from the given render function 
   </div>
   <div
     className="emotion-8"
+    style={
+      Object {
+        "left": "0px",
+        "top": "0px",
+      }
+    }
   >
     <div
       aria-hidden="true"
       className="emotion-4"
       role="presentation"
-      style={undefined}
+      style={
+        Object {
+          "left": "0px",
+          "top": "0px",
+        }
+      }
     >
       <svg
         height="24"
@@ -670,12 +703,23 @@ exports[`flyout/Flyout snapshots renders open by default 1`] = `
   />
   <div
     className="emotion-7"
+    style={
+      Object {
+        "left": "0px",
+        "top": "0px",
+      }
+    }
   >
     <div
       aria-hidden="true"
       className="emotion-3"
       role="presentation"
-      style={undefined}
+      style={
+        Object {
+          "left": "0px",
+          "top": "0px",
+        }
+      }
     >
       <svg
         height="24"
@@ -833,12 +877,23 @@ exports[`flyout/Flyout snapshots renders the panel from a basic render function 
   </div>
   <div
     className="emotion-5"
+    style={
+      Object {
+        "left": "0px",
+        "top": "0px",
+      }
+    }
   >
     <div
       aria-hidden="true"
       className="emotion-4"
       role="presentation"
-      style={undefined}
+      style={
+        Object {
+          "left": "0px",
+          "top": "0px",
+        }
+      }
     >
       <svg
         height="24"
@@ -993,12 +1048,23 @@ exports[`flyout/Flyout snapshots renders the panel from a complex render functio
   </div>
   <div
     className="emotion-7"
+    style={
+      Object {
+        "left": "0px",
+        "top": "0px",
+      }
+    }
   >
     <div
       aria-hidden="true"
       className="emotion-4"
       role="presentation"
-      style={undefined}
+      style={
+        Object {
+          "left": "0px",
+          "top": "0px",
+        }
+      }
     >
       <svg
         height="24"
@@ -1183,12 +1249,23 @@ exports[`flyout/Flyout snapshots renders with a basic set of props 1`] = `
   </div>
   <div
     className="emotion-8"
+    style={
+      Object {
+        "left": "0px",
+        "top": "0px",
+      }
+    }
   >
     <div
       aria-hidden="true"
       className="emotion-4"
       role="presentation"
-      style={undefined}
+      style={
+        Object {
+          "left": "0px",
+          "top": "0px",
+        }
+      }
     >
       <svg
         height="24"
@@ -1308,12 +1385,23 @@ exports[`flyout/Flyout snapshots renders without props 1`] = `
   />
   <div
     className="emotion-7"
+    style={
+      Object {
+        "left": "0px",
+        "top": "0px",
+      }
+    }
   >
     <div
       aria-hidden="true"
       className="emotion-3"
       role="presentation"
-      style={undefined}
+      style={
+        Object {
+          "left": "0px",
+          "top": "0px",
+        }
+      }
     >
       <svg
         height="24"

--- a/packages/flyout/src/presenters/FlyoutPresenter.js
+++ b/packages/flyout/src/presenters/FlyoutPresenter.js
@@ -12,18 +12,33 @@ import stylesheet from "./stylesheet";
 import PointerPresenter from "./PointerPresenter";
 import PointerWrapperPresenter from "./PointerWrapperPresenter";
 
+/**
+ * @param {import("../getCoordinates").Position} position
+ * @returns {import("react").CSSProperties}
+ */
+function positionToStyle({ top, left }) {
+  return {
+    top: `${top}px`,
+    left: `${left}px`
+  };
+}
+
 export default function FlyoutPresenter(props) {
   const {
     anchorPoint,
+    containerPosition,
     children,
     panel,
     pointer,
+    pointerPosition,
     refAction,
-    refPanelWrapper,
     refPointer,
     refWrapper,
     transitionStatus
   } = props;
+
+  const containerStyle = positionToStyle(containerPosition);
+  const pointerStyle = positionToStyle(pointerPosition);
 
   return (
     <ThemeContext.Consumer>
@@ -38,10 +53,11 @@ export default function FlyoutPresenter(props) {
             <div className={css(styles.flyoutAction)} ref={refAction}>
               {children}
             </div>
-            <div className={css(styles.flyoutContainer)} ref={refPanelWrapper}>
+            <div className={css(styles.flyoutContainer)} style={containerStyle}>
               <PointerWrapperPresenter
                 innerRef={refPointer}
                 anchorPoint={anchorPoint}
+                style={pointerStyle}
               >
                 {pointer}
               </PointerWrapperPresenter>
@@ -56,7 +72,9 @@ export default function FlyoutPresenter(props) {
 
 FlyoutPresenter.defaultProps = {
   anchorPoint: DEFAULT_COORDINATES.anchorPoint,
+  containerPosition: DEFAULT_COORDINATES.containerPosition,
   pointer: <PointerPresenter />,
+  pointerPosition: DEFAULT_COORDINATES.pointerPosition,
   transitionStatus: transitionStatuses.EXITED
 };
 
@@ -67,10 +85,18 @@ FlyoutPresenter.propTypes = {
   panel: PropTypes.node,
   /** Pointer for the flyout */
   pointer: PropTypes.node,
+  /** Top/Left position of the container relative to the action */
+  containerPosition: PropTypes.shape({
+    top: PropTypes.number,
+    left: PropTypes.number
+  }),
+  /** Top/Left position of the pointer relative to the action */
+  pointerPosition: PropTypes.shape({
+    top: PropTypes.number,
+    left: PropTypes.number
+  }),
   /** Reference the action element */
   refAction: PropTypes.func,
-  /** Reference the panel wrapper element */
-  refPanelWrapper: PropTypes.func,
   /** Reference the pointer element */
   refPointer: PropTypes.func,
   /** Reference the wrapper element */

--- a/packages/flyout/src/presenters/FlyoutPresenter.test.js
+++ b/packages/flyout/src/presenters/FlyoutPresenter.test.js
@@ -17,11 +17,12 @@ describe("flyout/FlyoutPresenter/FlyoutPresenter", () => {
       props: {
         anchorPoint: anchorPoints.TOP_CENTER,
         content: "World",
+        containerPosition: { top: 42, left: 42 },
+        pointerPosition: { top: 42, left: 42 },
         maxHeight: 150,
         refAction: function refAction() {},
         refContainer: function refContainer() {},
         refPanel: function refPanel() {},
-        refPanelWrapper: function refPanelWrapper() {},
         refWrapper: function refWrapper() {},
         onScroll: function onScroll() {},
         transitionStatus: transitionStatuses.ENTERED,

--- a/packages/flyout/src/presenters/__snapshots__/FlyoutPresenter.test.js.snap
+++ b/packages/flyout/src/presenters/__snapshots__/FlyoutPresenter.test.js.snap
@@ -112,12 +112,23 @@ exports[`flyout/FlyoutPresenter/FlyoutPresenter renders with all props 1`] = `
   </div>
   <div
     className="emotion-3"
+    style={
+      Object {
+        "left": "42px",
+        "top": "42px",
+      }
+    }
   >
     <div
       aria-hidden="true"
       className="emotion-2"
       role="presentation"
-      style={undefined}
+      style={
+        Object {
+          "left": "42px",
+          "top": "42px",
+        }
+      }
     >
       <div>
         I am a custom pointer
@@ -187,12 +198,23 @@ exports[`flyout/FlyoutPresenter/FlyoutPresenter renders without props 1`] = `
   />
   <div
     className="emotion-4"
+    style={
+      Object {
+        "left": "0px",
+        "top": "0px",
+      }
+    }
   >
     <div
       aria-hidden="true"
       className="emotion-3"
       role="presentation"
-      style={undefined}
+      style={
+        Object {
+          "left": "0px",
+          "top": "0px",
+        }
+      }
     >
       <svg
         height="24"

--- a/packages/flyout/src/presenters/stylesheet.js
+++ b/packages/flyout/src/presenters/stylesheet.js
@@ -62,9 +62,6 @@ export default function(props, themeData) {
   const shadowColor = themeData
     ? getStyle(themeData, `flyout.shadowColor`)
     : `transparent`;
-  const densitySmall = themeData
-    ? getStyle(themeData, `density.spacings.small`)
-    : 0;
 
   return {
     flyoutWrapper: {
@@ -105,7 +102,7 @@ export default function(props, themeData) {
       minWidth: `200px`,
       maxWidth: `400px`,
       maxHeight: `360px`,
-      padding: densitySmall,
+      padding: `12px`,
       overflowY: `auto`,
       msOverflowStyle: `-ms-autohiding-scrollbar`
     },

--- a/packages/tooltip/src/Tooltip.test.js
+++ b/packages/tooltip/src/Tooltip.test.js
@@ -1,4 +1,4 @@
-import { anchorPoints } from "@hig/flyout/src";
+import { anchorPoints } from "@hig/flyout";
 import Button from "@hig/button";
 import React from "react";
 import { takeSnapshotsOf } from "@hig/jest-preset/helpers";

--- a/yarn.lock
+++ b/yarn.lock
@@ -143,6 +143,16 @@
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.2.tgz#63985d3d8b02530e0869962f4da09142ee8e200e"
 
+"@hig/flyout@^0.8.0", "@hig/flyout@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@hig/flyout/-/flyout-0.8.1.tgz#501f3fe1179634c5bd74009dde2ace7b502e2259"
+  integrity sha512-RKOmhrXRdKiYUH1dc/rqagX3VWyyG3yke8xEjt79hUc0ptUidaM4Y/uBQINUbtRbikeupB9mJsw26s7YRtHg2Q==
+  dependencies:
+    "@hig/theme-context" "^1.0.1"
+    emotion "^10.0.0"
+    prop-types "^15.6.1"
+    react-transition-group "^2.3.1"
+
 "@hig/icons@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@hig/icons/-/icons-1.0.0.tgz#b2e023887beae46934a919816a56f4c9f995a9bc"


### PR DESCRIPTION
BREAKING CHANGE: The padding of the flyout container is 12px across all densities

The above breaking change note is to get semantic versioning to bump this package to `1.0.0` but I do not believe anyone is using density specific themes at the moment, but also manually updating the `package.json` so the dependent components do not pull this in yet.

With the padding no longer being density based, the `Flyout` no longer needs to do calculations on the `componentDidUpdate` life-cycle, so am undoing/reverting this commit:
https://github.com/Autodesk/hig/commit/e75cfb16fc4aa73eff5bfbd2c0398d8565bc2062#diff-32db5e56e9aa91b678c74a66f0c626d2

Resolves https://github.com/Autodesk/hig/issues/1537.