### PR TITLE
feat(avatar): Small refactors for usage by avatarBundle (ACWB-8852)

### DIFF
--- a/packages/avatar/src/Avatar.js
+++ b/packages/avatar/src/Avatar.js
@@ -6,8 +6,9 @@ import { polyfill } from "react-lifecycles-compat";
 import { ThemeContext } from "@hig/theme-context";
 import { createCustomClassNames } from "@hig/utils";
 
+import stylesheet from "./Avatar.stylesheet";
 import { sizes, AVAILABLE_SIZES } from "./sizes";
-import stylesheet, { StyleItems } from "./Avatar.stylesheet";
+import { StyleItems } from "./constants";
 
 export const COLOR_VARIANT_COUNT = 15;
 

--- a/packages/avatar/src/Avatar.js
+++ b/packages/avatar/src/Avatar.js
@@ -2,10 +2,12 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { cx, css } from "emotion";
 import { polyfill } from "react-lifecycles-compat";
+
 import { ThemeContext } from "@hig/theme-context";
 import { createCustomClassNames } from "@hig/utils";
+
 import { sizes, AVAILABLE_SIZES } from "./sizes";
-import stylesheet from "./Avatar.stylesheet";
+import stylesheet, { StyleItems } from "./Avatar.stylesheet";
 
 export const COLOR_VARIANT_COUNT = 15;
 
@@ -99,8 +101,15 @@ function buildFirstAndLastName(name) {
  * @param {string} props.size
  * @returns {JSX.Element}
  */
-// eslint-disable-next-line react/prop-types, prettier/prettier
-function Image({ image, alt, size, onError, className, resolvedRoles, stylesheet: customStylesheet }) {
+function Image({
+  image,
+  alt,
+  size,
+  onError,
+  className,
+  resolvedRoles,
+  stylesheet: customStylesheet
+}) {
   const styles = stylesheet(
     { size, stylesheet: customStylesheet },
     resolvedRoles
@@ -113,9 +122,14 @@ function Image({ image, alt, size, onError, className, resolvedRoles, stylesheet
   const imageClassName = createCustomClassNames(className, "image");
 
   return (
-    <span className={cx(css(styles.avatarImageWrapper), imageWrapperClassName)}>
+    <span
+      className={cx(
+        css(styles[StyleItems.avatarImageWrapper]),
+        imageWrapperClassName
+      )}
+    >
       <img
-        className={cx(css(styles.avatarImage), imageClassName)}
+        className={cx(css(styles[StyleItems.avatarImage]), imageClassName)}
         src={image}
         alt={alt}
         onError={onError}
@@ -123,6 +137,23 @@ function Image({ image, alt, size, onError, className, resolvedRoles, stylesheet
     </span>
   );
 }
+Image.propTypes = {
+  /** URL to a profile image */
+  image: PropTypes.string,
+  /** Optional alt message override for Avatar Image  */
+  alt: PropTypes.string,
+  /** Set the size of the avatar */
+  size: PropTypes.oneOf(AVAILABLE_SIZES),
+  /** Called when an error occurs on the image  */
+  onError: PropTypes.func,
+  /** Optional className */
+  className: PropTypes.string,
+  /** Theme context */
+  // eslint-disable-next-line react/forbid-prop-types
+  resolvedRoles: PropTypes.any,
+  /** Optional style override */
+  stylesheet: PropTypes.func
+};
 
 /**
  * @param {Object} props
@@ -132,8 +163,13 @@ function Image({ image, alt, size, onError, className, resolvedRoles, stylesheet
  * @param {string} className
  * @returns {JSX.Element}
  */
-// eslint-disable-next-line react/prop-types, prettier/prettier
-function Initials({size, name, className, resolvedRoles, stylesheet: customStylesheet }) {
+function Initials({
+  size,
+  name,
+  className,
+  resolvedRoles,
+  stylesheet: customStylesheet
+}) {
   const styles = stylesheet(
     { size, stylesheet: customStylesheet },
     resolvedRoles
@@ -143,13 +179,29 @@ function Initials({size, name, className, resolvedRoles, stylesheet: customStyle
 
   return (
     <span
-      className={cx(css(styles.avatarInitials), initialsClassName)}
+      className={cx(css(styles[StyleItems.avatarInitials]), initialsClassName)}
       aria-hidden="true"
     >
       {size === sizes.SMALL_16 ? initials[0] : initials}
     </span>
   );
 }
+Initials.propTypes = {
+  /** Set the size of the avatar */
+  size: PropTypes.oneOf(AVAILABLE_SIZES),
+  /** First and Last name object */
+  name: PropTypes.shape({
+    firstName: PropTypes.string,
+    lastName: PropTypes.string
+  }),
+  /** Optional className */
+  className: PropTypes.string,
+  /** Theme context */
+  // eslint-disable-next-line react/forbid-prop-types
+  resolvedRoles: PropTypes.any,
+  /** Optional style override */
+  stylesheet: PropTypes.func
+};
 
 /**
  * @typedef {Object} AvatarProps
@@ -272,7 +324,7 @@ class Avatar extends Component {
           <span
             aria-label={label}
             className={cx(
-              css(styles(resolvedRoles).avatarContainer),
+              css(styles(resolvedRoles)[StyleItems.avatarContainer]),
               className
             )}
             role="img"

--- a/packages/avatar/src/Avatar.stylesheet.js
+++ b/packages/avatar/src/Avatar.stylesheet.js
@@ -1,11 +1,18 @@
 import { sizes } from "./sizes";
 
-const SizeMapping = {
+export const SizeMapping = {
   [sizes.SMALL_16]: "extraSmall",
   [sizes.MEDIUM_24]: "small",
   [sizes.MEDIUM_32]: "medium",
   [sizes.LARGE_48]: "large",
   [sizes.XLARGE_64]: "extraLarge"
+};
+
+export const StyleItems = {
+  avatarContainer: "avatarContainer",
+  avatarImageWrapper: "avatarImageWrapper",
+  avatarImage: "avatarImage",
+  avatarInitials: "avatarInitials"
 };
 
 export default function stylesheet(props, themeData) {
@@ -18,7 +25,7 @@ export default function stylesheet(props, themeData) {
   const fgColor = themeData["avatar.fontColor"];
 
   const styles = {
-    avatarContainer: {
+    [StyleItems.avatarContainer]: {
       backgroundColor: bgColor,
       color: fgColor,
       width: diameter,
@@ -32,18 +39,18 @@ export default function stylesheet(props, themeData) {
       borderRadius: "50%",
       textAlign: "center"
     },
-    avatarImageWrapper: {
+    [StyleItems.avatarImageWrapper]: {
       position: "absolute",
       display: "flex",
       zIndex: "2",
       fontSize
     },
-    avatarImage: {
+    [StyleItems.avatarImage]: {
       borderRadius: "50%",
       width: diameter,
       height: diameter
     },
-    avatarInitials: {
+    [StyleItems.avatarInitials]: {
       width: diameter,
       height: diameter,
       fontFamily

--- a/packages/avatar/src/Avatar.stylesheet.js
+++ b/packages/avatar/src/Avatar.stylesheet.js
@@ -1,19 +1,5 @@
 import { sizes } from "./sizes";
-
-export const SizeMapping = {
-  [sizes.SMALL_16]: "extraSmall",
-  [sizes.MEDIUM_24]: "small",
-  [sizes.MEDIUM_32]: "medium",
-  [sizes.LARGE_48]: "large",
-  [sizes.XLARGE_64]: "extraLarge"
-};
-
-export const StyleItems = {
-  avatarContainer: "avatarContainer",
-  avatarImageWrapper: "avatarImageWrapper",
-  avatarImage: "avatarImage",
-  avatarInitials: "avatarInitials"
-};
+import { SizeMapping, StyleItems } from "./constants";
 
 export default function stylesheet(props, themeData) {
   const { backgroundId, size, stylesheet: customStylesheet } = props;

--- a/packages/avatar/src/constants.js
+++ b/packages/avatar/src/constants.js
@@ -1,0 +1,16 @@
+import { sizes } from "./sizes";
+
+export const SizeMapping = {
+  [sizes.SMALL_16]: "extraSmall",
+  [sizes.MEDIUM_24]: "small",
+  [sizes.MEDIUM_32]: "medium",
+  [sizes.LARGE_48]: "large",
+  [sizes.XLARGE_64]: "extraLarge"
+};
+
+export const StyleItems = {
+  avatarContainer: "avatarContainer",
+  avatarImageWrapper: "avatarImageWrapper",
+  avatarImage: "avatarImage",
+  avatarInitials: "avatarInitials"
+};

--- a/packages/avatar/src/index.js
+++ b/packages/avatar/src/index.js
@@ -1,7 +1,4 @@
 export { default } from "./Avatar";
 export { sizes, AVAILABLE_SIZES } from "./sizes";
-export {
-  default as stylesheet,
-  SizeMapping,
-  StyleItems
-} from "./Avatar.stylesheet";
+export { default as stylesheet } from "./Avatar.stylesheet";
+export * from "./constants";

--- a/packages/avatar/src/index.js
+++ b/packages/avatar/src/index.js
@@ -1,2 +1,7 @@
 export { default } from "./Avatar";
 export { sizes, AVAILABLE_SIZES } from "./sizes";
+export {
+  default as stylesheet,
+  SizeMapping,
+  StyleItems
+} from "./Avatar.stylesheet";


### PR DESCRIPTION
**This PR must be merged before Avatar Bundle PR https://github.com/Autodesk/hig/pull/2432**

 - Some linting changes to remove the `// eslint-disable-next-line react/prop-types, prettier/prettier` comments and more throughly describe prop types.
 - New use of StyleItems values.
 - These changes are part of the Avatar Bundle work described in https://jira.autodesk.com/browse/ACWB-8852.
See Figma spec here:
https://www.figma.com/file/S657OgrT8eiU4TreWWYQi8/LIB_Components?node-id=528%3A15

Another commit with the Avatar Bundle component updates that utilize `StyleItems` will follow this one.