### PR TITLE
Chore/greenkeeper post release

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -31,7 +31,7 @@
     "@hig/notifications-toast": "^1.0.4",
     "@hig/profile-flyout": "^2.0.0",
     "@hig/progress-bar": "^1.0.1",
-    "@hig/progress-ring": "^0.1.1",
+    "@hig/progress-ring": "^1.0.0",
     "@hig/project-account-switcher": "^1.0.5",
     "@hig/radio-button": "^1.0.1",
     "@hig/rich-text": "^0.1.4",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -47,7 +47,7 @@
     "@hig/theme-data": "^2.0.0",
     "@hig/themes": "^0.3.0",
     "@hig/timestamp": "^0.1.4",
-    "@hig/tooltip": "^0.4.2",
+    "@hig/tooltip": "^1.0.0",
     "@hig/top-nav": "^2.0.2",
     "@hig/typography": "^1.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -206,6 +206,13 @@
   dependencies:
     tinycolor2 "^1.4.1"
 
+"@hig/theme-data@^1.1.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@hig/theme-data/-/theme-data-1.6.0.tgz#f167677636d95b8776acb0ccf4b72031a17305c5"
+  integrity sha512-5iJisDZnKSfSKcxkyrw52Bod5uEh2q3XfrBU/AcIT0BEL+YlS2+2yuUUvBFl5J5AkIWQHpdqFPe/6rWVvhARvQ==
+  dependencies:
+    tinycolor2 "^1.4.1"
+
 "@hig/themes@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@hig/themes/-/themes-0.3.0.tgz#15b20fd8c9a8e2a3d9146824ffbfbe88d81bfc9f"


### PR DESCRIPTION
Combines https://github.com/Autodesk/hig/pull/1588 and https://github.com/Autodesk/hig/pull/1587.

- Did not update `progress-ring` in `notifications-flyout` as that will get that when `notifications-flyout` gets made themeable.