### PR TITLE
feat: make side-nav themeable

### DIFF
--- a/packages/side-nav/package.json
+++ b/packages/side-nav/package.json
@@ -21,13 +21,13 @@
     "@hig/icon-button": "^1.0.1",
     "@hig/icons": "^2.0.1",
     "@hig/skeleton-item": "^0.4.0",
-    "@hig/utils": "^0.3.0",
-    "@hig/theme-context": "^2.1.0",
-    "prop-types": "^15.7.1",
-    "@hig/typography": "^1.0.2",
+    "@hig/surface": "^1.0.0",
     "@hig/text-link": "^1.0.0",
+    "@hig/theme-context": "^2.1.0",
+    "@hig/typography": "^1.0.2",
+    "@hig/utils": "^0.3.0",
     "emotion": "^10.0.0",
-    "@hig/surface": "^1.0.0"
+    "prop-types": "^15.7.1"
   },
   "devDependencies": {
     "@hig/babel-preset": "^0.1.1",


### PR DESCRIPTION
BREAKING CHANGE:

* CSS stylesheets no longer used

This commit is to allow for the proper `BREAKING CHANGE:` commit message so semantic release will properly version the component