### PR TITLE
Fix/disabled buttons

### DIFF
--- a/packages/banner/src/BannerPresenter/__snapshots__/BannerPresenter.test.js.snap
+++ b/packages/banner/src/BannerPresenter/__snapshots__/BannerPresenter.test.js.snap
@@ -882,6 +882,7 @@ exports[`banner/BannerPresenter/BannerPresenter renders with onDismiss function 
     >
       <button
         className="emotion-6"
+        disabled={undefined}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}

--- a/packages/button/src/presenters/stylesheet.js
+++ b/packages/button/src/presenters/stylesheet.js
@@ -82,7 +82,8 @@ function getButtonRulesByType(type, themeData) {
 function getButtonRulesByDisabled(type, themeData) {
   return {
     opacity: themeData["component.disabled.opacity"],
-    cursor: "default"
+    cursor: "default",
+    pointerEvents: "none"
   };
 }
 

--- a/packages/icon-button/src/__snapshots__/IconButton.test.js.snap
+++ b/packages/icon-button/src/__snapshots__/IconButton.test.js.snap
@@ -52,6 +52,7 @@ exports[`IconButton renders correctly 1`] = `
 
 <button
   className="emotion-1"
+  disabled={undefined}
   onBlur={[Function]}
   onClick={undefined}
   onFocus={[Function]}
@@ -136,6 +137,7 @@ exports[`IconButton renders correctly when disabled 1`] = `
 
 <a
   className="emotion-1"
+  disabled={true}
   href="//example.com"
   onBlur={[Function]}
   onClick={undefined}
@@ -219,6 +221,7 @@ exports[`IconButton renders correctly with a link 1`] = `
 
 <a
   className="emotion-1"
+  disabled={undefined}
   href="//example.com"
   onBlur={[Function]}
   onClick={undefined}

--- a/packages/icon-button/src/presenters/IconButtonPresenter.js
+++ b/packages/icon-button/src/presenters/IconButtonPresenter.js
@@ -81,6 +81,7 @@ export default class IconButtonPresenter extends Component {
           return (
             <Element
               className={css(styles.iconButton)}
+              disabled={disabled}
               onClick={onClick}
               onBlur={onBlur}
               onFocus={onFocus}

--- a/packages/icon-button/src/presenters/__snapshots__/IconButtonPresenter.test.js.snap
+++ b/packages/icon-button/src/presenters/__snapshots__/IconButtonPresenter.test.js.snap
@@ -52,6 +52,7 @@ exports[`IconButtonPresenter renders correctly 1`] = `
 
 <button
   className="emotion-1"
+  disabled={undefined}
   onBlur={undefined}
   onClick={undefined}
   onFocus={undefined}
@@ -136,6 +137,7 @@ exports[`IconButtonPresenter renders correctly when disabled 1`] = `
 
 <a
   className="emotion-1"
+  disabled={true}
   href="//example.com"
   onBlur={undefined}
   onClick={undefined}
@@ -219,6 +221,7 @@ exports[`IconButtonPresenter renders correctly with a link 1`] = `
 
 <a
   className="emotion-1"
+  disabled={undefined}
   href="//example.com"
   onBlur={undefined}
   onClick={undefined}

--- a/packages/modal/src/__snapshots__/Modal.test.js.snap
+++ b/packages/modal/src/__snapshots__/Modal.test.js.snap
@@ -214,6 +214,7 @@ exports[`modal/Modal integration renders correctly 1`] = `
           </p>
           <button
             className="emotion-2"
+            disabled={undefined}
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -467,6 +468,7 @@ exports[`modal/Modal integration renders with styles customized 1`] = `
           </p>
           <button
             className="emotion-2"
+            disabled={undefined}
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}

--- a/packages/modal/src/presenters/__snapshots__/ModalHeaderPresenter.test.js.snap
+++ b/packages/modal/src/presenters/__snapshots__/ModalHeaderPresenter.test.js.snap
@@ -80,6 +80,7 @@ exports[`modal/presenters/ModalHeaderPresenter  1`] = `
     />
     <button
       className="emotion-2"
+      disabled={undefined}
       onBlur={[Function]}
       onClick={undefined}
       onFocus={[Function]}
@@ -202,6 +203,7 @@ exports[`modal/presenters/ModalHeaderPresenter  3`] = `
     </p>
     <button
       className="emotion-2"
+      disabled={undefined}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}

--- a/packages/modal/src/presenters/__snapshots__/ModalPresenter.test.js.snap
+++ b/packages/modal/src/presenters/__snapshots__/ModalPresenter.test.js.snap
@@ -80,6 +80,7 @@ exports[`modal/presenters/ModalPresenter  1`] = `
     />
     <button
       className="emotion-2"
+      disabled={undefined}
       onBlur={[Function]}
       onClick={undefined}
       onFocus={[Function]}

--- a/packages/notifications-flyout/src/__snapshots__/Notification.test.js.snap
+++ b/packages/notifications-flyout/src/__snapshots__/Notification.test.js.snap
@@ -239,6 +239,7 @@ exports[`notifications-flyout/Notification renders correctly with the featured p
       >
         <button
           className="emotion-2"
+          disabled={undefined}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}

--- a/packages/notifications-flyout/src/__snapshots__/NotificationsFlyout.test.js.snap
+++ b/packages/notifications-flyout/src/__snapshots__/NotificationsFlyout.test.js.snap
@@ -334,6 +334,7 @@ exports[`notifications-flyout/NotificationsFlyout renders a notification with th
     >
       <button
         className="emotion-1"
+        disabled={undefined}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
@@ -811,6 +812,7 @@ exports[`notifications-flyout/NotificationsFlyout renders a notification with th
     >
       <button
         className="emotion-1"
+        disabled={undefined}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
@@ -1288,6 +1290,7 @@ exports[`notifications-flyout/NotificationsFlyout renders with all props 1`] = `
     >
       <button
         className="emotion-1"
+        disabled={undefined}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
@@ -1667,6 +1670,7 @@ exports[`notifications-flyout/NotificationsFlyout renders without props 1`] = `
     >
       <button
         className="emotion-1"
+        disabled={undefined}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}

--- a/packages/notifications-flyout/src/presenters/__snapshots__/DismissButtonPresenter.test.js.snap
+++ b/packages/notifications-flyout/src/presenters/__snapshots__/DismissButtonPresenter.test.js.snap
@@ -62,6 +62,7 @@ exports[`notifications-flyout/presenters/DismissButtonPresenter renders with all
 >
   <button
     className="emotion-1"
+    disabled={undefined}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -152,6 +153,7 @@ exports[`notifications-flyout/presenters/DismissButtonPresenter renders without 
 >
   <button
     className="emotion-1"
+    disabled={undefined}
     onBlur={[Function]}
     onClick={undefined}
     onFocus={[Function]}

--- a/packages/notifications-flyout/src/presenters/__snapshots__/IndicatorPresenter.test.js.snap
+++ b/packages/notifications-flyout/src/presenters/__snapshots__/IndicatorPresenter.test.js.snap
@@ -82,6 +82,7 @@ exports[`notifications-flyout/presenters/IndicatorPresenter renders with all pro
 >
   <button
     className="emotion-1"
+    disabled={undefined}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -197,6 +198,7 @@ exports[`notifications-flyout/presenters/IndicatorPresenter renders without prop
 >
   <button
     className="emotion-1"
+    disabled={undefined}
     onBlur={[Function]}
     onClick={undefined}
     onFocus={[Function]}

--- a/packages/notifications-flyout/src/presenters/__snapshots__/NotificationPresenter.test.js.snap
+++ b/packages/notifications-flyout/src/presenters/__snapshots__/NotificationPresenter.test.js.snap
@@ -225,6 +225,7 @@ exports[`notifications-flyout/presenters/NotificationPresenter renders with all 
       >
         <button
           className="emotion-2"
+          disabled={undefined}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}

--- a/packages/top-nav/src/presenters/__snapshots__/HelpButtonPresenter.test.js.snap
+++ b/packages/top-nav/src/presenters/__snapshots__/HelpButtonPresenter.test.js.snap
@@ -52,6 +52,7 @@ exports[`top-nav/presenters/HelpButtonPresenter  1`] = `
 
 <button
   className="emotion-1"
+  disabled={undefined}
   onBlur={[Function]}
   onClick={undefined}
   onFocus={[Function]}
@@ -139,6 +140,7 @@ exports[`top-nav/presenters/HelpButtonPresenter  2`] = `
 
 <button
   className="emotion-1"
+  disabled={undefined}
   onBlur={[Function]}
   onClick={undefined}
   onFocus={[Function]}
@@ -226,6 +228,7 @@ exports[`top-nav/presenters/HelpButtonPresenter  3`] = `
 
 <button
   className="emotion-1"
+  disabled={undefined}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}


### PR DESCRIPTION
Related to https://github.com/Autodesk/hig/issues/1963.
- `IconButton` now passes down the `disabled` attribute to the `button` element like the `Button` component
- `Button` when used as a link now has `pointer-events: none` style