### PR TITLE
Fine tune CI dependency caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
           name: Create dependency hash
           command: yarn run create-dependency-hash
       - restore_cache:
-          key: v2-dependencies-{{ checksum ".dependency-hash" }}
+          key: v3-dependencies-{{ .Revision }}-{{ checksum ".dependency-hash" }}
       - run:
           name: Extract dependencies
           command: yarn run extract:dependencies
@@ -53,7 +53,7 @@ jobs:
           name: Archive dependencies
           command: yarn run archive:dependencies
       - save_cache:
-          key: v2-dependencies-{{ checksum ".dependency-hash" }}
+          key: v3-dependencies-{{ .Revision }}-{{ checksum ".dependency-hash" }}
           paths:
             - .archives/dependencies.tgz
   package-build:
@@ -64,7 +64,7 @@ jobs:
           name: Create dependency hash
           command: yarn run create-dependency-hash
       - restore_cache:
-          key: v2-dependencies-{{ checksum ".dependency-hash" }}
+          key: v3-dependencies-{{ .Revision }}-{{ checksum ".dependency-hash" }}
       - run:
           name: Extract dependencies
           command: yarn run extract:dependencies
@@ -86,7 +86,7 @@ jobs:
           name: Create dependency hash
           command: yarn run create-dependency-hash
       - restore_cache:
-          key: v2-dependencies-{{ checksum ".dependency-hash" }}
+          key: v3-dependencies-{{ .Revision }}-{{ checksum ".dependency-hash" }}
       - restore_cache:
           key: v1-package-builds-{{ .Revision }}
       - run:
@@ -108,7 +108,7 @@ jobs:
           name: Create dependency hash
           command: yarn run create-dependency-hash
       - restore_cache:
-          key: v2-dependencies-{{ checksum ".dependency-hash" }}
+          key: v3-dependencies-{{ .Revision }}-{{ checksum ".dependency-hash" }}
       - restore_cache:
           key: v1-package-builds-{{ .Revision }}
       - run:
@@ -137,7 +137,7 @@ jobs:
           name: Create dependency hash
           command: yarn run create-dependency-hash
       - restore_cache:
-          key: v2-dependencies-{{ checksum ".dependency-hash" }}
+          key: v3-dependencies-{{ .Revision }}-{{ checksum ".dependency-hash" }}
       - restore_cache:
           key: v1-package-builds-{{ .Revision }}
       - run:
@@ -157,7 +157,7 @@ jobs:
           name: Create dependency hash
           command: yarn run create-dependency-hash
       - restore_cache:
-          key: v2-dependencies-{{ checksum ".dependency-hash" }}
+          key: v3-dependencies-{{ .Revision }}-{{ checksum ".dependency-hash" }}
       - restore_cache:
           key: v1-package-builds-{{ .Revision }}
       - run:
@@ -175,7 +175,7 @@ jobs:
           name: Create dependency hash
           command: yarn run create-dependency-hash
       - restore_cache:
-          key: v2-dependencies-{{ checksum ".dependency-hash" }}
+          key: v3-dependencies-{{ .Revision }}-{{ checksum ".dependency-hash" }}
       - restore_cache:
           key: v1-package-builds-{{ .Revision }}
       - run:

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -50,7 +50,7 @@
     "surge": "^0.20.1"
   },
   "dependencies": {
-    "@hig/theme-context": "^1.0.1",
+    "@hig/theme-context": "^2.0.0",
     "@hig/theme-data": "^1.5.0",
     "faker": "^4.1.0",
     "prop-types": "^15.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -160,15 +160,6 @@
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@hig/styles/-/styles-0.2.3.tgz#675631d008c1861921d6148ecf15b140c04cc5b4"
 
-"@hig/theme-context@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@hig/theme-context/-/theme-context-1.0.1.tgz#338aa727352b0d0debfd369cfec6d46a6ecf8c65"
-  integrity sha512-wU0l7kuRj/8W5CRTaGOcI2QwUTf6934ouNw1pESjx2xGFoAnsU2kePA4rQvrW0bSdkeKSZ5Jcpt+k9jN8i0Ezg==
-  dependencies:
-    "@hig/theme-data" "^1.1.0"
-    create-react-context "^0.2.3"
-    prop-types "^15.6.1"
-
 "@hig/theme-data-poc@^0.0.8-alpha":
   version "0.0.8-alpha"
   resolved "https://registry.yarnpkg.com/@hig/theme-data-poc/-/theme-data-poc-0.0.8-alpha.tgz#a690b7c8f9b4d7c4b6ff6a56eec0d2795be9b8e7"


### PR DESCRIPTION
This adds `{{ .Revision }}` to the cache key for the dependency hash creation step in the CI jobs that run at the start of each workflow. This means that the dependency caching will only be fresh for the duration of the workflow/just this git commit. It allows all of the following steps of the workflow to use that cache and lets each CI build based on that same commit use the cache. Builds based on other commits will use their own cache.