### PR TITLE
fix: ProjectAccountSwitcher does not accept non-English labels

### DIFF
--- a/packages/project-account-switcher/src/presenters/constructPlaceholder.js
+++ b/packages/project-account-switcher/src/presenters/constructPlaceholder.js
@@ -1,3 +1,3 @@
 export default function constructPlaceholder(label) {
-  return label.match(/\b(\w)/g).join("");
+  return (label.match(/(?<=[-\s._'",;]|^)([^-\s._'",;])/g) || []).join("");
 }


### PR DESCRIPTION
Fix issue #2332: ProjectAccountSwitcher does not accept non-English labels.
https://github.com/Autodesk/hig/issues/2332