### PR TITLE
Function initialsFromName() can't handle some non-English names properly

### DIFF
--- a/packages/avatar/src/Avatar.js
+++ b/packages/avatar/src/Avatar.js
@@ -39,9 +39,17 @@ function backgroundIdFromName(name) {
  * @returns {string}
  */
 function initialsFromName(name) {
-  const initials = name.match(/\b\w/g) || [];
-
-  return ((initials.shift() || "") + (initials.pop() || "")).toUpperCase();
+	const temp = name.match(/(?<=[-\s,.:;"'_]|^)\p{L}/gu) || [];
+	const initials = ((temp.shift() || "") + (temp.pop() || "")).toUpperCase();
+	if (initials.length == 2) {
+		if (initials[0].match(/\p{sc=Han}/gu)) {
+			return initials[0];
+		}
+		if (initials[1].match(/\p{sc=Han}/gu)) {
+			return initials[1];
+		}
+	}
+	return initials;
 }
 
 /**


### PR DESCRIPTION
The original function initialsFromName() can't handle some non-English names properly, here are some examples: "Λεωνίδας ωή", "Иван Виктор", and "安倍晋三".
Note: if initials contain any Asian full-width character, it should only return 1 character because 1 full-width character equals 2 English alphabets.