### PR TITLE
Fix disappearance of x-button in notification toast

### DIFF
--- a/packages/notifications-toast/src/NotificationsToast.js
+++ b/packages/notifications-toast/src/NotificationsToast.js
@@ -79,12 +79,14 @@ export default class NotificationsToast extends Component {
               <div className={css(styles.toastBody)}>
                 <div className={css(styles.toastMessage)}>
                   <RichText>
-                    <Typography style={{
+                    <Typography
+                      style={{
                         fontSize: "12px",
                         maxWidth: "220px",
-                        textOverflow: "ellipsis", 
-                        overflow: `hidden`
-                      }}>
+                        textOverflow: "ellipsis",
+                        overflow: "hidden"
+                      }}
+                    >
                       {this.props.children}
                     </Typography>
                   </RichText>

--- a/packages/notifications-toast/src/NotificationsToast.js
+++ b/packages/notifications-toast/src/NotificationsToast.js
@@ -79,7 +79,12 @@ export default class NotificationsToast extends Component {
               <div className={css(styles.toastBody)}>
                 <div className={css(styles.toastMessage)}>
                   <RichText>
-                    <Typography style={{ fontSize: "12px" }}>
+                    <Typography style={{
+                        fontSize: "12px",
+                        maxWidth: "220px",
+                        textOverflow: "ellipsis", 
+                        overflow: `hidden`
+                      }}>
                       {this.props.children}
                     </Typography>
                   </RichText>


### PR DESCRIPTION
These changes fix the disappearance of the **x-button** due to a long text body (e.g. an url) in the notification toast. See the comparison below:

Before | After
------------ | -------------
![before](https://raw.githubusercontent.com/galibhassan/images/master/hig-images/hig%20toast%20long%20text%20before%20fix.JPG) | ![after](https://raw.githubusercontent.com/galibhassan/images/master/hig-images/hig%20toast%20long%20text%20after%20fix.JPG)

**Note** I tried to put the changes in `/src/NotificationsToast.stylesheet.js` file in `toastMessage` section, but wasn't quite successful probably because of some overriding. 