### PR TITLE
feat: allow for disabled options

### DIFF
--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -30,3 +30,54 @@ import Dropdown from "@hig/dropdown";
 ## Custom CSS
 
 Use the `className` prop to pass in a css class name to the outermost container of the component. The class name will also pass down to most of the other styled elements within the component.
+
+## Using [render props][] for additional customization
+
+[render props]: https://reactjs.org/docs/render-props.html
+
+#### Render Option
+
+When a function is provided to `props.renderOption`, it will be given a payload containing:
+
+* `option {object || string}`
+    - the string or object from `props.options`
+* `props {object}`
+    - object that can be used as `props` to retain some of the `Dropdown` functionality in the custom rendered menu option. It contains the following properties:
+      - `aria-selected {boolean}` 
+      - `disabled {boolean}`
+      - `highlighted {boolean}`
+      - `id {string}`
+      - `key {string}` 
+      - `onClick {function(MouseEvent)}`
+      - `onMouseDown {function(MouseEvent)}`
+      - `onMouseMove {function(MouseEvent)}`
+      - `role {string}`
+      - `selected {boolean}`
+
+```jsx
+<Dropdown
+  placeholder="Select a theme",
+  options={[
+    {item: "HIG Light Theme", disabled: true}, 
+    {item: "HIG Dark Blue Theme"}, 
+    {item: "Matrix Theme"}
+  ]}
+  renderOption={(option, props) => {
+    return(
+      <div
+        aria-selected={props["aria-selected"]}
+        id={props.id}
+        onClick={props.onClick}
+        onMouseDown={props.onMouseDown}
+        onMouseMove={props.onMouseMove}
+        disabled={props.disabled}
+        selected={props.selected}
+        role={props.role}
+        key={props.key}
+      >
+        <strong>{option.item}</strong>
+      </div>
+    );
+  }}
+/>
+```

--- a/packages/dropdown/src/Dropdown.js
+++ b/packages/dropdown/src/Dropdown.js
@@ -56,6 +56,8 @@ export default class Dropdown extends Component {
     onFocus: PropTypes.func,
     /**
      * An array of unique values of any type except `undefined`
+     * If you use an array of objects, the object must contain the property `item`,
+     * the option's disabled state can be controlled with a `disabled` property.
      */
     options: PropTypes.arrayOf(PropTypes.any),
     /**
@@ -67,6 +69,10 @@ export default class Dropdown extends Component {
      * option is passed as an argument. If any option has Option.render
      * prop present, that will take precedence and this
      * function will not be called for that option.
+     *
+     * In  addition to the option passed as an argument, props
+     * are also passed in that can be used for each option to help
+     * maintain some of the built-in `Dropdown` option functionality.
      *
      * Similarly if both formatOption and renderOption are provided,
      * renderOption will take precedence
@@ -276,7 +282,8 @@ export default class Dropdown extends Component {
     } = this.props;
 
     /**
-     * The `Wrapper` presenter is used as a function to avoid having to use Downshift's `getRootProps`
+     * The `Wrapper` presenter is used as a function to avoid having to
+     * use Downshift's `getRootProps`
      * @see https://github.com/paypal/downshift#getrootprops
      */
     return renderWrapper({

--- a/packages/dropdown/src/__snapshots__/Dropdown.test.js.snap
+++ b/packages/dropdown/src/__snapshots__/Dropdown.test.js.snap
@@ -255,6 +255,7 @@ exports[`Dropdown renders non-undefined values as options 1`] = `
     <div
       aria-selected={false}
       className="emotion-5"
+      disabled={false}
       id="downshift-2-item-0"
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -270,6 +271,7 @@ exports[`Dropdown renders non-undefined values as options 1`] = `
     <div
       aria-selected={false}
       className="emotion-5"
+      disabled={false}
       id="downshift-2-item-1"
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -285,6 +287,7 @@ exports[`Dropdown renders non-undefined values as options 1`] = `
     <div
       aria-selected={false}
       className="emotion-5"
+      disabled={false}
       id="downshift-2-item-2"
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -300,6 +303,7 @@ exports[`Dropdown renders non-undefined values as options 1`] = `
     <div
       aria-selected={false}
       className="emotion-5"
+      disabled={false}
       id="downshift-2-item-3"
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -315,6 +319,7 @@ exports[`Dropdown renders non-undefined values as options 1`] = `
     <div
       aria-selected={true}
       className="emotion-10"
+      disabled={false}
       id="downshift-2-item-4"
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -347,6 +352,7 @@ exports[`Dropdown renders non-undefined values as options 1`] = `
     <div
       aria-selected={false}
       className="emotion-5"
+      disabled={false}
       id="downshift-2-item-5"
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -362,6 +368,7 @@ exports[`Dropdown renders non-undefined values as options 1`] = `
     <div
       aria-selected={false}
       className="emotion-5"
+      disabled={false}
       id="downshift-2-item-6"
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -377,6 +384,7 @@ exports[`Dropdown renders non-undefined values as options 1`] = `
     <div
       aria-selected={false}
       className="emotion-5"
+      disabled={false}
       id="downshift-2-item-7"
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -648,6 +656,7 @@ exports[`Dropdown renders with a controlled value 1`] = `
     <div
       aria-selected={false}
       className="emotion-5"
+      disabled={false}
       id="downshift-9-item-0"
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -663,6 +672,7 @@ exports[`Dropdown renders with a controlled value 1`] = `
     <div
       aria-selected={false}
       className="emotion-5"
+      disabled={false}
       id="downshift-9-item-1"
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -678,6 +688,7 @@ exports[`Dropdown renders with a controlled value 1`] = `
     <div
       aria-selected={true}
       className="emotion-8"
+      disabled={false}
       id="downshift-9-item-2"
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -1311,6 +1322,7 @@ exports[`Dropdown renders with custom option formatting 1`] = `
     <div
       aria-selected={false}
       className="emotion-5"
+      disabled={false}
       id="downshift-1-item-0"
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -1326,6 +1338,7 @@ exports[`Dropdown renders with custom option formatting 1`] = `
     <div
       aria-selected={false}
       className="emotion-5"
+      disabled={false}
       id="downshift-1-item-1"
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -1341,6 +1354,7 @@ exports[`Dropdown renders with custom option formatting 1`] = `
     <div
       aria-selected={false}
       className="emotion-5"
+      disabled={false}
       id="downshift-1-item-2"
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -1822,6 +1836,7 @@ exports[`Dropdown renders with default value 1`] = `
     <div
       aria-selected={false}
       className="emotion-5"
+      disabled={false}
       id="downshift-7-item-0"
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -1837,6 +1852,7 @@ exports[`Dropdown renders with default value 1`] = `
     <div
       aria-selected={false}
       className="emotion-5"
+      disabled={false}
       id="downshift-7-item-1"
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -1852,6 +1868,7 @@ exports[`Dropdown renders with default value 1`] = `
     <div
       aria-selected={true}
       className="emotion-8"
+      disabled={false}
       id="downshift-7-item-2"
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -2103,6 +2120,7 @@ exports[`Dropdown renders with multiple selection 1`] = `
     <div
       aria-selected={false}
       className="emotion-5"
+      disabled={false}
       id="downshift-8-item-0"
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -2118,6 +2136,7 @@ exports[`Dropdown renders with multiple selection 1`] = `
     <div
       aria-selected={false}
       className="emotion-5"
+      disabled={false}
       id="downshift-8-item-1"
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -2133,6 +2152,7 @@ exports[`Dropdown renders with multiple selection 1`] = `
     <div
       aria-selected={false}
       className="emotion-5"
+      disabled={false}
       id="downshift-8-item-2"
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -2404,6 +2424,7 @@ exports[`Dropdown renders with multiple selection and a controlled value 1`] = `
     <div
       aria-selected={true}
       className="emotion-6"
+      disabled={false}
       id="downshift-10-item-0"
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -2436,6 +2457,7 @@ exports[`Dropdown renders with multiple selection and a controlled value 1`] = `
     <div
       aria-selected={false}
       className="emotion-7"
+      disabled={false}
       id="downshift-10-item-1"
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -2451,6 +2473,7 @@ exports[`Dropdown renders with multiple selection and a controlled value 1`] = `
     <div
       aria-selected={true}
       className="emotion-6"
+      disabled={false}
       id="downshift-10-item-2"
       onClick={[Function]}
       onKeyDown={[Function]}

--- a/packages/dropdown/src/__stories__/getKnobs.js
+++ b/packages/dropdown/src/__stories__/getKnobs.js
@@ -16,7 +16,6 @@ const knobLabels = {
   multiple: "Multiple",
   onBlur: "onBlur",
   onChange: "onChange",
-  onClickOutside: "onClickOutside",
   onFocus: "onFocus",
   options: "Options",
   value: "Value"
@@ -61,7 +60,6 @@ export default function getKnobs(props) {
     multiple: boolean(knobLabels.multiple, multiple, knobGroupIds.basic),
     onBlur: action(knobLabels.onBlur),
     onChange: action(knobLabels.onChange),
-    onClickOutside: action(knobLabels.onClickOutside),
     onFocus: action(knobLabels.onFocus),
     options: object(knobLabels.options, options, knobGroupIds.basic)
   };

--- a/packages/dropdown/src/presenters/OptionPresenter.js
+++ b/packages/dropdown/src/presenters/OptionPresenter.js
@@ -9,6 +9,7 @@ import stylesheet from "./OptionPresenter.stylesheet";
 function OptionWrapper(props) {
   const {
     children,
+    disabled,
     id,
     onClick,
     onMouseDown,
@@ -25,8 +26,12 @@ function OptionWrapper(props) {
         <div
           aria-selected={selected}
           className={css(
-            stylesheet({ selected, highlighted, ...props }, resolvedRoles)
+            stylesheet(
+              { disabled, selected, highlighted, ...props },
+              resolvedRoles
+            )
           )}
+          disabled={disabled}
           id={id}
           onClick={handleClick}
           onKeyDown={handleKeyDown}
@@ -44,6 +49,7 @@ function OptionWrapper(props) {
 
 OptionWrapper.propTypes = {
   children: PropTypes.node,
+  disabled: PropTypes.bool,
   highlighted: PropTypes.bool,
   id: PropTypes.string,
   onClick: PropTypes.func,
@@ -59,7 +65,8 @@ export default class OptionPresenter extends Component {
      */
     children: PropTypes.node,
     /**
-     * Indicates the option is currently highlighted. This is comparable to hover state, but useful when interacting by keyboard.
+     * Indicates the option is currently highlighted.
+     * This is comparable to hover state, but useful when interacting by keyboard.
      */
     highlighted: PropTypes.bool,
     /**

--- a/packages/dropdown/src/presenters/OptionPresenter.stylesheet.js
+++ b/packages/dropdown/src/presenters/OptionPresenter.stylesheet.js
@@ -17,11 +17,14 @@ export default function stylesheet(props, themeData) {
     fontSize: themeData[`typography.body.fontSize`],
     lineHeight: themeData[`typography.body.lineHeight`],
     backgroundColor: "transparent",
-    ...(props.highlighted
+    ...(props.highlighted && !props.disabled
       ? { backgroundColor: themeData["menu.item.hover.backgroundColor"] }
       : null),
     ...(props.selected
       ? { backgroundColor: themeData["menu.item.focus.backgroundColor"] }
+      : null),
+    ...(props.disabled
+      ? { opacity: themeData["component.disabled.opacity"] }
       : null)
   };
 }

--- a/packages/dropdown/src/presenters/__snapshots__/OptionPresenter.test.js.snap
+++ b/packages/dropdown/src/presenters/__snapshots__/OptionPresenter.test.js.snap
@@ -41,6 +41,7 @@ exports[`Dropdown/presenters/OptionPresenter renders with all props 1`] = `
 <div
   aria-selected={true}
   className="emotion-1"
+  disabled={undefined}
   id={undefined}
   onClick={[Function]}
   onKeyDown={[Function]}
@@ -105,6 +106,7 @@ exports[`Dropdown/presenters/OptionPresenter renders without props 1`] = `
 <div
   aria-selected={undefined}
   className="emotion-0"
+  disabled={undefined}
   id={undefined}
   onClick={undefined}
   onKeyDown={undefined}

--- a/packages/dropdown/src/presenters/renderOptions.js
+++ b/packages/dropdown/src/presenters/renderOptions.js
@@ -29,22 +29,25 @@ function createOptionRenderer(downshift, renderOption) {
   const isSelected = createSelectedDeterminer(downshift);
 
   return (option, index) => {
+    const itemProps = getItemProps({
+      index,
+      key: `option-${index}`,
+      item: option && option.item ? option.item : option,
+      disabled: option && option.disabled ? option.disabled : false,
+      selected: isSelected(option),
+      highlighted: highlightedIndex === index
+    });
     let result;
     if (option && option.render !== undefined) {
-      result = option.render(option);
+      result = option.render(option, itemProps);
     } else if (renderOption !== undefined) {
-      result = renderOption(option);
+      result = renderOption(option, itemProps);
     } else {
-      const itemProps = getItemProps({
-        index,
-        key: `option-${index}`,
-        item: option,
-        selected: isSelected(option),
-        highlighted: highlightedIndex === index
-      });
-
+      const optionLabel = option && option.item ? option.item : option;
       result = (
-        <OptionPresenter {...itemProps}>{formatOption(option)}</OptionPresenter>
+        <OptionPresenter {...itemProps}>
+          {formatOption(optionLabel)}
+        </OptionPresenter>
       );
     }
     return result;


### PR DESCRIPTION
*  allow custom rendered options using the renderOption prop to have some of the built in dropdown/option functionality by passing in itemProps to the function

Resolves: https://github.com/Autodesk/hig/issues/2062
Resolves: https://github.com/Autodesk/hig/issues/2061