### PR TITLE
Function initialsFromName() can't handle some non-English names properly

### DIFF
--- a/packages/avatar/src/Avatar.js
+++ b/packages/avatar/src/Avatar.js
@@ -39,9 +39,16 @@ function backgroundIdFromName(name) {
  * @returns {string}
  */
 function initialsFromName(name) {
-  const initials = name.match(/\b\w/g) || [];
-
-  return ((initials.shift() || "") + (initials.pop() || "")).toUpperCase();
+  const temp = name.match(/(?<=[-\s,.:;"'_]|^)\p{L}/gu) || [];
+  const initials = ((temp.shift() || "") + (temp.pop() || "")).toUpperCase();
+  if (initials.length === 2) {
+    for (let i = 0; i < 2; i++) {
+      if (initials[i].match(/\p{sc=Han}/gu)) {
+        return initials[i];
+      }
+    }
+  }
+  return initials;
 }
 
 /**


### PR DESCRIPTION
Fix the problem that function initialsFromName() can't handle some non-English names properly, for example: "Λεωνίδας ωή", "Иван Виктор" and "安倍晋三".
Note: If initials contain any Asian full-width characters, it should return only 1 full-width character, because the width of 1 full-width character equals 2 alphabets.