### PR TITLE
Function initialsFromName() can't handle some non-English names properly

### DIFF
--- a/packages/avatar/src/Avatar.js
+++ b/packages/avatar/src/Avatar.js
@@ -39,8 +39,15 @@ function backgroundIdFromName(name) {
  * @returns {string}
  */
 function initialsFromName(name) {
-  const initials = name.match(/\b\w/g) || [];
-
+  const results = name.matchAll(/([-\s,.:;"'_]|^)(?<FirstChar>\p{L})/gu);
+  let initials = [];
+  for (let result of results) {
+    // Return initial if it is a Chinese or Japanese character
+    if (result.groups.FirstChar.match(/\p{sc=Han}/gu)) {
+      return result.groups.FirstChar;
+    }
+    initials.push(result.groups.FirstChar);
+  }
   return ((initials.shift() || "") + (initials.pop() || "")).toUpperCase();
 }
 


### PR DESCRIPTION
Fix the problem that function initialsFromName() can't handle some non-English names properly, for example: "Λεωνίδας ωή", "Иван Виктор" and "安倍晋三".
Note: If initials contain any Asian full-width characters, it should return only 1 full-width character, because the width of 1 full-width character equals 2 alphabets.