### PR TITLE
fix: Title hover for HelpAction being returned to the correct version…

### DIFF
--- a/packages/top-nav/src/HelpAction.js
+++ b/packages/top-nav/src/HelpAction.js
@@ -57,7 +57,7 @@ export default class HelpAction extends Component {
     return (
       <ThemeContext.Consumer>
         {({ metadata }) => {
-          const title = "View Help";
+          const title = "View help";
           const HelpIcon =
             metadata.densityId === "high-density" ? Help16 : Help24;
           return (


### PR DESCRIPTION
… of View help

Accidental change of HelpAcion title to be View Help instead of View help after refactor. Title updated to have the correct casing.

No breaking changes