### PR TITLE
fix: use correct color for dark themed icon colors

### DIFF
--- a/packages/theme-data/src/basics/colors.js
+++ b/packages/theme-data/src/basics/colors.js
@@ -47,8 +47,8 @@ export default {
   green900: { value: "#445e20", type: COLOR },
 
   iconLightGrayColor: { value: "#808080", type: COLOR },
-  iconDarkBlueColor: { value: "#d1deee", type: COLOR },
-  iconDarkGrayColor: { value: "#cccccc", type: COLOR },
+  iconDarkBlueColor: { value: "#a2a6b0", type: COLOR },
+  iconDarkGrayColor: { value: "#999999", type: COLOR },
 
   red100: { value: "#ffd9d9", type: COLOR },
   red200: { value: "#f8d3d3", type: COLOR },


### PR DESCRIPTION
Resolves: https://github.com/Autodesk/hig/issues/1976