### PR TITLE
docs: Update theme data readme json section

### DIFF
--- a/packages/theme-data/README.md
+++ b/packages/theme-data/README.md
@@ -51,7 +51,7 @@ console.log(lightGrayMediumDensityTheme);
 
 ### Access theme data as JSON
 ```js
-import lightGrayMediumDensityTheme from '@hig/theme-data/build/json/lightGrayMediumDensityTheme/resolvedRoles.json';
+import lightGrayMediumDensityTheme from '@hig/theme-data/build/json/lightGrayMediumDensityTheme/theme.json';
 
 console.log(lightGrayMediumDensityTheme);
 // {


### PR DESCRIPTION
Updating the read me for theme data to use the theme.json file rather than the resolvedRoles.json which doesn't contain both the meta data and the styles.

This would fix github issue #2048 (filed by me)

