### PR TITLE
docs: add CLI shortcut to storybook in watch mode

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -67,6 +67,15 @@ yarn
 yarn build
 ```
 
+## Watch mode
+
+To recompile/reload browser automatically on every changes
+
+```bash
+yarn start
+```
+Go to http://localhost:9001/
+
 ## Project structure
 
 ### Monorepo

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "version": "1.0.1",
   "scripts": {
     "build": "lerna run build --stream",
+    "start": "cd packages/storybook && yarn storybook",
     "create-dependency-hash": "cat yarn.lock > .dependency-hash && ls ./packages >> .dependency-hash",
     "lint": "lerna run lint --stream",
     "test": "jest --watch",


### PR DESCRIPTION
- Add a new shortcut to launch Storybook in dev mode.
- Add a documentation to make the onboarding of a future developer easier.