### PR TITLE
Fix icon positioning in Button

### DIFF
--- a/packages/button/src/__snapshots__/Button.test.js.snap
+++ b/packages/button/src/__snapshots__/Button.test.js.snap
@@ -327,7 +327,6 @@ exports[`Button  5`] = `
   position: absolute;
   height: 24px;
   margin-right: 4px;
-  top: 50%;
   -webkit-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);

--- a/packages/button/src/presenters/stylesheet.js
+++ b/packages/button/src/presenters/stylesheet.js
@@ -214,7 +214,6 @@ export default function stylesheet(props, themeData, theme) {
       position: "absolute",
       height: iconSize,
       marginRight: themeData["button.gutterWidth"],
-      top: "50%",
       transform: "translateY(-50%)"
     },
     iconText: {


### PR DESCRIPTION
See also https://git.autodesk.com/InfraWorks/application-home/issues/513

It seems like the rule i removed has no effect in Chrome 79, but makes the icon be in the wrong place in newer chrome and firefox.

I have not verified the change within the hig-repository, I just have observed that disabling this rule in the devtools of the browser fixes the issue. I'd appreciate if you could validate the change!

Screenshots in different browsers/web engines:

CEF:
![image](https://user-images.githubusercontent.com/47857027/106147704-7c0b0980-6178-11eb-8568-f6fe43c4022f.png)


Chrome 88:
![image](https://user-images.githubusercontent.com/47857027/106147722-8200ea80-6178-11eb-871b-96037f89817c.png)

Interestingly, chrome 79 shows the icon in the intended position.

Microsoft Edge WebView2:
![image](https://user-images.githubusercontent.com/47857027/106147755-8cbb7f80-6178-11eb-86e7-2a336bd4990a.png)
