### PR TITLE
Feat/add banner theme data

### DIFF
--- a/packages/theme-data/src/baseTheme/components/banner.js
+++ b/packages/theme-data/src/baseTheme/components/banner.js
@@ -1,0 +1,35 @@
+import { COLOR } from "../../consts/types";
+
+export default {
+  // Info
+  "banner.info.iconBackground": {
+    type: COLOR,
+    value: { ref: "colorScheme.infoColor" }
+  },
+  "banner.info.borderColor": { type: COLOR },
+  "banner.info.backgroundColor": { type: COLOR },
+
+  // Error
+  "banner.error.iconBackground": {
+    type: COLOR,
+    value: { ref: "colorScheme.errorColor" }
+  },
+  "banner.error.borderColor": { type: COLOR },
+  "banner.error.backgroundColor": { type: COLOR },
+
+  // Success
+  "banner.success.iconBackground": {
+    type: COLOR,
+    value: { ref: "colorScheme.successColor" }
+  },
+  "banner.success.borderColor": { type: COLOR },
+  "banner.success.backgroundColor": { type: COLOR },
+
+  // Warning
+  "banner.warning.iconBackground": {
+    type: COLOR,
+    value: { ref: "colorScheme.warningColor" }
+  },
+  "banner.warning.borderColor": { type: COLOR },
+  "banner.warning.backgroundColor": { type: COLOR }
+};

--- a/packages/theme-data/src/baseTheme/system/colorScheme.js
+++ b/packages/theme-data/src/baseTheme/system/colorScheme.js
@@ -13,5 +13,29 @@ export default {
   surfaceLevel350Color: { type: COLOR },
   "component.backgroundColor": { type: COLOR },
   textColor: { type: COLOR },
-  textColorDim: { type: COLOR }
+  textColorDim: { type: COLOR },
+  infoColor: {
+    value: {
+      ref: "basics.colors.autodeskBlue400"
+    },
+    type: COLOR
+  },
+  errorColor: {
+    value: {
+      ref: "basics.colors.red500"
+    },
+    type: COLOR
+  },
+  successColor: {
+    value: {
+      ref: "basics.colors.green500"
+    },
+    type: COLOR
+  },
+  warningColor: {
+    value: {
+      ref: "basics.colors.yellowOrange500"
+    },
+    type: COLOR
+  }
 };

--- a/packages/theme-data/src/baseTheme/unresolvedRoles.js
+++ b/packages/theme-data/src/baseTheme/unresolvedRoles.js
@@ -4,6 +4,7 @@ import basics from "../basics";
 import system from "./system";
 
 import avatar from "./components/avatar";
+import banner from "./components/banner";
 import button from "./components/button";
 import checkbox from "./components/checkbox";
 import component from "./components/component";
@@ -39,6 +40,7 @@ const baseThemeConfig = extendTheme(
     mapKeys(system.colorScheme, key => `colorScheme.${key}`),
     mapKeys(system.density, key => `density.${key}`),
     avatar,
+    banner,
     button,
     checkbox,
     component,

--- a/packages/theme-data/src/basics/colors.js
+++ b/packages/theme-data/src/basics/colors.js
@@ -148,9 +148,33 @@ export default {
   textAgainstLight: { value: "#3c3c3c", type: COLOR },
 
   // Alert colors
-  error: { value: "#ec4a41", type: COLOR },
-  success: { value: "#87b340", type: COLOR },
-  warning: { value: "#faa21b", type: COLOR },
+  error: {
+    value: {
+      ref: "colorScheme.errorColor"
+    },
+    metadata: {
+      deprecated: { equivalent: "colorScheme.errorColor" }
+    },
+    type: COLOR
+  },
+  success: {
+    value: {
+      ref: "colorScheme.successColor"
+    },
+    metadata: {
+      deprecated: { equivalent: "colorScheme.successColor" }
+    },
+    type: COLOR
+  },
+  warning: {
+    value: {
+      ref: "colorScheme.warningColor"
+    },
+    metadata: {
+      deprecated: { equivalent: "colorScheme.warningColor" }
+    },
+    type: COLOR
+  },
 
   textLinkAgainstLight: { value: "#006EAF", type: COLOR },
   textLinkAgainstDark: { value: "#6DD2FF", type: COLOR }

--- a/packages/theme-data/src/colorSchemes/darkBlue/components/banner.js
+++ b/packages/theme-data/src/colorSchemes/darkBlue/components/banner.js
@@ -1,0 +1,33 @@
+export default {
+  // Info
+  "banner.info.borderColor": {
+    value: { ref: "basics.colors.autodeskBlue700" }
+  },
+  "banner.info.backgroundColor": {
+    value: { ref: "basics.colors.autodeskBlue800" }
+  },
+
+  // Error
+  "banner.error.borderColor": {
+    value: { ref: "basics.colors.red500" }
+  },
+  "banner.error.backgroundColor": {
+    value: { ref: "basics.colors.red700" }
+  },
+
+  // Success
+  "banner.success.borderColor": {
+    value: { ref: "basics.colors.green600" }
+  },
+  "banner.success.backgroundColor": {
+    value: { ref: "basics.colors.green800" }
+  },
+
+  // Warning
+  "banner.warning.borderColor": {
+    value: { ref: "basics.colors.yellowOrange600" }
+  },
+  "banner.warning.backgroundColor": {
+    value: { ref: "basics.colors.yellowOrange700" }
+  }
+};

--- a/packages/theme-data/src/colorSchemes/darkBlue/unresolvedRoles.js
+++ b/packages/theme-data/src/colorSchemes/darkBlue/unresolvedRoles.js
@@ -3,6 +3,7 @@ import mapKeys from "../../utils/mapKeys";
 import system from "./system";
 import baseTheme from "../../baseTheme";
 import mediumDensityTheme from "../../densities/mediumDensity";
+import banner from "./components/banner";
 import button from "./components/button";
 import checkbox from "./components/checkbox";
 import formField from "./components/formField";
@@ -21,6 +22,7 @@ const darkBlueThemeConfig = extendTheme(
     {},
     mediumDensityTheme.unresolvedRoles,
     mapKeys(system.colorScheme, key => `colorScheme.${key}`),
+    banner,
     button,
     checkbox,
     formField,

--- a/packages/theme-data/src/colorSchemes/lightGray/components/banner.js
+++ b/packages/theme-data/src/colorSchemes/lightGray/components/banner.js
@@ -1,0 +1,33 @@
+export default {
+  // Info
+  "banner.info.borderColor": {
+    value: { ref: "basics.colors.autodeskBlue700" }
+  },
+  "banner.info.backgroundColor": {
+    value: { ref: "basics.colors.autodeskBlue800" }
+  },
+
+  // Error
+  "banner.error.borderColor": {
+    value: { ref: "basics.colors.red500" }
+  },
+  "banner.error.backgroundColor": {
+    value: { ref: "basics.colors.red700" }
+  },
+
+  // Success
+  "banner.success.borderColor": {
+    value: { ref: "basics.colors.green600" }
+  },
+  "banner.success.backgroundColor": {
+    value: { ref: "basics.colors.green800" }
+  },
+
+  // Warning
+  "banner.warning.borderColor": {
+    value: { ref: "basics.colors.yellowOrange600" }
+  },
+  "banner.warning.backgroundColor": {
+    value: { ref: "basics.colors.yellowOrange700" }
+  }
+};

--- a/packages/theme-data/src/colorSchemes/lightGray/unresolvedRoles.js
+++ b/packages/theme-data/src/colorSchemes/lightGray/unresolvedRoles.js
@@ -3,6 +3,7 @@ import mapKeys from "../../utils/mapKeys";
 import baseTheme from "../../baseTheme";
 import mediumDensityTheme from "../../densities/mediumDensity";
 import system from "./system";
+import banner from "./components/banner";
 import formField from "./components/formField";
 import input from "./components/input";
 import skeletonItem from "./components/skeletonItem";
@@ -13,6 +14,7 @@ const lightGrayThemeConfig = extendTheme(
     {},
     mediumDensityTheme.unresolvedRoles,
     mapKeys(system.colorScheme, key => `colorScheme.${key}`),
+    banner,
     formField,
     input,
     skeletonItem


### PR DESCRIPTION
- Adds `colorScheme.infoColor`, `colorScheme.errorColor`, `colorScheme.warningColor`, `colorScheme.successColor`.
- Deprecates `basics.colors.error`, `basics.colors.warning`, and `basics.colors.success`.
- Adds roles and values for `banner`.