### PR TITLE
Chore: flapping visual regression tests

### DIFF
--- a/packages/storybook/.gemini.js
+++ b/packages/storybook/.gemini.js
@@ -15,6 +15,8 @@ module.exports = {
   screenshotsDir: "./gemini/screens",
   compositeImage: true,
   sessionsPerBrowser: 3,
+  httpTimeout: 9000,
+  retry: 3,
   system: {
     plugins: {
       sauce: {

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "gemini": "yarn storybook-test-build && concurrently 'yarn storybook-test-serve' 'gemini test --reporter flat' --kill-others --success first",
     "gemini-update": "yarn storybook-test-build && concurrently 'yarn storybook-test-serve' 'gemini update --reporter flat' --kill-others --success first",
-    "gemini-ci": "gemini test --reporter flat",
+    "gemini-ci": "yarn wait-port -t 60000 http://:9876/iframe.html && gemini test --reporter flat",
     "lint": "eslint .storybook utils --color --ext .js",
     "storybook": "start-storybook -p 9001 -c .storybook/development",
     "storybook-build": "build-storybook -c .storybook/development",
@@ -53,7 +53,8 @@
     "@hig/theme-context": "^2.0.0",
     "@hig/theme-data": "^1.6.0",
     "faker": "^4.1.0",
-    "prop-types": "^15.6.1"
+    "prop-types": "^15.6.1",
+    "wait-port": "^0.2.2"
   },
   "eslintConfig": {
     "extends": "@hig"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12269,6 +12269,15 @@ w3c-hr-time@^1.0.1:
   dependencies:
     browser-process-hrtime "^0.1.2"
 
+wait-port@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/wait-port/-/wait-port-0.2.2.tgz#d51a491e484a17bf75a947e711a2f012b4e6f2e3"
+  integrity sha1-1RpJHkhKF791qUfnEaLwErTm8uM=
+  dependencies:
+    chalk "^1.1.3"
+    commander "^2.9.0"
+    debug "^2.6.6"
+
 walker@~1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"


### PR DESCRIPTION
Adds retry + timeout settings to the Gemini config, and block `gemini-ci` from running until port 9876 is open locally.