### PR TITLE
Feat/button arbitrary props

### DIFF
--- a/packages/button/src/Button.js
+++ b/packages/button/src/Button.js
@@ -97,7 +97,8 @@ export default class Button extends Component {
       target,
       title,
       type,
-      width
+      width,
+      ...otherProps
     } = this.props;
 
     return (
@@ -139,6 +140,7 @@ export default class Button extends Component {
             title={title}
             type={type}
             width={width}
+            {...otherProps}
           />
         )}
       </ControlBehavior>

--- a/packages/button/src/presenters/ButtonPresenter.js
+++ b/packages/button/src/presenters/ButtonPresenter.js
@@ -52,7 +52,8 @@ export default class ButtonPresenter extends Component {
       target,
       title,
       type,
-      width
+      width,
+      ...otherProps
     } = this.props;
 
     const href = link || undefined;
@@ -82,6 +83,7 @@ export default class ButtonPresenter extends Component {
               onMouseOver={onHover}
               onMouseUp={onMouseUp}
               disabled={disabled}
+              {...otherProps}
             >
               {icon && <span className={css(styles.icon)}>{icon}</span>}
               <span className="hig__button__title">{title}</span>

--- a/packages/button/src/presenters/stylesheet.js
+++ b/packages/button/src/presenters/stylesheet.js
@@ -77,7 +77,7 @@ function getButtonRulesByType(type, themeData) {
 
 function getButtonRulesByDisabled(type, themeData) {
   return {
-    opacity: themeData["button.disabled.opacity"],
+    opacity: themeData["component.disabled.opacity"],
     cursor: "default"
   };
 }

--- a/packages/theme-data/src/baseTheme/components/button.js
+++ b/packages/theme-data/src/baseTheme/components/button.js
@@ -6,7 +6,6 @@ import {
   FONT_WEIGHT,
   LENGTH,
   LINE_HEIGHT,
-  OPACITY,
   COLOR
 } from "../../consts/types";
 
@@ -144,14 +143,6 @@ export default {
     transform: {
       alpha: 0.15
     }
-  },
-
-  /**
-   * ### Disabled
-   */
-  "button.disabled.opacity": {
-    type: OPACITY,
-    value: "0.5"
   },
 
   /**


### PR DESCRIPTION
Resolves https://github.com/Autodesk/hig/issues/1667.

Also removes the `button.disabled.opacity` role in favor of the universal `component.disabled.opacity` role.