### PR TITLE
docs: move rich-text dependency out of comps into storybook

### DIFF
--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -28,7 +28,6 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -30,7 +30,6 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.3.0"

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -26,7 +26,6 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/theme-data": "^2.2.0"

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -31,7 +31,6 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -33,7 +33,6 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.3.0"

--- a/packages/flyout/package.json
+++ b/packages/flyout/package.json
@@ -29,7 +29,6 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },

--- a/packages/icon-button/package.json
+++ b/packages/icon-button/package.json
@@ -27,7 +27,6 @@
     "@hig/eslint-config": "^0.1.0",
     "@hig/icons": "^1.0.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.3.0"

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -21,7 +21,6 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/typography": "^1.0.2",

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -27,7 +27,6 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.2.3"

--- a/packages/label/package.json
+++ b/packages/label/package.json
@@ -26,7 +26,6 @@
   "devDependencies": {
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
-    "@hig/rich-text": "1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -35,7 +35,6 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",
     "lodash.merge": "^4.4.0"

--- a/packages/profile-flyout/package.json
+++ b/packages/profile-flyout/package.json
@@ -31,7 +31,6 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -28,7 +28,6 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },

--- a/packages/progress-ring/package.json
+++ b/packages/progress-ring/package.json
@@ -30,7 +30,6 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },

--- a/packages/project-account-switcher/package.json
+++ b/packages/project-account-switcher/package.json
@@ -33,7 +33,6 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },

--- a/packages/radio-button/package.json
+++ b/packages/radio-button/package.json
@@ -32,7 +32,6 @@
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
     "@hig/label": "^1.0.1",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/spacer": "^1.0.4"

--- a/packages/side-nav/package.json
+++ b/packages/side-nav/package.json
@@ -31,7 +31,6 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/styles": "^0.3.0"

--- a/packages/skeleton-item/package.json
+++ b/packages/skeleton-item/package.json
@@ -26,7 +26,6 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -30,7 +30,6 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },

--- a/packages/spacer/package.json
+++ b/packages/spacer/package.json
@@ -25,7 +25,6 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -50,6 +50,7 @@
     "surge": "^0.20.1"
   },
   "dependencies": {
+    "@hig/rich-text": "^1.0.0",
     "@hig/theme-context": "^2.1.0",
     "@hig/theme-data": "^2.2.0",
     "@hig/typography": "^1.0.2",

--- a/packages/surface/package.json
+++ b/packages/surface/package.json
@@ -25,7 +25,6 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/typography": "^1.0.2"

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -35,7 +35,6 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -27,7 +27,6 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },

--- a/packages/text-link/package.json
+++ b/packages/text-link/package.json
@@ -29,7 +29,6 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },

--- a/packages/theme-data/package.json
+++ b/packages/theme-data/package.json
@@ -29,7 +29,6 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",
     "@hig/typography": "^0.1.3",

--- a/packages/timestamp/package.json
+++ b/packages/timestamp/package.json
@@ -26,7 +26,6 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0",
     "mockdate": "^2.0.2"

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -30,7 +30,6 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },

--- a/packages/top-nav/package.json
+++ b/packages/top-nav/package.json
@@ -34,7 +34,6 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -26,7 +26,6 @@
     "@hig/babel-preset": "^0.1.1",
     "@hig/eslint-config": "^0.1.0",
     "@hig/jest-preset": "^0.1.0",
-    "@hig/rich-text": "^1.0.0",
     "@hig/scripts": "^0.1.2",
     "@hig/semantic-release-config": "^0.1.0"
   },


### PR DESCRIPTION
Resolves https://github.com/Autodesk/hig/issues/1659.

- Moved `rich-text` out of `devDependencies` for all the components and instead added it as a `dependency` for `storybook`.