### PR TITLE
feat: add stylesheet prop to flyout

### DIFF
--- a/packages/flyout/README.md
+++ b/packages/flyout/README.md
@@ -33,6 +33,31 @@ import Flyout, { anchorPoints } from "@hig/flyout";
 
 Use the `className` prop to pass in a css class name to the outermost container of the component. The class name will also pass down to most of the other styled elements within the component. 
 
+Flyout also has a `stylesheet` prop that accepts a function wherein you can modify its styles. The original styles, props, current theme data and theme meta will be passed to your custom stylesheet function, and it should return an object with the same structure as the original styles. For instance
+
+```jsx
+function customStylesheet(styles) {
+  return {
+    ...styles,
+    flyoutContainer: {
+      ...styles.flyoutContainer,
+      opacity: "0.3"
+    },
+    panel: {
+      ...styles.panel,
+      backgroundColor: "orange"
+    },
+    pointerBody: {
+      fill: "orange"
+    }
+  };
+}
+
+<Flyout stylesheet={customStylesheet} content={<p>Any content can go in here.</p>}>
+  <Button title="Open flyout" />
+</Flyout>
+```
+
 ## Using [render props][] for additional customization
 
 [render props]: https://reactjs.org/docs/render-props.html

--- a/packages/flyout/src/Flyout.js
+++ b/packages/flyout/src/Flyout.js
@@ -73,7 +73,9 @@ export default class Flyout extends Component {
      * If openOnHover is true, this prop will determine the delay
      * from when mouseEnter begins until the flyout visually opens
      */
-    openOnHoverDelay: PropTypes.number
+    openOnHoverDelay: PropTypes.number,
+    /** Function to modify the component's styles */
+    stylesheet: PropTypes.func
   };
 
   static defaultProps = {
@@ -85,14 +87,26 @@ export default class Flyout extends Component {
     /**
      * @param {PanelRendererPayload} payload
      */
-    panel({ innerRef, content, handleScroll, maxHeight, className }) {
+    panel({
+      innerRef,
+      content,
+      handleScroll,
+      maxHeight,
+      className,
+      stylesheet
+    }) {
       return (
         <PanelContainerPresenter
           innerRef={innerRef}
           maxHeight={maxHeight}
           className={className}
+          stylesheet={stylesheet}
         >
-          <PanelPresenter onScroll={handleScroll} className={className}>
+          <PanelPresenter
+            onScroll={handleScroll}
+            className={className}
+            stylesheet={stylesheet}
+          >
             {content}
           </PanelPresenter>
         </PanelContainerPresenter>
@@ -252,7 +266,7 @@ export default class Flyout extends Component {
    */
   createPanelPayload() {
     const { hideFlyout } = this;
-    const { maxHeight, onScroll, ...otherProps } = this.props;
+    const { maxHeight, onScroll, stylesheet, ...otherProps } = this.props;
     const { className } = otherProps;
 
     return {
@@ -261,7 +275,8 @@ export default class Flyout extends Component {
       content: this.renderContent(),
       handleScroll: onScroll,
       innerRef: this.refPanel,
-      className
+      className,
+      stylesheet
     };
   }
 
@@ -316,7 +331,7 @@ export default class Flyout extends Component {
       refPointer,
       refWrapper
     } = this;
-    const { openOnHoverDelay, pointer, ...otherProps } = this.props;
+    const { openOnHoverDelay, pointer, stylesheet, ...otherProps } = this.props;
     const { className } = otherProps;
     const panel = this.renderPanel({ transitionStatus });
     const {
@@ -335,6 +350,7 @@ export default class Flyout extends Component {
           <FlyoutPresenter
             anchorPoint={anchorPoint}
             className={className}
+            stylesheet={stylesheet}
             containerPosition={containerPosition}
             panel={panel}
             pointer={pointer}

--- a/packages/flyout/src/Flyout.test.js
+++ b/packages/flyout/src/Flyout.test.js
@@ -101,6 +101,28 @@ describe("flyout/Flyout", () => {
           ...basicProps,
           className: "my-class"
         }
+      },
+      {
+        desc: "renders with custom stylesheet function",
+        props: {
+          ...basicProps,
+          stylesheet(styles) {
+            return {
+              ...styles,
+              flyoutContainer: {
+                ...styles.flyoutContainer,
+                opacity: "0.3"
+              },
+              panel: {
+                ...styles.panel,
+                backgroundColor: "orange"
+              },
+              pointerBody: {
+                fill: "orange"
+              }
+            };
+          }
+        }
       }
     ]);
   });

--- a/packages/flyout/src/__snapshots__/Flyout.test.js.snap
+++ b/packages/flyout/src/__snapshots__/Flyout.test.js.snap
@@ -1544,6 +1544,209 @@ exports[`flyout/Flyout snapshots renders with className prop 1`] = `
 </div>
 `;
 
+exports[`flyout/Flyout snapshots renders with custom stylesheet function 1`] = `
+.emotion-9 {
+  position: relative;
+  display: inline-block;
+}
+
+.emotion-1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: absolute;
+  -webkit-transform: rotate(0deg);
+  -ms-transform: rotate(0deg);
+  transform: rotate(0deg);
+}
+
+.emotion-2 {
+  fill: transparent;
+}
+
+.emotion-7 {
+  background-color: #ffffff;
+  border-radius: 4px;
+  border: none;
+  box-shadow: 0 0 16px rgba(0,0,0,0.25);
+}
+
+.emotion-6 {
+  position: relative;
+}
+
+.emotion-0 {
+  border-width: 1px;
+  border-style: solid;
+  border-color: transparent;
+  border-radius: 2px;
+  box-sizing: border-box;
+  color: #f5f5f5;
+  cursor: pointer;
+  display: inline-block;
+  font-family: ArtifaktElement,sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 18px;
+  margin: 0;
+  overflow: hidden;
+  padding: 8px 16px;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  -webkit-transition-duration: 0.3s;
+  transition-duration: 0.3s;
+  -webkit-transition-property: box-shadow;
+  transition-property: box-shadow;
+  -webkit-transition-timing-function: cubic-bezier(0.4,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.4,0,0.2,1);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  white-space: nowrap;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  background: #0696d7;
+}
+
+.emotion-0:visited {
+  color: #f5f5f5;
+}
+
+.emotion-0 svg * {
+  fill: #f5f5f5;
+}
+
+.emotion-8 {
+  position: absolute;
+  display: table;
+  width: 100%;
+  z-index: 9999;
+  -webkit-transition-property: opacity,-webkit-transform;
+  -webkit-transition-property: opacity,transform;
+  transition-property: opacity,transform;
+  -webkit-transition-duration: 250ms;
+  transition-duration: 250ms;
+  -webkit-transition-timing-function: cubic-bezier(0.77,0,0.265,2);
+  transition-timing-function: cubic-bezier(0.77,0,0.265,2);
+  touch-action: auto;
+  pointer-events: auto;
+  opacity: 0.3;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.emotion-3 {
+  fill: orange;
+}
+
+.emotion-5 {
+  min-width: 200px;
+  max-height: 360px;
+  padding: 12px;
+  overflow-y: auto;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
+  background-color: orange;
+}
+
+<div
+  className="emotion-9"
+>
+  <div
+    className="emotion-1"
+  >
+    <button
+      className="emotion-0"
+      disabled={false}
+      href={undefined}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseOver={undefined}
+      onMouseUp={[Function]}
+      tabIndex="0"
+      target={undefined}
+    >
+      <span
+        className=""
+      >
+        Click Me
+      </span>
+    </button>
+  </div>
+  <div
+    className="emotion-8"
+    style={
+      Object {
+        "left": "0px",
+        "top": "0px",
+      }
+    }
+  >
+    <div
+      aria-hidden="true"
+      className="emotion-4"
+      role="presentation"
+      style={
+        Object {
+          "left": "0px",
+          "top": "0px",
+        }
+      }
+    >
+      <svg
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+      >
+        <polygon
+          className="emotion-2"
+          points="0,12 12,0 24,12"
+        />
+        <polygon
+          className="emotion-3"
+          points="2.5,12 12,2.5 21.5,12"
+        />
+      </svg>
+    </div>
+    <div
+      className="emotion-7"
+      style={
+        Object {
+          "maxHeight": "150px",
+        }
+      }
+    >
+      <div
+        className="emotion-6"
+      >
+        <div
+          className="emotion-5"
+          onScroll={[Function]}
+        >
+          Hello World
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`flyout/Flyout snapshots renders without props 1`] = `
 .emotion-8 {
   position: relative;

--- a/packages/flyout/src/presenters/FlyoutPresenter.js
+++ b/packages/flyout/src/presenters/FlyoutPresenter.js
@@ -36,6 +36,7 @@ export default function FlyoutPresenter(props) {
     refPointer,
     refWrapper,
     transitionStatus,
+    stylesheet: customStylesheet,
     ...otherProps
   } = props;
   const { className } = otherProps;
@@ -54,7 +55,7 @@ export default function FlyoutPresenter(props) {
     <ThemeContext.Consumer>
       {({ resolvedRoles }) => {
         const styles = stylesheet(
-          { transitionStatus, anchorPoint },
+          { transitionStatus, anchorPoint, stylesheet: customStylesheet },
           resolvedRoles
         );
 
@@ -81,8 +82,9 @@ export default function FlyoutPresenter(props) {
                 anchorPoint={anchorPoint}
                 style={pointerStyle}
                 className={className}
+                stylesheet={customStylesheet}
               >
-                {pointer}
+                {pointer || <PointerPresenter stylesheet={customStylesheet} />}
               </PointerWrapperPresenter>
               {panel}
             </div>
@@ -96,7 +98,6 @@ export default function FlyoutPresenter(props) {
 FlyoutPresenter.defaultProps = {
   anchorPoint: DEFAULT_COORDINATES.anchorPoint,
   containerPosition: DEFAULT_COORDINATES.containerPosition,
-  pointer: <PointerPresenter />,
   pointerPosition: DEFAULT_COORDINATES.pointerPosition,
   transitionStatus: transitionStatuses.EXITED
 };
@@ -127,5 +128,7 @@ FlyoutPresenter.propTypes = {
   /** The status of the container transition */
   transitionStatus: PropTypes.oneOf(AVAILABLE_TRANSITION_STATUSES),
   /** Target component to open the flyout */
-  children: PropTypes.node
+  children: PropTypes.node,
+  /** Function to modify the component's styles */
+  stylesheet: PropTypes.func
 };

--- a/packages/flyout/src/presenters/PanelContainerPresenter.js
+++ b/packages/flyout/src/presenters/PanelContainerPresenter.js
@@ -7,7 +7,13 @@ import { createCustomClassNames } from "@hig/utils";
 import stylesheet from "./stylesheet";
 
 export default function PanelContainerPresenter(props) {
-  const { children, innerRef, maxHeight, ...otherProps } = props;
+  const {
+    children,
+    innerRef,
+    maxHeight,
+    stylesheet: customStylesheet,
+    ...otherProps
+  } = props;
   const { className } = otherProps;
   const maxHeightInPixels = maxHeight ? `${maxHeight}px` : undefined;
   const panelContainerClassName = createCustomClassNames(
@@ -26,7 +32,8 @@ export default function PanelContainerPresenter(props) {
         const styles = stylesheet(
           {
             transitionStatus: null,
-            anchorPoint: null
+            anchorPoint: null,
+            stylesheet: customStylesheet
           },
           resolvedRoles,
           themeId
@@ -59,5 +66,7 @@ PanelContainerPresenter.propTypes = {
   /** The panel content */
   children: PropTypes.node,
   /** Max height of the panel */
-  maxHeight: PropTypes.number
+  maxHeight: PropTypes.number,
+  /** Function to modify the component's styles */
+  stylesheet: PropTypes.func
 };

--- a/packages/flyout/src/presenters/PanelPresenter.js
+++ b/packages/flyout/src/presenters/PanelPresenter.js
@@ -6,7 +6,12 @@ import { createCustomClassNames } from "@hig/utils";
 
 import stylesheet from "./stylesheet";
 
-export default function PanelPresenter({ children, onScroll, ...otherProps }) {
+export default function PanelPresenter({
+  children,
+  onScroll,
+  stylesheet: customStylesheet,
+  ...otherProps
+}) {
   const { className } = otherProps;
   const panelClassName = createCustomClassNames(className, "panel");
 
@@ -14,7 +19,11 @@ export default function PanelPresenter({ children, onScroll, ...otherProps }) {
     <ThemeContext.Consumer>
       {({ resolvedRoles }) => {
         const styles = stylesheet(
-          { transitionStatus: null, anchorPoint: null },
+          {
+            transitionStatus: null,
+            anchorPoint: null,
+            stylesheet: customStylesheet
+          },
           resolvedRoles
         );
 
@@ -33,5 +42,6 @@ export default function PanelPresenter({ children, onScroll, ...otherProps }) {
 
 PanelPresenter.propTypes = {
   children: PropTypes.node,
-  onScroll: PropTypes.func
+  onScroll: PropTypes.func,
+  stylesheet: PropTypes.func
 };

--- a/packages/flyout/src/presenters/PointerPresenter.js
+++ b/packages/flyout/src/presenters/PointerPresenter.js
@@ -5,7 +5,7 @@ import { ThemeContext } from "@hig/theme-context";
 import stylesheet from "./stylesheet";
 
 export default function PointerPresenter(props) {
-  const { borderWidth, size } = props;
+  const { borderWidth, size, stylesheet: customStylesheet } = props;
   const height = size / 2;
   const width = size;
   const widthMidpoint = width / 2;
@@ -14,12 +14,14 @@ export default function PointerPresenter(props) {
     <ThemeContext.Consumer>
       {({ resolvedRoles }) => {
         const styles = stylesheet(
-          { transitionStatus: null, anchorPoint: null },
+          {
+            transitionStatus: null,
+            anchorPoint: null,
+            stylesheet: customStylesheet
+          },
           resolvedRoles
         );
-        const cssStyles = props.stylesheet
-          ? props.stylesheet(styles, props, resolvedRoles)
-          : styles;
+
         return (
           <svg
             height={size.toString()}
@@ -27,7 +29,7 @@ export default function PointerPresenter(props) {
             width={width.toString()}
           >
             <polygon
-              className={css(cssStyles.pointerBorder)}
+              className={css(styles.pointerBorder)}
               points={[
                 `0,${height}`,
                 `${widthMidpoint},0`,
@@ -35,7 +37,7 @@ export default function PointerPresenter(props) {
               ].join(" ")}
             />
             <polygon
-              className={css(cssStyles.pointerBody)}
+              className={css(styles.pointerBody)}
               points={[
                 `${borderWidth},${height}`,
                 `${widthMidpoint},${borderWidth}`,

--- a/packages/flyout/src/presenters/PointerWrapperPresenter.js
+++ b/packages/flyout/src/presenters/PointerWrapperPresenter.js
@@ -10,9 +10,14 @@ export default function PointerWrapperPresenter({
   innerRef,
   style,
   anchorPoint,
+  stylesheet: customStylesheet,
   ...otherProps
 }) {
-  const styles = stylesheet({ transitionStatus: null, anchorPoint });
+  const styles = stylesheet({
+    transitionStatus: null,
+    anchorPoint,
+    stylesheet: customStylesheet
+  });
   const { className } = otherProps;
   const pointerWrapperClassName = createCustomClassNames(
     className,
@@ -37,5 +42,6 @@ PointerWrapperPresenter.propTypes = {
   innerRef: PropTypes.func,
   /* eslint-disable-next-line react/forbid-prop-types */
   style: PropTypes.object,
-  anchorPoint: PropTypes.oneOf(AVAILABLE_ANCHOR_POINTS)
+  anchorPoint: PropTypes.oneOf(AVAILABLE_ANCHOR_POINTS),
+  stylesheet: PropTypes.func
 };

--- a/packages/flyout/src/presenters/stylesheet.js
+++ b/packages/flyout/src/presenters/stylesheet.js
@@ -45,7 +45,7 @@ function getAnchorPointTransformRotate(anchorPoint) {
 }
 
 export default function(props, themeData, themeId) {
-  const { transitionStatus, anchorPoint } = props;
+  const { transitionStatus, anchorPoint, stylesheet } = props;
   const isExiting = transitionStatus === `exiting`;
   const isExited = transitionStatus === `exited`;
   const isHidden = transitionStatus === `hidden`;
@@ -66,7 +66,7 @@ export default function(props, themeData, themeId) {
     ? getStyle(themeData, `density.spacings.small`)
     : 0;
 
-  return {
+  const styles = {
     flyoutWrapper: {
       position: `relative`,
       display: `inline-block`
@@ -123,4 +123,10 @@ export default function(props, themeData, themeId) {
       fill: backgroundColor
     }
   };
+
+  if (stylesheet) {
+    return stylesheet(styles, props, themeData, themeId);
+  }
+
+  return styles;
 }


### PR DESCRIPTION
- Not like what we did for input, textarea, for Flyout (and the new Accordion, new Menu components) I added the logic of `if (customStylesheet) {...} else {...}` in `stylesheet.js`, the `stylesheet` actually is a prop like other props, so in each presenter.js, we just need to pass `stylesheet: customStylesheet` to our component's stylesheet function along with the other props, and then we will not need to add the `if else` logic again and again.

- I have tested it and also updated the README and jest files.