### PR TITLE
Fix: Prioritize focus over hover behavior for Input halo

### DIFF
--- a/packages/input/src/presenters/InputHaloPresenter.stylesheet.js
+++ b/packages/input/src/presenters/InputHaloPresenter.stylesheet.js
@@ -29,16 +29,16 @@ function borderBottomStyles({ isDisabled, hasFocus, hasHover }, themeData) {
       opacity: themeData["input.disabled.opacity"]
     };
   }
-  if (hasHover) {
-    return {
-      ...defaults,
-      borderBottomColor: themeData["input.hover.borderBottomColor"]
-    };
-  }
   if (hasFocus) {
     return {
       ...defaults,
       borderBottomColor: themeData["input.focus.borderBottomColor"]
+    };
+  }
+  if (hasHover) {
+    return {
+      ...defaults,
+      borderBottomColor: themeData["input.hover.borderBottomColor"]
     };
   }
   return defaults;
@@ -55,17 +55,17 @@ function haloStyles({ isDisabled, hasFocus, hasHover }, themeData) {
   if (isDisabled) {
     return {};
   }
-  if (hasHover) {
-    return {
-      ...defaults,
-      height: themeData["input.hover.halo.width"],
-      transitionDuration: "0.1s, 0.1s"
-    };
-  }
   if (hasFocus) {
     return {
       height: themeData["input.focus.halo.width"],
       backgroundColor: themeData["input.focus.halo.color"],
+      transitionDuration: "0.1s, 0.1s"
+    };
+  }
+  if (hasHover) {
+    return {
+      ...defaults,
+      height: themeData["input.hover.halo.width"],
       transitionDuration: "0.1s, 0.1s"
     };
   }


### PR DESCRIPTION
## Symptom

The `Input` halo was grey when you had both `focus` and `hover`.

![OldInputBehaviour](https://user-images.githubusercontent.com/20013361/62113252-25cfb880-b2ac-11e9-8079-529639f22e8e.gif)

As far as I can tell this isn't correct. The HIG page seems to imply that on focus you should always have the blue halo.

## Problem

The logic is ordered so that on hover it will return early from the function and apply the hover styles, missing the `hasFocus` section completely.

## Solution

Change the logic of the function so that `focus` is considered before `hover` .

![NewInputBehaviour](https://user-images.githubusercontent.com/20013361/62113528-aee6ef80-b2ac-11e9-9d1f-4874a4ec9e0a.gif)

## Verification

TODO (waiting on credentials)

