### PR TITLE
feat: adds discrete slider

### DIFF
--- a/packages/slider/src/Slider.js
+++ b/packages/slider/src/Slider.js
@@ -4,6 +4,7 @@ import { css } from "emotion";
 import { ControlBehavior } from "@hig/behaviors";
 
 import SliderPresenter from "./presenters/SliderPresenter";
+import { AVAILABLE_SLIDER_TYPES } from "./constants";
 
 /**
  * @typedef {string|number} Value
@@ -79,11 +80,16 @@ export default class Slider extends Component {
     /**
      * Value of the field
      */
-    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    /**
+     * Type of the slider
+     */
+    variant: PropTypes.oneOf(AVAILABLE_SLIDER_TYPES)
   };
 
   static defaultProps = {
     disabled: false,
+    variant: "continuous",
     max: "100",
     min: "0",
     step: "1"

--- a/packages/slider/src/Slider.test.js
+++ b/packages/slider/src/Slider.test.js
@@ -2,6 +2,7 @@ import React from "react";
 import { takeSnapshotsOf } from "@hig/jest-preset/helpers";
 import { mount } from "enzyme";
 import Slider from "./index";
+import SliderPresenter from "./presenters/SliderPresenter";
 
 describe("slider/Slider", () => {
   takeSnapshotsOf(Slider, [{ desc: "renders", props: {} }]);
@@ -53,6 +54,20 @@ describe("slider/Slider", () => {
       expect(input.prop("value")).toEqual("10");
       wrapper.setProps({ value: "20" });
       expect(input.prop("value")).toEqual("20");
+    });
+  });
+
+  describe("slider variant", () => {
+    it("default variant is continuous", () => {
+      const wrapper = mount(<Slider value="10" />);
+      const presenter = wrapper.find(SliderPresenter);
+      expect(presenter.props().variant).toEqual("continuous");
+    });
+
+    it("specify discrete variant", () => {
+      const wrapper = mount(<Slider variant="discrete" />);
+      const presenter = wrapper.find(SliderPresenter);
+      expect(presenter.props().variant).toEqual("discrete");
     });
   });
 });

--- a/packages/slider/src/__stories__/getKnobs.js
+++ b/packages/slider/src/__stories__/getKnobs.js
@@ -1,6 +1,10 @@
 import { action } from "@storybook/addon-actions";
-import { boolean, number, text } from "@storybook/addon-knobs/react";
-import { controlledText } from "@hig/storybook/utils";
+import { boolean, number, select, text } from "@storybook/addon-knobs/react";
+import { controlledText, makeSelectOptions } from "@hig/storybook/utils";
+
+import { sliderTypes } from "../constants";
+
+const typeOptions = makeSelectOptions(sliderTypes);
 
 const knobGroupIds = {
   basic: "Basic",
@@ -17,7 +21,8 @@ const knobLabels = {
   onFocus: "onFocus",
   onInput: "onInput",
   step: "Step",
-  value: "Value"
+  value: "Value",
+  variant: "Variant"
 };
 
 export default function getKnobs(props) {
@@ -28,6 +33,7 @@ export default function getKnobs(props) {
     min,
     step,
     value,
+    variant,
     ...otherProps
   } = props;
 
@@ -46,6 +52,12 @@ export default function getKnobs(props) {
     onFocus: action(knobLabels.onFocus),
     onInput: action(knobLabels.onInput),
     step: number(knobLabels.step, step, knobGroupIds.basic),
-    value: controlledText(knobLabels.value, value, knobGroupIds.form)
+    value: controlledText(knobLabels.value, value, knobGroupIds.form),
+    variant: select(
+      knobLabels.variant,
+      typeOptions,
+      variant,
+      knobGroupIds.basic
+    )
   };
 }

--- a/packages/slider/src/constants.js
+++ b/packages/slider/src/constants.js
@@ -1,0 +1,6 @@
+export const sliderTypes = Object.freeze({
+  CONTINUOUS: "continuous",
+  DISCRETE: "discrete"
+});
+
+export const AVAILABLE_SLIDER_TYPES = Object.freeze(Object.values(sliderTypes));

--- a/packages/slider/src/constants.test.js
+++ b/packages/slider/src/constants.test.js
@@ -1,0 +1,11 @@
+import * as constants from "./constants";
+
+describe("slider/constants", () => {
+  it("has an array of available types", () => {
+    expect(constants).toHavePropertyOfConstants("AVAILABLE_SLIDER_TYPES");
+  });
+
+  it("has constants for sliderTypes", () => {
+    expect(constants).toHavePropertyOfConstants("sliderTypes");
+  });
+});

--- a/packages/slider/src/index.js
+++ b/packages/slider/src/index.js
@@ -1,1 +1,2 @@
 export { default } from "./Slider";
+export * from "./constants";

--- a/packages/slider/src/index.test.js
+++ b/packages/slider/src/index.test.js
@@ -5,6 +5,14 @@ describe("slider/index", () => {
     {
       name: "default",
       value: expect.any(Function)
+    },
+    {
+      name: "sliderTypes",
+      value: expect.any(Object)
+    },
+    {
+      name: "AVAILABLE_SLIDER_TYPES",
+      value: expect.any(Array)
     }
   ].forEach(({ name, value }) => {
     it(`exports ${name}`, () => {

--- a/packages/slider/src/presenters/SliderPresenter.js
+++ b/packages/slider/src/presenters/SliderPresenter.js
@@ -2,7 +2,9 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { css } from "emotion";
 import ThemeContext from "@hig/theme-context";
+
 import stylesheet from "./stylesheet";
+import { AVAILABLE_SLIDER_TYPES, sliderTypes } from "../constants";
 
 export default class SliderPresenter extends Component {
   static propTypes = {
@@ -13,7 +15,31 @@ export default class SliderPresenter extends Component {
     max: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     min: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     step: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    variant: PropTypes.oneOf(AVAILABLE_SLIDER_TYPES)
+  };
+
+  getTickMarks = (min, max, step, styles) => {
+    const loops = step ? Math.floor((max - min) / step) : 1;
+    const tickMarks = [];
+    for (let i = 0; i < loops; i += 1) {
+      tickMarks.push(
+        <div
+          className={css(styles.markRules)}
+          style={{ left: `${(i * 100) / loops}%` }}
+          key={`mark-${i}`}
+        />
+      );
+    }
+    // adds the mark to end of slider
+    tickMarks.push(
+      <div
+        className={css(styles.markRules)}
+        style={{ right: "0%" }}
+        key={`mark-${loops}`}
+      />
+    );
+    return tickMarks;
   };
 
   render() {
@@ -25,6 +51,7 @@ export default class SliderPresenter extends Component {
       max,
       min,
       value,
+      variant,
       ...otherProps
     } = this.props;
 
@@ -40,7 +67,28 @@ export default class SliderPresenter extends Component {
             resolvedRoles
           );
 
-          return (
+          const marks =
+            variant === sliderTypes.DISCRETE
+              ? this.getTickMarks(min, max, otherProps.step, styles)
+              : null;
+
+          return marks ? (
+            <div className={css(styles.discrete)}>
+              <input
+                className={css(styles.slider)}
+                disabled={disabled}
+                type="range"
+                aria-valuemin={min}
+                aria-valuemax={max}
+                aria-valuenow={value}
+                max={max}
+                min={min}
+                value={value}
+                {...otherProps}
+              />
+              <div className={css(styles.markContainer)}>{marks}</div>
+            </div>
+          ) : (
             <input
               className={css(styles.slider)}
               disabled={disabled}

--- a/packages/slider/src/presenters/SliderPresenter.test.js
+++ b/packages/slider/src/presenters/SliderPresenter.test.js
@@ -15,4 +15,16 @@ describe("Slider/presenters/SliderPresenter", () => {
   takeSnapshotsOf(SliderPresenter, [
     { desc: "renders pressed", props: { isPressed: true } }
   ]);
+  takeSnapshotsOf(SliderPresenter, [
+    {
+      desc: "renders discrete slider",
+      props: { variant: "discrete", min: 0, max: 5, step: 1 }
+    }
+  ]);
+  takeSnapshotsOf(SliderPresenter, [
+    {
+      desc: "renders discrete slider with step 0",
+      props: { variant: "discrete", step: 0 }
+    }
+  ]);
 });

--- a/packages/slider/src/presenters/__snapshots__/SliderPresenter.test.js.snap
+++ b/packages/slider/src/presenters/__snapshots__/SliderPresenter.test.js.snap
@@ -281,6 +281,398 @@ exports[`Slider/presenters/SliderPresenter renders disabled 1`] = `
 />
 `;
 
+exports[`Slider/presenters/SliderPresenter renders discrete slider 1`] = `
+.emotion-0 {
+  -webkit-appearance: none;
+  width: 100%;
+  background-color: transparent;
+  box-sizing: content-box;
+  height: 20px;
+  margin: 0;
+  position: relative;
+  outline: none;
+}
+
+.emotion-0::-ms-tooltip {
+  display: none;
+}
+
+.emotion-0::-ms-tooltip {
+  display: none;
+}
+
+.emotion-0::-moz-focus-outer {
+  border: 0;
+}
+
+.emotion-0::-ms-thumb {
+  box-sizing: content-box;
+  height: 20px;
+  width: 6px;
+  background-color: #808080;
+  border: 0;
+  border-radius: 1px;
+  box-shadow: 0 0 0 0 rgba(255,255,255,0);
+  position: relative;
+  top: 50%;
+  -webkit-transition-duration: 0.3s;
+  transition-duration: 0.3s;
+  -webkit-transition-property: box-shadow;
+  transition-property: box-shadow;
+  -webkit-transition-timing-function: cubic-bezier(0.4,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.4,0,0.2,1);
+  -webkit-appearance: none;
+}
+
+.emotion-0::-moz-range-thumb {
+  box-sizing: content-box;
+  height: 20px;
+  width: 6px;
+  background-color: #808080;
+  border: 0;
+  border-radius: 1px;
+  box-shadow: 0 0 0 0 rgba(255,255,255,0);
+  position: relative;
+  top: 50%;
+  -webkit-transition-duration: 0.3s;
+  transition-duration: 0.3s;
+  -webkit-transition-property: box-shadow;
+  transition-property: box-shadow;
+  -webkit-transition-timing-function: cubic-bezier(0.4,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.4,0,0.2,1);
+  -webkit-appearance: none;
+}
+
+.emotion-0::-webkit-slider-thumb {
+  box-sizing: content-box;
+  height: 20px;
+  width: 6px;
+  background-color: #808080;
+  border: 0;
+  border-radius: 1px;
+  box-shadow: 0 0 0 0 rgba(255,255,255,0);
+  position: relative;
+  top: 50%;
+  -webkit-transition-duration: 0.3s;
+  transition-duration: 0.3s;
+  -webkit-transition-property: box-shadow;
+  transition-property: box-shadow;
+  -webkit-transition-timing-function: cubic-bezier(0.4,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.4,0,0.2,1);
+  -webkit-appearance: none;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+}
+
+.emotion-0::-ms-track {
+  width: 100%;
+  height: 2px;
+  border: none;
+  background-color: rgba(128,128,128,0.2);
+  color: transparent;
+  outline: none;
+}
+
+.emotion-0::-moz-range-track {
+  width: 100%;
+  height: 2px;
+  border: none;
+  background-color: rgba(128,128,128,0.2);
+  color: transparent;
+  outline: none;
+}
+
+.emotion-0::-webkit-slider-runnable-track {
+  width: 100%;
+  height: 2px;
+  border: none;
+  background-color: rgba(128,128,128,0.2);
+  color: transparent;
+  outline: none;
+  background-image: linear-gradient(#808080,#808080);
+  background-position: 0;
+  background-size: calc((0.5 * 6px)  + (NaN * (100% - 6px))) 100%;
+  background-repeat: no-repeat;
+}
+
+.emotion-0::-ms-fill-lower {
+  border: none;
+  background-color: #808080;
+}
+
+.emotion-0::-moz-range-progress {
+  border: none;
+  background-color: #808080;
+}
+
+.emotion-1 {
+  width: 1px;
+  height: 4px;
+  margin-top: -12px;
+  position: absolute;
+  background-color: #808080;
+}
+
+.emotion-8 {
+  position: relative;
+}
+
+.emotion-7 {
+  position: absolute;
+  width: 100%;
+}
+
+<div
+  className="emotion-8"
+>
+  <input
+    aria-valuemax={5}
+    aria-valuemin={0}
+    aria-valuenow={undefined}
+    className="emotion-0"
+    disabled={undefined}
+    max={5}
+    min={0}
+    step={1}
+    type="range"
+    value={undefined}
+  />
+  <div
+    className="emotion-7"
+  >
+    <div
+      className="emotion-1"
+      style={
+        Object {
+          "left": "0%",
+        }
+      }
+    />
+    <div
+      className="emotion-1"
+      style={
+        Object {
+          "left": "20%",
+        }
+      }
+    />
+    <div
+      className="emotion-1"
+      style={
+        Object {
+          "left": "40%",
+        }
+      }
+    />
+    <div
+      className="emotion-1"
+      style={
+        Object {
+          "left": "60%",
+        }
+      }
+    />
+    <div
+      className="emotion-1"
+      style={
+        Object {
+          "left": "80%",
+        }
+      }
+    />
+    <div
+      className="emotion-1"
+      style={
+        Object {
+          "left": "100%",
+        }
+      }
+    />
+  </div>
+</div>
+`;
+
+exports[`Slider/presenters/SliderPresenter renders discrete slider with step 0 1`] = `
+.emotion-0 {
+  -webkit-appearance: none;
+  width: 100%;
+  background-color: transparent;
+  box-sizing: content-box;
+  height: 20px;
+  margin: 0;
+  position: relative;
+  outline: none;
+}
+
+.emotion-0::-ms-tooltip {
+  display: none;
+}
+
+.emotion-0::-ms-tooltip {
+  display: none;
+}
+
+.emotion-0::-moz-focus-outer {
+  border: 0;
+}
+
+.emotion-0::-ms-thumb {
+  box-sizing: content-box;
+  height: 20px;
+  width: 6px;
+  background-color: #808080;
+  border: 0;
+  border-radius: 1px;
+  box-shadow: 0 0 0 0 rgba(255,255,255,0);
+  position: relative;
+  top: 50%;
+  -webkit-transition-duration: 0.3s;
+  transition-duration: 0.3s;
+  -webkit-transition-property: box-shadow;
+  transition-property: box-shadow;
+  -webkit-transition-timing-function: cubic-bezier(0.4,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.4,0,0.2,1);
+  -webkit-appearance: none;
+}
+
+.emotion-0::-moz-range-thumb {
+  box-sizing: content-box;
+  height: 20px;
+  width: 6px;
+  background-color: #808080;
+  border: 0;
+  border-radius: 1px;
+  box-shadow: 0 0 0 0 rgba(255,255,255,0);
+  position: relative;
+  top: 50%;
+  -webkit-transition-duration: 0.3s;
+  transition-duration: 0.3s;
+  -webkit-transition-property: box-shadow;
+  transition-property: box-shadow;
+  -webkit-transition-timing-function: cubic-bezier(0.4,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.4,0,0.2,1);
+  -webkit-appearance: none;
+}
+
+.emotion-0::-webkit-slider-thumb {
+  box-sizing: content-box;
+  height: 20px;
+  width: 6px;
+  background-color: #808080;
+  border: 0;
+  border-radius: 1px;
+  box-shadow: 0 0 0 0 rgba(255,255,255,0);
+  position: relative;
+  top: 50%;
+  -webkit-transition-duration: 0.3s;
+  transition-duration: 0.3s;
+  -webkit-transition-property: box-shadow;
+  transition-property: box-shadow;
+  -webkit-transition-timing-function: cubic-bezier(0.4,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.4,0,0.2,1);
+  -webkit-appearance: none;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+}
+
+.emotion-0::-ms-track {
+  width: 100%;
+  height: 2px;
+  border: none;
+  background-color: rgba(128,128,128,0.2);
+  color: transparent;
+  outline: none;
+}
+
+.emotion-0::-moz-range-track {
+  width: 100%;
+  height: 2px;
+  border: none;
+  background-color: rgba(128,128,128,0.2);
+  color: transparent;
+  outline: none;
+}
+
+.emotion-0::-webkit-slider-runnable-track {
+  width: 100%;
+  height: 2px;
+  border: none;
+  background-color: rgba(128,128,128,0.2);
+  color: transparent;
+  outline: none;
+  background-image: linear-gradient(#808080,#808080);
+  background-position: 0;
+  background-size: calc((0.5 * 6px)  + (NaN * (100% - 6px))) 100%;
+  background-repeat: no-repeat;
+}
+
+.emotion-0::-ms-fill-lower {
+  border: none;
+  background-color: #808080;
+}
+
+.emotion-0::-moz-range-progress {
+  border: none;
+  background-color: #808080;
+}
+
+.emotion-1 {
+  width: 1px;
+  height: 4px;
+  margin-top: -12px;
+  position: absolute;
+  background-color: #808080;
+}
+
+.emotion-4 {
+  position: relative;
+}
+
+.emotion-3 {
+  position: absolute;
+  width: 100%;
+}
+
+<div
+  className="emotion-4"
+>
+  <input
+    aria-valuemax={undefined}
+    aria-valuemin={undefined}
+    aria-valuenow={undefined}
+    className="emotion-0"
+    disabled={undefined}
+    max={undefined}
+    min={undefined}
+    step={0}
+    type="range"
+    value={undefined}
+  />
+  <div
+    className="emotion-3"
+  >
+    <div
+      className="emotion-1"
+      style={
+        Object {
+          "left": "0%",
+        }
+      }
+    />
+    <div
+      className="emotion-1"
+      style={
+        Object {
+          "left": "100%",
+        }
+      }
+    />
+  </div>
+</div>
+`;
+
 exports[`Slider/presenters/SliderPresenter renders focused 1`] = `
 .emotion-0 {
   -webkit-appearance: none;

--- a/packages/slider/src/presenters/__snapshots__/SliderPresenter.test.js.snap
+++ b/packages/slider/src/presenters/__snapshots__/SliderPresenter.test.js.snap
@@ -485,7 +485,7 @@ exports[`Slider/presenters/SliderPresenter renders discrete slider 1`] = `
       className="emotion-1"
       style={
         Object {
-          "left": "100%",
+          "right": "0%",
         }
       }
     />
@@ -665,7 +665,7 @@ exports[`Slider/presenters/SliderPresenter renders discrete slider with step 0 1
       className="emotion-1"
       style={
         Object {
-          "left": "100%",
+          "right": "0%",
         }
       }
     />

--- a/packages/slider/src/presenters/stylesheet.js
+++ b/packages/slider/src/presenters/stylesheet.js
@@ -175,13 +175,35 @@ function stylesheet(props, trackValueRatio, themeData) {
     }
   );
 
+  const markRules = {
+    width: "1px",
+    height: "4px",
+    marginTop: "-12px",
+    position: "absolute",
+    backgroundColor: themeData["slider.value.backgroundColor"],
+
+    ...trackDisabledRules
+  };
+
+  const markContainer = {
+    position: "absolute",
+    width: "100%"
+  };
+
+  const discrete = {
+    position: "relative"
+  };
+
   return {
     slider: {
       ...baseRules,
       ...thumbRules,
       ...trackRules,
       ...trackProgressRules
-    }
+    },
+    markRules,
+    markContainer,
+    discrete
   };
 }
 

--- a/packages/slider/src/presenters/stylesheet.test.js
+++ b/packages/slider/src/presenters/stylesheet.test.js
@@ -30,6 +30,29 @@ describe("stylesheet", () => {
     );
   });
 
+  it("returns discrete style", () => {
+    const props = {};
+
+    const styles = stylesheet(props, 0, themeData);
+
+    expect(styles).toEqual(
+      expect.objectContaining({ discrete: expect.anything() })
+    );
+  });
+
+  it("returns marks style", () => {
+    const props = {};
+
+    const styles = stylesheet(props, 0, themeData);
+
+    expect(styles).toEqual(
+      expect.objectContaining({
+        markRules: expect.anything(),
+        markContainer: expect.anything()
+      })
+    );
+  });
+
   describe("when disabled", () => {
     let props;
     let styles;


### PR DESCRIPTION
Implement discrete slider according to design https://hig.autodesk.com/web/components/sliders

- Add new property to component slider 
  - property name: type
  - property type: enum
  `{
  CONTINUOUS: "continuous",
  DISCRETE: "discrete"
 }`
  - default value: "continuous"
- Discrete slider implementation
  - calculate the number of marks according to property min, max and step.
    If step is 0, add 2 marks to the start point and end point of the slider.
  - render marks below the slider

**A discrete slider - step 1**
<img width="873" alt="Screen Shot 2020-11-27 at 4 06 14 PM" src="https://user-images.githubusercontent.com/37433962/100425681-9a964b00-30ca-11eb-8f13-c56d3c3e7c19.png">
**A discrete slider - step 2**
<img width="569" alt="Screen Shot 2020-11-27 at 4 12 20 PM" src="https://user-images.githubusercontent.com/37433962/100426150-60797900-30cb-11eb-9067-36f7a8db9508.png">
**A discrete slider - step 0**
<img width="530" alt="Screen Shot 2020-11-27 at 4 10 17 PM" src="https://user-images.githubusercontent.com/37433962/100425913-07114a00-30cb-11eb-882f-49653eeb197b.png">


- Keep default slider unchanged
- Add type option to storybook of slider