### PR TITLE
feat: add error prop for Dropdown

### DIFF
--- a/packages/dropdown/src/Dropdown.js
+++ b/packages/dropdown/src/Dropdown.js
@@ -86,7 +86,11 @@ export default class Dropdown extends Component {
     /**
      * The visual variant of the textarea
      */
-    variant: PropTypes.oneOf(variantTypes)
+    variant: PropTypes.oneOf(variantTypes),
+    /**
+     * Specifies if the value provided is wrong
+     */
+    error: PropTypes.bool
   };
 
   static defaultProps = {
@@ -164,6 +168,7 @@ export default class Dropdown extends Component {
       onBlur,
       onFocus,
       variant,
+      error,
       ...otherProps
     } = this.props;
 
@@ -176,6 +181,7 @@ export default class Dropdown extends Component {
 
     const inputProps = getInputProps({
       id,
+      error,
       placeholder,
       disabled,
       isOpen,
@@ -265,6 +271,7 @@ export default class Dropdown extends Component {
       required,
       value,
       variant,
+      error,
       ...otherProps
     } = this.props;
 

--- a/packages/dropdown/src/__stories__/getKnobs.js
+++ b/packages/dropdown/src/__stories__/getKnobs.js
@@ -11,6 +11,7 @@ const knobLabels = {
   variant: "Variant",
   placeholder: "Placeholder",
   disabled: "Disabled",
+  error: "Error",
   required: "Required",
   multiple: "Multiple",
   onBlur: "onBlur",
@@ -30,6 +31,7 @@ export default function getKnobs(props) {
   const {
     placeholder = "",
     disabled = false,
+    error = false,
     required = "",
     multiple = false,
     options = [],
@@ -54,6 +56,7 @@ export default function getKnobs(props) {
     value: controlledObject(knobLabels.value, value, knobGroupIds.advanced),
     placeholder: text(knobLabels.placeholder, placeholder, knobGroupIds.basic),
     disabled: boolean(knobLabels.disabled, disabled, knobGroupIds.basic),
+    error: boolean(knobLabels.error, error, knobGroupIds.basic),
     required: text(knobLabels.required, required, knobGroupIds.basic),
     multiple: boolean(knobLabels.multiple, multiple, knobGroupIds.basic),
     onBlur: action(knobLabels.onBlur),


### PR DESCRIPTION
After `Input` got the `error` prop, enable passing this prop from `Dropdown` to its inside `Input` component. Resolves the issue in https://github.com/Autodesk/hig/issues/2019