### PR TITLE
fix: tab with zero index not trigger to active in Tabs

### DIFF
--- a/packages/tabs/src/Tabs.js
+++ b/packages/tabs/src/Tabs.js
@@ -136,7 +136,7 @@ class Tabs extends Component {
 
     const nextTabs = createTabs(children);
     const nextActiveTabIndex = nextTabs.findIndex(({ props }) => props.active);
-    if (nextActiveTabIndex > 0 && nextActiveTabIndex !== prevActiveTabIndex) {
+    if (nextActiveTabIndex >= 0 && nextActiveTabIndex !== prevActiveTabIndex) {
       newState.activeTabIndex = nextActiveTabIndex;
       hasStateChanged = true;
     }


### PR DESCRIPTION
fix https://github.com/Autodesk/hig/issues/2064 