### PR TITLE
feat: Update avatar props and background color calculation

### DIFF
--- a/packages/avatar/src/Avatar.test.js
+++ b/packages/avatar/src/Avatar.test.js
@@ -42,11 +42,186 @@ describe("avatar/Avatar", () => {
     }
   ]);
 
+  describe("Creating initials from name", () => {
+    const singleStringNames = [
+      { name: "John Snow", expectedInitials: "JS" },
+      { name: "maria bamford", expectedInitials: "MB" },
+      { name: "JustOneName", expectedInitials: "J" },
+      { name: "Λεωνίδας ωή", expectedInitials: "ΛΩ" },
+      { name: "Иван Виктор", expectedInitials: "ИВ" },
+      { name: "安倍晋三", expectedInitials: "安" },
+      { name: "Yu Jye Foo", expectedInitials: "YF" },
+      { name: "Song Hye-gyo", expectedInitials: "SH" },
+      { name: "송혜교", expectedInitials: "송" },
+      { name: "高橋 留美子", expectedInitials: "高留" },
+      { name: "W--first W--last", expectedInitials: "WW" }
+    ];
+
+    singleStringNames.forEach(nameData => {
+      it(`renders initials based on the single string name "${
+        nameData.name
+      }"`, () => {
+        const wrapper = mount(<Avatar name={nameData.name} />);
+
+        expect(wrapper.find("Initials")).toHaveText(nameData.expectedInitials);
+      });
+    });
+
+    const firstLastNames = [
+      { firstName: "John", lastName: "Snow", expectedInitials: "JS" },
+      {
+        firstName: "maria",
+        lastName: "bamford",
+        expectedInitials: "MB"
+      },
+      {
+        firstName: "JustOneName",
+        expectedInitials: "J"
+      },
+      {
+        firstName: "Λεωνίδας",
+        lastName: "ωή",
+        expectedInitials: "ΛΩ"
+      },
+      {
+        firstName: "Иван",
+        lastName: "Виктор",
+        expectedInitials: "ИВ"
+      },
+      {
+        lastName: "安倍晋三",
+        expectedInitials: "安"
+      },
+      {
+        firstName: "Yu Jye",
+        lastName: "Foo",
+        expectedInitials: "YF"
+      },
+      {
+        firstName: "Song",
+        lastName: "Hye-gyo",
+        expectedInitials: "SH"
+      },
+      {
+        firstName: "송혜교",
+        expectedInitials: "송"
+      },
+      {
+        firstName: "高橋",
+        lastName: "留美子",
+        expectedInitials: "高留"
+      },
+      {
+        firstName: "W--first",
+        lastName: "W--last",
+        expectedInitials: "WW"
+      }
+    ];
+
+    firstLastNames.forEach(nameData => {
+      it(`renders initials based on first and last names "${
+        nameData.firstName
+      }" "${nameData.lastName}"`, () => {
+        const wrapper = mount(
+          <Avatar firstName={nameData.firstName} lastName={nameData.lastName} />
+        );
+
+        expect(wrapper.find("Initials")).toHaveText(nameData.expectedInitials);
+      });
+    });
+  });
+
+  describe("css background colors", () => {
+    it("calculates background color based on full name", () => {
+      const wrapper = mount(<Avatar firstName="John" lastName="Snow" />);
+      expect(
+        window
+          .getComputedStyle(
+            wrapper
+              .find("span")
+              .first()
+              .getDOMNode()
+          )
+          .getPropertyValue("background-color")
+      ).toEqual("rgb(255, 149, 130)");
+
+      const wrapper2 = mount(<Avatar firstName="John" lastName="Snoz" />);
+      expect(
+        window
+          .getComputedStyle(
+            wrapper2
+              .find("span")
+              .first()
+              .getDOMNode()
+          )
+          .getPropertyValue("background-color")
+      ).toEqual("rgb(250, 162, 27)");
+    });
+  });
+
+  describe("when label prop is not provided", () => {
+    it("uses the default aria-label message", () => {
+      const wrapper = mount(<Avatar firstName="John" lastName="Snow" />);
+
+      expect(wrapper.find("span").first()).toHaveProp(
+        "aria-label",
+        "Avatar for John Snow"
+      );
+    });
+  });
+
+  describe("when label prop is provided", () => {
+    it("overrides the default aria-label message", () => {
+      const wrapper = mount(
+        <Avatar firstName="John" lastName="Snow" label="Avatar en Español" />
+      );
+
+      expect(wrapper.find("span").first()).toHaveProp(
+        "aria-label",
+        "Avatar en Español"
+      );
+    });
+  });
+
+  describe("when imageAlt prop is not provided", () => {
+    it("uses the default alt message", () => {
+      const wrapper = mount(
+        <Avatar
+          firstName="John"
+          lastName="Snow"
+          image="http://placekitten.com/g/64/64"
+        />
+      );
+
+      expect(wrapper.find("Image")).toHaveProp(
+        "alt",
+        "Avatar image of John Snow"
+      );
+    });
+  });
+
+  describe("when imageAlt prop is provided", () => {
+    it("overrides the default aria-label message", () => {
+      const wrapper = mount(
+        <Avatar
+          firstName="John"
+          lastName="Snow"
+          image="http://placekitten.com/g/64/64"
+          imageAlt="Comment dit-ons"
+        />
+      );
+
+      expect(wrapper.find("Image")).toHaveProp("alt", "Comment dit-ons");
+    });
+  });
+
   describe("when an image URL is not provided", () => {
     it("renders initials based on the provided name", () => {
-      const wrapper = mount(<Avatar name="Jon Snow" size={sizes.LARGE_48} />);
+      const wrapper = mount(
+        <Avatar firstName="John" lastName="Snow" size={sizes.LARGE_48} />
+      );
 
-      expect(wrapper.find("Initials")).toIncludeText("JS");
+      expect(wrapper.find("Initials")).toHaveText("JS");
     });
   });
 
@@ -55,7 +230,8 @@ describe("avatar/Avatar", () => {
       it("doesn't render the image", () => {
         const wrapper = mount(
           <Avatar
-            name="Jon Snow"
+            firstName="John"
+            lastName="Snow"
             image="http://placekitten.com/g/64/64"
             size={sizes.LARGE_48}
           />

--- a/packages/avatar/src/__snapshots__/Avatar.test.js.snap
+++ b/packages/avatar/src/__snapshots__/Avatar.test.js.snap
@@ -8,7 +8,7 @@ exports[`avatar/Avatar renders with a name 1`] = `
 }
 
 .emotion-1 {
-  background-color: #507b16;
+  background-color: #7993b0;
   color: #ffffff;
   width: 32px;
   height: 32px;
@@ -38,7 +38,7 @@ exports[`avatar/Avatar renders with a name 1`] = `
 
 exports[`avatar/Avatar renders with all props 1`] = `
 .emotion-3 {
-  background-color: #507b16;
+  background-color: #7993b0;
   color: #ffffff;
   width: 48px;
   height: 48px;
@@ -100,7 +100,7 @@ exports[`avatar/Avatar renders with all props 1`] = `
 
 exports[`avatar/Avatar renders with an image 1`] = `
 .emotion-3 {
-  background-color: #6ac0e7;
+  background-color: #5bc9bd;
   color: #3c3c3c;
   width: 32px;
   height: 32px;
@@ -162,7 +162,7 @@ exports[`avatar/Avatar renders with an image 1`] = `
 
 exports[`avatar/Avatar renders with className prop 1`] = `
 .emotion-3 {
-  background-color: #507b16;
+  background-color: #7993b0;
   color: #ffffff;
   width: 48px;
   height: 48px;
@@ -224,7 +224,7 @@ exports[`avatar/Avatar renders with className prop 1`] = `
 
 exports[`avatar/Avatar renders without props 1`] = `
 .emotion-1 {
-  background-color: #6ac0e7;
+  background-color: #5bc9bd;
   color: #3c3c3c;
   width: 32px;
   height: 32px;

--- a/packages/avatar/src/__stories__/getKnobs.js
+++ b/packages/avatar/src/__stories__/getKnobs.js
@@ -11,18 +11,22 @@ const knobGroupIds = {
 };
 
 const knobLabels = {
-  name: "Name",
+  name: "Full Name",
+  firstName: "First Name",
+  lastName: "Last Name",
   size: "Size",
   image: "Image",
   onImageError: "onImageError"
 };
 
 export default function getKnobs(props) {
-  const { name, size, image, ...otherProps } = props;
+  const { name, firstName, lastName, size, image, ...otherProps } = props;
 
   return {
     ...otherProps,
     name: text(knobLabels.name, name, knobGroupIds.basic),
+    firstName: text(knobLabels.firstName, firstName, knobGroupIds.basic),
+    lastName: text(knobLabels.lastName, lastName, knobGroupIds.basic),
     size: select(knobLabels.size, sizeOptions, size, knobGroupIds.basic),
     image: text(knobLabels.image, image, knobGroupIds.basic),
     onImageError: action(knobLabels.onImageError)

--- a/packages/avatar/src/__stories__/stories.js
+++ b/packages/avatar/src/__stories__/stories.js
@@ -5,14 +5,18 @@ export default [
   {
     description: "default",
     getProps: () => ({
-      name: "Maria McCaplin",
+      name: "Maria Smith",
+      firstName: "",
+      lastName: "",
       size: sizes.LARGE_48
     })
   },
   {
     description: "with picture",
     getProps: () => ({
-      name: "Maria McCaplin",
+      name: "",
+      firstName: "Jonas",
+      lastName: "James",
       image: avatarImagePath,
       size: sizes.LARGE_48
     })

--- a/packages/profile-flyout/src/__snapshots__/ProfileFlyout.test.js.snap
+++ b/packages/profile-flyout/src/__snapshots__/ProfileFlyout.test.js.snap
@@ -90,7 +90,7 @@ exports[`profile-flyout/ProfileFlyout renders with all props 1`] = `
 }
 
 .emotion-1 {
-  background-color: #6ac0e7;
+  background-color: #5bc9bd;
   color: #3c3c3c;
   width: 32px;
   height: 32px;
@@ -276,7 +276,7 @@ exports[`profile-flyout/ProfileFlyout renders with no props 1`] = `
 }
 
 .emotion-1 {
-  background-color: #6ac0e7;
+  background-color: #5bc9bd;
   color: #3c3c3c;
   width: 32px;
   height: 32px;

--- a/packages/profile-flyout/src/presenters/__snapshots__/ProfileButtonPresenter.test.js.snap
+++ b/packages/profile-flyout/src/presenters/__snapshots__/ProfileButtonPresenter.test.js.snap
@@ -95,15 +95,9 @@ exports[`profile-flyout/presenters/ProfileButtonPresenter  2`] = `
   cursor: pointer;
 }
 
-.emotion-2 {
-  width: 32px;
-  height: 32px;
-  font-family: ArtifaktElement,sans-serif;
-}
-
 .emotion-3 {
-  background-color: #7993b0;
-  color: #ffffff;
+  background-color: #5bc9bd;
+  color: #3c3c3c;
   width: 32px;
   height: 32px;
   line-height: 32px;
@@ -114,6 +108,12 @@ exports[`profile-flyout/presenters/ProfileButtonPresenter  2`] = `
   overflow: hidden;
   border-radius: 50%;
   text-align: center;
+}
+
+.emotion-2 {
+  width: 32px;
+  height: 32px;
+  font-family: ArtifaktElement,sans-serif;
 }
 
 .emotion-1 {

--- a/packages/top-nav/src/presenters/__snapshots__/ProfileButtonPresenter.test.js.snap
+++ b/packages/top-nav/src/presenters/__snapshots__/ProfileButtonPresenter.test.js.snap
@@ -42,15 +42,9 @@ exports[`top-nav/presenters/ProfileButtonPresenter  1`] = `
 `;
 
 exports[`top-nav/presenters/ProfileButtonPresenter  2`] = `
-.emotion-0 {
-  width: 32px;
-  height: 32px;
-  font-family: ArtifaktElement,sans-serif;
-}
-
 .emotion-1 {
-  background-color: #507b16;
-  color: #ffffff;
+  background-color: #5bc9bd;
+  color: #3c3c3c;
   width: 32px;
   height: 32px;
   line-height: 32px;
@@ -61,6 +55,12 @@ exports[`top-nav/presenters/ProfileButtonPresenter  2`] = `
   overflow: hidden;
   border-radius: 50%;
   text-align: center;
+}
+
+.emotion-0 {
+  width: 32px;
+  height: 32px;
+  font-family: ArtifaktElement,sans-serif;
 }
 
 <button
@@ -83,15 +83,9 @@ exports[`top-nav/presenters/ProfileButtonPresenter  2`] = `
 `;
 
 exports[`top-nav/presenters/ProfileButtonPresenter  3`] = `
-.emotion-2 {
-  width: 32px;
-  height: 32px;
-  font-family: ArtifaktElement,sans-serif;
-}
-
 .emotion-3 {
-  background-color: #7993b0;
-  color: #ffffff;
+  background-color: #5bc9bd;
+  color: #3c3c3c;
   width: 32px;
   height: 32px;
   line-height: 32px;
@@ -102,6 +96,12 @@ exports[`top-nav/presenters/ProfileButtonPresenter  3`] = `
   overflow: hidden;
   border-radius: 50%;
   text-align: center;
+}
+
+.emotion-2 {
+  width: 32px;
+  height: 32px;
+  font-family: ArtifaktElement,sans-serif;
 }
 
 .emotion-1 {


### PR DESCRIPTION
Makes several updates to the Avatar component:
 - Adds new optional props: firstName and lastName. This gives devs the option to pass in the first and last names of the user separately, which helps avoid errors due to parsing a full name. For example, for the name "Yu Jye Foo", the name can be passed in properly separated, so that the Avatar does not need to guess about where the first name ends and the last name begins.
 - Generates initials from name, regardless of the characters in the name. The current Avatar tends to skip non-Roman alphabet characters when building initials. This means that users with non-English names will not see the correct initials, sometimes no initials are shown.
 - Background color is generated regardless of characters in the name. The current Avatar calculates the background color assuming that only Roman alphabet characters will be used, which means that users with non-English names will all have the same default background color. This change uses modulo to generate a number between 1 and 7 (inclusive), no matter what characters are in use.
 - Background color is generated based on full name. The current Avatar calculates the background color using only the first letter in the first name as a reference. This means that users with the same initials will always have the same background color. This update uses the user's full name to calculate background color, meaning that the chance of users with the same initials having the same background color is only 1 in 7.
 - Adds new optional props: label and imageAlt - there will overwrite the Avatar label and the image's alt text if provided. This way localized strings can be used.

Some examples of the updated Avatar component in storybook:
![Screen Shot 2020-11-17 at 2 56 19 PM](https://user-images.githubusercontent.com/3441699/99470786-2e615d80-28fa-11eb-9a79-e59b4b69344d.png)
![Screen Shot 2020-11-17 at 2 52 47 PM](https://user-images.githubusercontent.com/3441699/99470792-328d7b00-28fa-11eb-9318-68221adfdf0a.png)
![Screen Shot 2020-11-17 at 2 52 11 PM](https://user-images.githubusercontent.com/3441699/99470808-391bf280-28fa-11eb-984a-02ec01329471.png)
![Screen Shot 2020-11-17 at 2 59 10 PM](https://user-images.githubusercontent.com/3441699/99470834-45a04b00-28fa-11eb-80f8-fab8ce9d6e8c.png)
