### PR TITLE
Typography shopkeeping

### DIFF
--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -27,8 +27,7 @@
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/scripts": "^0.1.2",
-    "@hig/semantic-release-config": "^0.1.0",
-    "@hig/styles": "^0.3.0"
+    "@hig/semantic-release-config": "^0.1.0"
   },
   "peerDependencies": {
     "react": "^15.4.1 || ^16.3.2"

--- a/packages/typography/src/__stories__/Typography.stories.js
+++ b/packages/typography/src/__stories__/Typography.stories.js
@@ -2,7 +2,6 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import { select } from "@storybook/addon-knobs/react";
 import { withInfo } from "@storybook/addon-info";
-
 import KnobbedThemeProvider from "@hig/storybook/storybook-support/decorators/KnobbedThemeProvider";
 
 import {
@@ -22,16 +21,18 @@ function renderStory(component) {
 
 storybook.add(
   "base component",
-  withInfo(infoOptions)(() => {
-    const component = (
-      <Typography
-        variant={select("Variant", AVAILABLE_VARIANTS, "body")}
-        align={select("Text align", AVAILABLE_ALIGNMENTS, "left")}
-        fontWeight={select("Font weight", AVAILABLE_FONT_WEIGHTS, "normal")}
-      >
-        This should render nicely.
-      </Typography>
-    );
-    return renderStory(component);
-  })
+  withInfo({ ...infoOptions, propTablesExclude: [KnobbedThemeProvider] })(
+    () => {
+      const component = (
+        <Typography
+          variant={select("Variant", AVAILABLE_VARIANTS, "body")}
+          align={select("Text align", AVAILABLE_ALIGNMENTS, "left")}
+          fontWeight={select("Font weight", AVAILABLE_FONT_WEIGHTS, "normal")}
+        >
+          This should render nicely.
+        </Typography>
+      );
+      return renderStory(component);
+    }
+  )
 );

--- a/packages/typography/src/index.js
+++ b/packages/typography/src/index.js
@@ -1,5 +1,3 @@
-import "@hig/styles/build/fonts.css";
-
 export { default } from "./Typography";
 
 export {


### PR DESCRIPTION
This import was previously used to get fonts. Recently, we replaced the
need for this with the use of the @hig/fonts packages, which consumers
should import alongside importing @hig/typography in order to get the
fonts.