### PR TITLE
fix: don't use regex lookbehind, revert to previous regex

### DIFF
--- a/packages/project-account-switcher/src/presenters/constructPlaceholder.js
+++ b/packages/project-account-switcher/src/presenters/constructPlaceholder.js
@@ -1,3 +1,3 @@
 export default function constructPlaceholder(label) {
-  return (label.match(/(?<=[-\s._'",;]|^)([^-\s._'",;])/g) || []).join("");
+  return label.match(/\b(\w)/g).join("");
 }


### PR DESCRIPTION
Regex lookbehind is not supported in IE and Safari