### PR TITLE
feat(menu): Add optionRef to Option component

### DIFF
--- a/packages/menu/src/Option.js
+++ b/packages/menu/src/Option.js
@@ -20,6 +20,10 @@ export default class Option extends Component {
      */
     children: PropTypes.node.isRequired,
     /**
+     * A callback ref that gets passed to the HTML 'li' element
+     */
+    optionRef: PropTypes.func,
+    /**
      * Disables the Option
      */
     disabled: PropTypes.bool,

--- a/packages/menu/src/Option.test.js
+++ b/packages/menu/src/Option.test.js
@@ -1,5 +1,6 @@
 import React from "react";
 import renderer from "react-test-renderer";
+import { mount } from "enzyme";
 import { Settings24 } from "@hig/icons";
 import Avatar from "@hig/avatar";
 import Menu from "./Menu";
@@ -110,5 +111,23 @@ describe("menu/Option", () => {
     );
     const tree = renderer.create(wrapper).toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  it("passes down the optionRef", () => {
+    let optionEl = null;
+    const setOptionEl = el => {
+      optionEl = el;
+    };
+    const wrapper = (
+      <Menu>
+        <Option optionRef={setOptionEl} id="option-1">
+          Option 1
+        </Option>
+        <Option id="option-2">Option 2</Option>
+        <Option id="option-3">Option 3</Option>
+      </Menu>
+    );
+
+    expect(mount(wrapper).containsMatchingElement(optionEl)).toBe(true);
   });
 });

--- a/packages/menu/src/presenters/OptionPresenter.js
+++ b/packages/menu/src/presenters/OptionPresenter.js
@@ -29,6 +29,7 @@ export default class OptionPresenter extends Component {
       asset,
       checkmark,
       children,
+      optionRef,
       disabled,
       highlighted,
       id,
@@ -99,6 +100,7 @@ export default class OptionPresenter extends Component {
               className={cx([menuOptionClassName, css(styles.menuOption)])}
               disabled={disabled}
               id={id}
+              ref={optionRef}
               role={role}
               selected={selected}
             >


### PR DESCRIPTION
Adds a ref to the Option component of Menu,
so consumers are able to get a reference to the internal 'li' element

(Test was copied from https://github.com/Autodesk/hig/pull/2260 - couldn't think of a better way to do it)