### PR TITLE
docs: fix @hig/icons SVG source file path in docs

### DIFF
--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -41,4 +41,4 @@ This will use SVGO to optimize the new icon, and update our release files. Remem
 
 ## Accessing SVG source files
 
-SVG source files for all icons are available in the `/svg` subdirectory of the `@hig/icons` package (e.g. `./node_modules/@hig/icons/svg`).
+SVG source files for all icons are available in the `build/svg` subdirectory of the `@hig/icons` package (e.g. `./node_modules/@hig/icons/build/svg`).


### PR DESCRIPTION
👋 Hello! Found a typo in the docs for the @hig/icons package.