### PR TITLE
fix: function initialsFromName() can't handle some non-English names properly

### DIFF
--- a/packages/avatar/src/Avatar.js
+++ b/packages/avatar/src/Avatar.js
@@ -39,8 +39,7 @@ function backgroundIdFromName(name) {
  * @returns {string}
  */
 function initialsFromName(name) {
-  const initials = name.match(/\b\w/g) || [];
-
+  const initials = name.match(/(?<=[-\s._'",;]|^)[^-\s._'",;]/g) || [];
   return ((initials.shift() || "") + (initials.pop() || "")).toUpperCase();
 }
 


### PR DESCRIPTION
Fix the problem that function initialsFromName() can't handle some non-English names properly, for example: "Λεωνίδας ωή", "Иван Виктор" and "安倍晋三".