### PR TITLE
Chore/greenkeeper post release

### DIFF
--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -18,7 +18,6 @@
   ],
   "dependencies": {
     "@hig/theme-context": "^2.1.0",
-    "classnames": "^2.2.5",
     "prop-types": "^15.6.1",
     "react-lifecycles-compat": "^3.0.4"
   },
@@ -29,9 +28,9 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
-    "@hig/semantic-release-config": "^0.1.0",
-    "@hig/styles": "^0.3.0"
+    "@hig/semantic-release-config": "^0.1.0"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/avatar/src/__stories__/infoOptions.js
+++ b/packages/avatar/src/__stories__/infoOptions.js
@@ -1,6 +1,5 @@
 import React from "react";
 import RichText from "@hig/rich-text";
-import "@hig/rich-text/build/index.css";
 
 import DefaultExport from "../index";
 import readme from "../../README.md";

--- a/packages/avatar/src/index.js
+++ b/packages/avatar/src/index.js
@@ -1,4 +1,2 @@
-import "@hig/styles/build/fonts.css";
-
 export { default } from "./Avatar";
 export { sizes, AVAILABLE_SIZES } from "./sizes";

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -30,6 +30,7 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.3.0"

--- a/packages/banner/src/__stories__/infoOptions.js
+++ b/packages/banner/src/__stories__/infoOptions.js
@@ -1,6 +1,5 @@
 import React from "react";
 import RichText from "@hig/rich-text";
-import "@hig/rich-text/build/index.css";
 
 import Banner from "../Banner";
 import readme from "../../README.md";

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -26,6 +26,7 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/theme-data": "^2.1.1"

--- a/packages/button/src/__stories__/infoOptions.js
+++ b/packages/button/src/__stories__/infoOptions.js
@@ -1,6 +1,5 @@
 import React from "react";
 import RichText from "@hig/rich-text";
-import "@hig/rich-text/build/index.css";
 
 import DefaultExport from "../index";
 import readme from "../../README.md";

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -31,6 +31,7 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },

--- a/packages/checkbox/src/__stories__/infoOptions.js
+++ b/packages/checkbox/src/__stories__/infoOptions.js
@@ -1,6 +1,5 @@
 import React from "react";
 import RichText from "@hig/rich-text";
-import "@hig/rich-text/build/index.css";
 
 import DefaultExport from "../index";
 import readme from "../../README.md";

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -34,7 +34,7 @@
     "@hig/progress-ring": "^1.0.1",
     "@hig/project-account-switcher": "^2.0.0",
     "@hig/radio-button": "^1.0.2",
-    "@hig/rich-text": "^0.1.4",
+    "@hig/rich-text": "^1.0.0",
     "@hig/side-nav": "^1.0.2",
     "@hig/skeleton-item": "^0.3.0",
     "@hig/slider": "^1.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -40,7 +40,7 @@
     "@hig/slider": "^1.0.0",
     "@hig/table": "^0.3.3",
     "@hig/tabs": "^0.1.3",
-    "@hig/text-area": "^0.2.0",
+    "@hig/text-area": "^1.0.0",
     "@hig/text-field": "^1.0.2",
     "@hig/text-link": "^1.0.0",
     "@hig/theme-context": "^2.1.0",

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -33,6 +33,7 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.3.0"

--- a/packages/dropdown/src/__stories__/infoOptions.js
+++ b/packages/dropdown/src/__stories__/infoOptions.js
@@ -1,6 +1,5 @@
 import React from "react";
 import RichText from "@hig/rich-text";
-import "@hig/rich-text/build/index.css";
 
 import DefaultExport from "../index";
 import readme from "../../README.md";

--- a/packages/flyout/package.json
+++ b/packages/flyout/package.json
@@ -29,6 +29,7 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },

--- a/packages/flyout/src/__stories__/stories.js
+++ b/packages/flyout/src/__stories__/stories.js
@@ -1,7 +1,6 @@
 import React from "react";
 import Button from "@hig/button";
 import RichText from "@hig/rich-text";
-import "@hig/rich-text/build/index.css";
 
 import { anchorPoints } from "../anchorPoints";
 

--- a/packages/icon-button/package.json
+++ b/packages/icon-button/package.json
@@ -27,6 +27,7 @@
     "@hig/eslint-config": "^0.1.0",
     "@hig/icons": "^1.0.0",
     "@hig/jest-preset": "^0.1.0",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.3.0"

--- a/packages/icon-button/src/__stories__/infoOptions.js
+++ b/packages/icon-button/src/__stories__/infoOptions.js
@@ -1,6 +1,5 @@
 import React from "react";
 import RichText from "@hig/rich-text";
-import "@hig/rich-text/build/index.css";
 
 import DefaultExport from "../index";
 import readme from "../../README.md";

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -21,7 +21,7 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^0.1.4",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/typography": "^1.0.2",

--- a/packages/icons/src/__stories__/infoOptions.js
+++ b/packages/icons/src/__stories__/infoOptions.js
@@ -1,6 +1,5 @@
 import React from "react";
 import RichText from "@hig/rich-text";
-import "@hig/rich-text/build/index.css";
 import readme from "../../README.md";
 
 export default {

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -27,6 +27,7 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.2.3"

--- a/packages/input/src/__stories__/infoOptions.js
+++ b/packages/input/src/__stories__/infoOptions.js
@@ -1,7 +1,6 @@
 import React from "react";
 import RichText from "@hig/rich-text";
 import KnobbedThemeProvider from "@hig/storybook/storybook-support/decorators/KnobbedThemeProvider";
-import "@hig/rich-text/build/index.css";
 
 import DefaultExport from "../index";
 import readme from "../../README.md";

--- a/packages/label/package.json
+++ b/packages/label/package.json
@@ -13,7 +13,6 @@
   },
   "main": "build/index.js",
   "module": "build/index.es.js",
-  "style": "build/index.css",
   "files": [
     "build/*"
   ],
@@ -27,9 +26,9 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
+    "@hig/rich-text": "1.0.0",
     "@hig/scripts": "^0.1.2",
-    "@hig/semantic-release-config": "^0.1.0",
-    "@hig/styles": "^0.3.0"
+    "@hig/semantic-release-config": "^0.1.0"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/label/src/__stories__/infoOptions.js
+++ b/packages/label/src/__stories__/infoOptions.js
@@ -1,6 +1,5 @@
 import React from "react";
 import RichText from "@hig/rich-text";
-import "@hig/rich-text/build/index.css";
 
 import { ThemeContext } from "@hig/theme-context";
 

--- a/packages/label/src/index.js
+++ b/packages/label/src/index.js
@@ -1,3 +1,1 @@
-import "@hig/styles/build/fonts.css";
-
 export { default } from "./Label";

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -32,6 +32,7 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.3.0"

--- a/packages/modal/src/__stories__/infoOptions.js
+++ b/packages/modal/src/__stories__/infoOptions.js
@@ -1,6 +1,5 @@
 import React from "react";
 import RichText from "@hig/rich-text";
-import "@hig/rich-text/build/index.css";
 
 import DefaultExport from "../index";
 import readme from "../../README.md";

--- a/packages/notifications-flyout/package.json
+++ b/packages/notifications-flyout/package.json
@@ -31,6 +31,7 @@
     "react-transition-group": "^2.3.0"
   },
   "devDependencies": {
+    "@hig/avatar": "^1.0.4",
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",

--- a/packages/notifications-flyout/src/__fixtures__/createSampleNotifications.js
+++ b/packages/notifications-flyout/src/__fixtures__/createSampleNotifications.js
@@ -6,7 +6,6 @@ import TextLink from "@hig/text-link";
 import Timestamp from "@hig/timestamp";
 import avatarImagePath from "@hig/storybook/storybook-support/fixtures/avatar/chris-reynolds.png";
 import thumbnailImagePath from "@hig/storybook/storybook-support/fixtures/thumbnail/greenhouse.png";
-import "@hig/avatar/build/index.css";
 import "@hig/text-link/build/index.css";
 import "@hig/timestamp/build/index.css";
 

--- a/packages/profile-flyout/package.json
+++ b/packages/profile-flyout/package.json
@@ -31,6 +31,7 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },

--- a/packages/profile-flyout/src/__stories__/infoOptions.js
+++ b/packages/profile-flyout/src/__stories__/infoOptions.js
@@ -1,6 +1,5 @@
 import React from "react";
 import RichText from "@hig/rich-text";
-import "@hig/rich-text/build/index.css";
 
 import DefaultExport from "../index";
 import readme from "../../README.md";

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -28,6 +28,7 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },

--- a/packages/progress-bar/src/__stories__/infoOptions.js
+++ b/packages/progress-bar/src/__stories__/infoOptions.js
@@ -1,6 +1,5 @@
 import React from "react";
 import RichText from "@hig/rich-text";
-import "@hig/rich-text/build/index.css";
 
 import DefaultExport from "../index";
 import readme from "../../README.md";

--- a/packages/progress-ring/package.json
+++ b/packages/progress-ring/package.json
@@ -30,6 +30,7 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },

--- a/packages/progress-ring/src/__stories__/infoOptions.js
+++ b/packages/progress-ring/src/__stories__/infoOptions.js
@@ -1,6 +1,5 @@
 import React from "react";
 import RichText from "@hig/rich-text";
-import "@hig/rich-text/build/index.css";
 
 import DefaultExport from "../index";
 import readme from "../../README.md";

--- a/packages/project-account-switcher/package.json
+++ b/packages/project-account-switcher/package.json
@@ -33,6 +33,7 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
+    "@hig/rich-text": "1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },

--- a/packages/project-account-switcher/src/__stories__/infoOptions.js
+++ b/packages/project-account-switcher/src/__stories__/infoOptions.js
@@ -1,6 +1,5 @@
 import React from "react";
 import RichText from "@hig/rich-text";
-import "@hig/rich-text/build/index.css";
 
 import DefaultExport from "../index";
 import readme from "../../README.md";

--- a/packages/radio-button/package.json
+++ b/packages/radio-button/package.json
@@ -32,9 +32,9 @@
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/label": "^1.0.1",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",
-    "@hig/styles": "^0.3.0",
     "@hig/spacer": "^1.0.4"
   },
   "scripts": {

--- a/packages/radio-button/src/__stories__/infoOptions.js
+++ b/packages/radio-button/src/__stories__/infoOptions.js
@@ -1,6 +1,5 @@
 import React from "react";
 import RichText from "@hig/rich-text";
-import "@hig/rich-text/build/index.css";
 
 import DefaultExport from "../index";
 import readme from "../../README.md";

--- a/packages/side-nav/package.json
+++ b/packages/side-nav/package.json
@@ -31,6 +31,7 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.3.0"

--- a/packages/side-nav/src/__stories__/infoOptions.js
+++ b/packages/side-nav/src/__stories__/infoOptions.js
@@ -1,7 +1,6 @@
 import React from "react";
 import RichText from "@hig/rich-text";
 import KnobbedThemeProvider from "@hig/storybook/storybook-support/decorators/KnobbedThemeProvider";
-import "@hig/rich-text/build/index.css";
 
 import DefaultExport from "../index";
 import readme from "../../README.md";

--- a/packages/skeleton-item/package.json
+++ b/packages/skeleton-item/package.json
@@ -14,7 +14,6 @@
   },
   "main": "build/index.js",
   "module": "build/index.es.js",
-  "style": "build/index.css",
   "files": [
     "build/*"
   ],
@@ -27,9 +26,9 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
-    "@hig/semantic-release-config": "^0.1.0",
-    "@hig/styles": "^0.3.0"
+    "@hig/semantic-release-config": "^0.1.0"
   },
   "peerDependencies": {
     "react": "^15.4.1 || ^16.3.2"

--- a/packages/skeleton-item/src/__stories__/infoOptions.js
+++ b/packages/skeleton-item/src/__stories__/infoOptions.js
@@ -1,6 +1,5 @@
 import React from "react";
 import RichText from "@hig/rich-text";
-import "@hig/rich-text/build/index.css";
 
 import DefaultExport from "../index";
 import readme from "../../README.md";

--- a/packages/skeleton-item/src/index.js
+++ b/packages/skeleton-item/src/index.js
@@ -1,3 +1,1 @@
-import "@hig/styles/build/fonts.css";
-
 export { default } from "./SkeletonItem";

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -30,6 +30,7 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },

--- a/packages/slider/src/__stories__/infoOptions.js
+++ b/packages/slider/src/__stories__/infoOptions.js
@@ -1,6 +1,5 @@
 import React from "react";
 import RichText from "@hig/rich-text";
-import "@hig/rich-text/build/index.css";
 
 import DefaultExport from "../index";
 import readme from "../../README.md";

--- a/packages/spacer/package.json
+++ b/packages/spacer/package.json
@@ -13,7 +13,6 @@
   },
   "main": "build/index.js",
   "module": "build/index.es.js",
-  "style": "build/index.css",
   "files": [
     "build/*"
   ],
@@ -26,9 +25,9 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
-    "@hig/semantic-release-config": "^0.1.0",
-    "@hig/styles": "^0.3.0"
+    "@hig/semantic-release-config": "^0.1.0"
   },
   "peerDependencies": {
     "react": "^15.4.1 || ^16.3.2"

--- a/packages/spacer/src/__stories__/infoOptions.js
+++ b/packages/spacer/src/__stories__/infoOptions.js
@@ -1,6 +1,5 @@
 import React from "react";
 import RichText from "@hig/rich-text";
-import "@hig/rich-text/build/index.css";
 
 import DefaultExport from "../index";
 import readme from "../../README.md";

--- a/packages/spacer/src/index.js
+++ b/packages/spacer/src/index.js
@@ -1,3 +1,1 @@
-import "@hig/styles/build/fonts.css";
-
 export { default } from "./Spacer";

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@hig/theme-context": "^2.1.0",
     "@hig/theme-data": "^2.1.1",
-    "@hig/typography": "^1.0.1",
+    "@hig/typography": "^1.0.2",
     "faker": "^4.1.0",
     "prop-types": "^15.6.1",
     "wait-port": "^0.2.2"

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -32,6 +32,7 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.3.0"

--- a/packages/tabs/src/__stories__/infoOptions.js
+++ b/packages/tabs/src/__stories__/infoOptions.js
@@ -1,6 +1,5 @@
 import React from "react";
 import RichText from "@hig/rich-text";
-import "@hig/rich-text/build/index.css";
 
 import Tabs, { Tab } from "../index";
 import readme from "../../README.md";

--- a/packages/tabs/src/__stories__/stories.js
+++ b/packages/tabs/src/__stories__/stories.js
@@ -1,7 +1,6 @@
 import React from "react";
 import RichText from "@hig/rich-text";
 import Button, { types } from "@hig/button";
-import "@hig/rich-text/build/index.css";
 
 import { Tab } from "../index";
 

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -27,6 +27,7 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },

--- a/packages/text-area/src/__stories__/infoOptions.js
+++ b/packages/text-area/src/__stories__/infoOptions.js
@@ -1,6 +1,5 @@
 import React from "react";
 import RichText from "@hig/rich-text";
-import "@hig/rich-text/build/index.css";
 
 import DefaultExport from "../index";
 import readme from "../../README.md";

--- a/packages/text-field/package.json
+++ b/packages/text-field/package.json
@@ -32,6 +32,7 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.3.0"

--- a/packages/text-field/src/__stories__/infoOptions.js
+++ b/packages/text-field/src/__stories__/infoOptions.js
@@ -1,6 +1,5 @@
 import React from "react";
 import RichText from "@hig/rich-text";
-import "@hig/rich-text/build/index.css";
 
 import DefaultExport from "../index";
 import readme from "../../README.md";

--- a/packages/text-link/package.json
+++ b/packages/text-link/package.json
@@ -29,9 +29,9 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
-    "@hig/semantic-release-config": "^0.1.0",
-    "@hig/styles": "^0.3.0"
+    "@hig/semantic-release-config": "^0.1.0"
   },
   "scripts": {
     "build": "hig-scripts-build",

--- a/packages/text-link/src/__stories__/infoOptions.js
+++ b/packages/text-link/src/__stories__/infoOptions.js
@@ -1,6 +1,5 @@
 import React from "react";
 import RichText from "@hig/rich-text";
-import "@hig/rich-text/build/index.css";
 
 import DefaultExport from "../index";
 import readme from "../../README.md";

--- a/packages/theme-data/package.json
+++ b/packages/theme-data/package.json
@@ -29,6 +29,7 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/typography": "^0.1.3",

--- a/packages/theme-data/src/__stories__/ThemeData.stories.js
+++ b/packages/theme-data/src/__stories__/ThemeData.stories.js
@@ -5,7 +5,6 @@ import { withInfo } from "@storybook/addon-info";
 import RichText from "@hig/rich-text";
 import KnobbedThemeProvider from "@hig/storybook/storybook-support/decorators/KnobbedThemeProvider";
 import { ThemeContext } from "@hig/theme-context";
-import "@hig/rich-text/build/index.css";
 
 import overallReadme from "../../README.md";
 import stories from "./stories";

--- a/packages/timestamp/package.json
+++ b/packages/timestamp/package.json
@@ -26,6 +26,7 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.3.0",

--- a/packages/timestamp/src/__stories__/infoOptions.js
+++ b/packages/timestamp/src/__stories__/infoOptions.js
@@ -1,6 +1,5 @@
 import React from "react";
 import RichText from "@hig/rich-text";
-import "@hig/rich-text/build/index.css";
 
 import DefaultExport from "../index";
 import readme from "../../README.md";

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -30,6 +30,7 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },

--- a/packages/tooltip/src/__stories__/infoOptions.js
+++ b/packages/tooltip/src/__stories__/infoOptions.js
@@ -1,6 +1,5 @@
 import React from "react";
 import RichText from "@hig/rich-text";
-import "@hig/rich-text/build/index.css";
 
 import DefaultExport from "../index";
 import readme from "../../README.md";

--- a/packages/top-nav/package.json
+++ b/packages/top-nav/package.json
@@ -18,6 +18,7 @@
     "build/*"
   ],
   "dependencies": {
+    "@hig/avatar": "1.0.4",
     "@hig/flyout": "^1.0.1",
     "@hig/icon-button": "^1.0.1",
     "@hig/icons": "^1.0.0",

--- a/packages/top-nav/package.json
+++ b/packages/top-nav/package.json
@@ -31,6 +31,7 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.3.0"

--- a/packages/top-nav/src/__stories__/infoOptions.js
+++ b/packages/top-nav/src/__stories__/infoOptions.js
@@ -1,6 +1,5 @@
 import React from "react";
 import RichText from "@hig/rich-text";
-import "@hig/rich-text/build/index.css";
 
 import readme from "../../README.md";
 import TopNav, {

--- a/packages/top-nav/src/presenters/ProfileButtonPresenter.js
+++ b/packages/top-nav/src/presenters/ProfileButtonPresenter.js
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Avatar, { sizes } from "@hig/avatar";
-import "@hig/avatar/build/index.css";
 
 import "./ProfileButtonPresenter.scss";
 

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -26,6 +26,7 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
+    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },

--- a/packages/typography/src/__stories__/infoOptions.js
+++ b/packages/typography/src/__stories__/infoOptions.js
@@ -1,6 +1,5 @@
 import React from "react";
 import RichText from "@hig/rich-text";
-import "@hig/rich-text/build/index.css";
 
 import DefaultExport from "../index";
 import readme from "../../README.md";


### PR DESCRIPTION
Combines https://github.com/Autodesk/hig/pull/1645 and https://github.com/Autodesk/hig/pull/1646.

Removes the dependency bumps for packages that aren't ready for them .