### PR TITLE
feat: allow className to be passed to Avatar

### DIFF
--- a/packages/avatar/README.md
+++ b/packages/avatar/README.md
@@ -28,3 +28,7 @@ import Avatar, { sizes } from '@hig/avatar';
   size={sizes.LARGE_48}
 />
 ```
+
+## Custom CSS
+
+Use the `className` prop to pass in a css class name to the outermost container of the component. The class name will also pass down to most of the other styled elements within the component. 

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -17,6 +17,7 @@
     "build/*"
   ],
   "dependencies": {
+    "@hig/utils": "^0.4.0",
     "prop-types": "^15.7.1",
     "react-lifecycles-compat": "^3.0.4"
   },

--- a/packages/avatar/src/Avatar.js
+++ b/packages/avatar/src/Avatar.js
@@ -1,8 +1,9 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { css } from "emotion";
+import { cx, css } from "emotion";
 import { polyfill } from "react-lifecycles-compat";
 import { ThemeContext } from "@hig/theme-context";
+import { createCustomClassNames } from "@hig/utils";
 import { sizes, AVAILABLE_SIZES } from "./sizes";
 import stylesheet from "./Avatar.stylesheet";
 
@@ -50,14 +51,22 @@ function initialsFromName(name) {
  * @returns {JSX.Element}
  */
 // eslint-disable-next-line react/prop-types
-function Image({ image, name, size, onError, resolvedRoles }) {
+function Image({ image, name, size, onError, className, resolvedRoles }) {
   const alt = `Avatar image of ${name}`;
   const styles = stylesheet({ size }, resolvedRoles);
 
+  const imageWrapperClassName = createCustomClassNames(
+    className,
+    "image-wrapper"
+  );
+  const imageClassName = createCustomClassNames(className, "image");
+
   return (
-    <span className={css(styles.avatar.imageWrapper)}>
+    <span
+      className={cx(css(styles.avatar.imageWrapper), imageWrapperClassName)}
+    >
       <img
-        className={css(styles.avatar.image)}
+        className={cx(css(styles.avatar.image), imageClassName)}
         src={image}
         alt={alt}
         onError={onError}
@@ -72,12 +81,16 @@ function Image({ image, name, size, onError, resolvedRoles }) {
  * @returns {JSX.Element}
  */
 // eslint-disable-next-line react/prop-types
-function Initials({ size, name, resolvedRoles }) {
+function Initials({ size, name, className, resolvedRoles }) {
   const styles = stylesheet({ size, name }, resolvedRoles);
   const initials = initialsFromName(name);
+  const initialsClassName = createCustomClassNames(className, "initials");
 
   return (
-    <span className={css(styles.avatar.initials)} aria-hidden="true">
+    <span
+      className={cx(css(styles.avatar.initials), initialsClassName)}
+      aria-hidden="true"
+    >
       {size === sizes.SMALL_16 ? initials[0] : initials}
     </span>
   );
@@ -152,7 +165,8 @@ class Avatar extends Component {
   };
 
   render() {
-    const { size, name } = this.props;
+    const { size, name, ...otherProps } = this.props;
+    const { className } = otherProps;
     const { imageUrl, hasImageError } = this.state;
     const { handleImageError } = this;
     const backgroundId =
@@ -168,7 +182,10 @@ class Avatar extends Component {
         {({ resolvedRoles }) => (
           <span
             aria-label={label}
-            className={css(styles(resolvedRoles).avatar.container)}
+            className={cx(
+              css(styles(resolvedRoles).avatar.container),
+              className
+            )}
             role="img"
           >
             {!showImage ? null : (
@@ -177,10 +194,16 @@ class Avatar extends Component {
                 size={size}
                 image={imageUrl}
                 name={name}
+                className={className}
                 onError={handleImageError}
               />
             )}
-            <Initials name={name} size={size} resolvedRoles={resolvedRoles} />
+            <Initials
+              name={name}
+              size={size}
+              resolvedRoles={resolvedRoles}
+              className={className}
+            />
           </span>
         )}
       </ThemeContext.Consumer>

--- a/packages/avatar/src/Avatar.test.js
+++ b/packages/avatar/src/Avatar.test.js
@@ -30,6 +30,15 @@ describe("avatar/Avatar", () => {
         onImageError: function handleImageError() {},
         size: sizes.LARGE_48
       }
+    },
+    {
+      desc: "renders with className prop",
+      props: {
+        name: "Jon Snow",
+        image: "http://placekitten.com/g/64/64",
+        className: "my-class-a my-class-b",
+        size: sizes.LARGE_48
+      }
     }
   ]);
 

--- a/packages/avatar/src/__snapshots__/Avatar.test.js.snap
+++ b/packages/avatar/src/__snapshots__/Avatar.test.js.snap
@@ -160,6 +160,68 @@ exports[`avatar/Avatar renders with an image 1`] = `
 </span>
 `;
 
+exports[`avatar/Avatar renders with className prop 1`] = `
+.emotion-3 {
+  background-color: #5d822c;
+  color: #ffffff;
+  width: 48px;
+  height: 48px;
+  line-height: 48px;
+  font-size: 24px;
+  display: block;
+  position: relative;
+  margin: 0;
+  overflow: hidden;
+  border-radius: 50%;
+  text-align: center;
+}
+
+.emotion-1 {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  z-index: 2;
+  font-size: 24px;
+}
+
+.emotion-0 {
+  border-radius: 50%;
+  width: 48px;
+  height: 48px;
+}
+
+.emotion-2 {
+  width: 48px;
+  height: 48px;
+  font-family: ArtifaktElement,sans-serif;
+}
+
+<span
+  aria-label="Avatar for Jon Snow"
+  className="emotion-3 my-class-a my-class-b"
+  role="img"
+>
+  <span
+    className="emotion-1 my-class-a__image-wrapper my-class-b__image-wrapper"
+  >
+    <img
+      alt="Avatar image of Jon Snow"
+      className="emotion-0 my-class-a__image my-class-b__image"
+      onError={[Function]}
+      src="http://placekitten.com/g/64/64"
+    />
+  </span>
+  <span
+    aria-hidden="true"
+    className="emotion-2 my-class-a__initials my-class-b__initials"
+  >
+    JS
+  </span>
+</span>
+`;
+
 exports[`avatar/Avatar renders without props 1`] = `
 .emotion-1 {
   background-color: #6ac0e7;


### PR DESCRIPTION
As we've done for other components, this PR is to allow className to be passed down to Avatar. This is a need for new Menu component, to add styles for menuItems contain avatars. otherwise we will have to add an additional wrapper for avatar.