### PR TITLE
Revert "fix: set success color for light gray to correct value"

### DIFF
--- a/packages/theme-data/src/baseTheme/system/colorScheme.js
+++ b/packages/theme-data/src/baseTheme/system/colorScheme.js
@@ -126,7 +126,7 @@ export default {
   },
   "status.success": {
     value: {
-      ref: "basics.colors.secondary.green.600"
+      ref: "basics.colors.secondary.green.500"
     },
     type: COLOR
   },

--- a/packages/theme-data/src/colorSchemes/darkBlue/system/colorScheme.js
+++ b/packages/theme-data/src/colorSchemes/darkBlue/system/colorScheme.js
@@ -357,10 +357,5 @@ export default {
     value: {
       ref: "basics.colors.secondary.yellowOrange.400"
     }
-  },
-  "status.success": {
-    value: {
-      ref: "basics.colors.secondary.green.500"
-    }
   }
 };


### PR DESCRIPTION
Reverts Autodesk/hig#2485 I need re run the tests to update them for this to pass