### PR TITLE
docs: remove buttons prop for Modal

### DIFF
--- a/packages/modal/README.md
+++ b/packages/modal/README.md
@@ -25,7 +25,6 @@ import '@hig/modal/build/index.css';
 <Modal
   title="Are you sure?"
   open
-  buttons={[{ title: "Cancel", type: "secondary" }, { title: "Ok" }]}
   body="This is the text body of my modal"
   style="alternate"
 >


### PR DESCRIPTION
Modal README was incorrectly suggesting the buttons prop which is
misleading.