### PR TITLE
Revert "fix: destruct unselect prop in menu to fix menu console error"

### DIFF
--- a/packages/menu/src/Menu.js
+++ b/packages/menu/src/Menu.js
@@ -12,6 +12,10 @@ export default class Menu extends Component {
      */
     checkmark: PropTypes.bool,
     /**
+     * Shows a ability of checkmark to be unchecked if required
+     */
+    unselect: PropTypes.bool,
+    /**
      * Accepts Option components
      */
     children: PropTypes.node.isRequired,
@@ -46,11 +50,7 @@ export default class Menu extends Component {
     /**
      * Adds custom/overriding styles
      */
-    stylesheet: PropTypes.func,
-    /**
-     * Shows a ability of checkmark to be unchecked if required
-     */
-    unselect: PropTypes.bool
+    stylesheet: PropTypes.func
   };
 
   static defaultProps = {
@@ -61,6 +61,7 @@ export default class Menu extends Component {
   render() {
     const {
       checkmark,
+      unselect,
       children,
       defaultSelected,
       divider,
@@ -69,7 +70,6 @@ export default class Menu extends Component {
       onChange,
       selected,
       stylesheet,
-      unselect,
       ...otherProps
     } = this.props;
     const { onBlur, onFocus, onKeyDown } = otherProps;
@@ -124,6 +124,7 @@ export default class Menu extends Component {
                 setHighlightIndex={setHighlightIndex}
                 setOptionsInfo={setOptionsInfo}
                 setPreviousEvent={setPreviousEvent}
+                unselect={unselect}
                 stylesheet={stylesheet}
               >
                 {children}

--- a/packages/menu/src/MenuGroup.js
+++ b/packages/menu/src/MenuGroup.js
@@ -23,6 +23,10 @@ export default class MenuGroup extends Component {
      */
     menuRef: PropTypes.func,
     /**
+     * Shows a ability of checkmark to be unchecked if required
+     */
+    unselect: PropTypes.bool,
+    /**
      * Enables multiple selection
      * This will take precedent over the Menu prop
      * of the same name
@@ -45,11 +49,7 @@ export default class MenuGroup extends Component {
      * This will take precedent over the Menu prop of the
      * same name
      */
-    stylesheet: PropTypes.func,
-    /**
-     * Shows a ability of checkmark to be unchecked if required
-     */
-    unselect: PropTypes.bool
+    stylesheet: PropTypes.func
   };
 
   static defaultProps = {
@@ -65,8 +65,8 @@ export default class MenuGroup extends Component {
       multiple,
       onChange,
       selected,
-      stylesheet,
       unselect,
+      stylesheet,
       ...otherProps
     } = this.props;
 
@@ -113,6 +113,7 @@ export default class MenuGroup extends Component {
             setHighlightIndex={setHighlightIndex}
             setOptionsInfo={setOptionsInfo}
             setPreviousEvent={setPreviousEvent}
+            unselect={unselect}
             stylesheet={stylesheet}
           >
             {children}

--- a/packages/menu/src/__snapshots__/Menu.test.js.snap
+++ b/packages/menu/src/__snapshots__/Menu.test.js.snap
@@ -66,6 +66,7 @@ exports[`menu/Menu renders Menu and Options with checkmark and unselect 1`] = `
   role="listbox"
   selected={undefined}
   tabIndex="0"
+  unselect={false}
 >
   <li
     aria-selected={false}
@@ -202,6 +203,7 @@ exports[`menu/Menu renders Menu and Options with defaultSelected 1`] = `
   role="listbox"
   selected={undefined}
   tabIndex="0"
+  unselect={true}
 >
   <li
     aria-selected={false}
@@ -395,6 +397,7 @@ exports[`menu/Menu renders Menu and Options with defaultSelected and checkmark v
   role="listbox"
   selected={undefined}
   tabIndex="0"
+  unselect={true}
 >
   <li
     aria-selected={false}
@@ -590,6 +593,7 @@ exports[`menu/Menu renders checkmark indicator Menu and Options 1`] = `
   role="listbox"
   selected={undefined}
   tabIndex="0"
+  unselect={true}
 >
   <li
     aria-selected={false}
@@ -753,6 +757,7 @@ exports[`menu/Menu renders default Menu and Options 1`] = `
   role="listbox"
   selected={undefined}
   tabIndex="0"
+  unselect={true}
 >
   <li
     aria-selected={false}

--- a/packages/menu/src/__snapshots__/MenuGroup.test.js.snap
+++ b/packages/menu/src/__snapshots__/MenuGroup.test.js.snap
@@ -96,6 +96,7 @@ exports[`menu/MenuGroup renders Menus with checkmark and unselect 1`] = `
   role="listbox"
   selected={undefined}
   tabIndex="0"
+  unselect={true}
 >
   <ul
     className="emotion-12"
@@ -107,6 +108,7 @@ exports[`menu/MenuGroup renders Menus with checkmark and unselect 1`] = `
     role="group"
     selected={undefined}
     tabIndex="-1"
+    unselect={true}
   >
     <li
       aria-selected={false}
@@ -230,6 +232,7 @@ exports[`menu/MenuGroup renders Menus with checkmark and unselect 1`] = `
     role="group"
     selected={undefined}
     tabIndex="-1"
+    unselect={true}
   >
     <li
       aria-selected={false}
@@ -308,6 +311,7 @@ exports[`menu/MenuGroup renders Menus with checkmark and unselect 1`] = `
     role="group"
     selected={undefined}
     tabIndex="-1"
+    unselect={true}
   >
     <li
       aria-selected={false}
@@ -520,6 +524,7 @@ exports[`menu/MenuGroup renders Menus with dividers and Options 1`] = `
   role="listbox"
   selected={undefined}
   tabIndex="0"
+  unselect={true}
 >
   <ul
     className="emotion-12"
@@ -531,6 +536,7 @@ exports[`menu/MenuGroup renders Menus with dividers and Options 1`] = `
     role="group"
     selected={undefined}
     tabIndex="-1"
+    unselect={true}
   >
     <li
       aria-selected={false}
@@ -654,6 +660,7 @@ exports[`menu/MenuGroup renders Menus with dividers and Options 1`] = `
     role="group"
     selected={undefined}
     tabIndex="-1"
+    unselect={true}
   >
     <li
       aria-selected={false}
@@ -732,6 +739,7 @@ exports[`menu/MenuGroup renders Menus with dividers and Options 1`] = `
     role="group"
     selected={undefined}
     tabIndex="-1"
+    unselect={true}
   >
     <li
       aria-selected={false}
@@ -900,6 +908,7 @@ exports[`menu/MenuGroup renders default Menu and Options 1`] = `
   role="listbox"
   selected={undefined}
   tabIndex="0"
+  unselect={true}
 >
   <ul
     className="emotion-6"
@@ -911,6 +920,7 @@ exports[`menu/MenuGroup renders default Menu and Options 1`] = `
     role="group"
     selected={undefined}
     tabIndex="-1"
+    unselect={true}
   >
     <li
       aria-selected={false}
@@ -989,6 +999,7 @@ exports[`menu/MenuGroup renders default Menu and Options 1`] = `
     role="group"
     selected={undefined}
     tabIndex="-1"
+    unselect={true}
   >
     <li
       aria-selected={false}
@@ -1067,6 +1078,7 @@ exports[`menu/MenuGroup renders default Menu and Options 1`] = `
     role="group"
     selected={undefined}
     tabIndex="-1"
+    unselect={true}
   >
     <li
       aria-selected={false}
@@ -1222,6 +1234,7 @@ exports[`menu/MenuGroup renders mixed default and checkmark Menu and Options 1`]
   role="listbox"
   selected={undefined}
   tabIndex="0"
+  unselect={true}
 >
   <ul
     className="emotion-12"
@@ -1233,6 +1246,7 @@ exports[`menu/MenuGroup renders mixed default and checkmark Menu and Options 1`]
     role="group"
     selected={undefined}
     tabIndex="-1"
+    unselect={true}
   >
     <li
       aria-selected={false}
@@ -1356,6 +1370,7 @@ exports[`menu/MenuGroup renders mixed default and checkmark Menu and Options 1`]
     role="group"
     selected={undefined}
     tabIndex="-1"
+    unselect={true}
   >
     <li
       aria-selected={false}
@@ -1434,6 +1449,7 @@ exports[`menu/MenuGroup renders mixed default and checkmark Menu and Options 1`]
     role="group"
     selected={undefined}
     tabIndex="-1"
+    unselect={true}
   >
     <li
       aria-selected={false}
@@ -1684,6 +1700,7 @@ exports[`menu/MenuGroup renders multiple and controlled Menu and Options 1`] = `
     ]
   }
   tabIndex="0"
+  unselect={true}
 >
   <ul
     className="emotion-12"
@@ -1701,6 +1718,7 @@ exports[`menu/MenuGroup renders multiple and controlled Menu and Options 1`] = `
       ]
     }
     tabIndex="-1"
+    unselect={true}
   >
     <li
       aria-selected={false}
@@ -1830,6 +1848,7 @@ exports[`menu/MenuGroup renders multiple and controlled Menu and Options 1`] = `
       ]
     }
     tabIndex="-1"
+    unselect={true}
   >
     <li
       aria-selected={false}
@@ -1914,6 +1933,7 @@ exports[`menu/MenuGroup renders multiple and controlled Menu and Options 1`] = `
       ]
     }
     tabIndex="-1"
+    unselect={true}
   >
     <li
       aria-selected={false}
@@ -2158,6 +2178,7 @@ exports[`menu/MenuGroup renders multiple and defaultSelected Menu and Options 1`
   role="listbox"
   selected={undefined}
   tabIndex="0"
+  unselect={true}
 >
   <ul
     className="emotion-12"
@@ -2169,6 +2190,7 @@ exports[`menu/MenuGroup renders multiple and defaultSelected Menu and Options 1`
     role="group"
     selected={undefined}
     tabIndex="-1"
+    unselect={true}
   >
     <li
       aria-selected={false}
@@ -2292,6 +2314,7 @@ exports[`menu/MenuGroup renders multiple and defaultSelected Menu and Options 1`
     role="group"
     selected={undefined}
     tabIndex="-1"
+    unselect={true}
   >
     <li
       aria-selected={false}
@@ -2370,6 +2393,7 @@ exports[`menu/MenuGroup renders multiple and defaultSelected Menu and Options 1`
     role="group"
     selected={undefined}
     tabIndex="-1"
+    unselect={true}
   >
     <li
       aria-selected={false}

--- a/packages/menu/src/__snapshots__/Option.test.js.snap
+++ b/packages/menu/src/__snapshots__/Option.test.js.snap
@@ -143,6 +143,7 @@ exports[`menu/Option renders Menu and Options that are disabled 1`] = `
   role="listbox"
   selected={undefined}
   tabIndex="0"
+  unselect={true}
 >
   <li
     aria-selected={false}
@@ -370,6 +371,7 @@ exports[`menu/Option renders Menu and Options with Avatars 1`] = `
   role="listbox"
   selected={undefined}
   tabIndex="0"
+  unselect={true}
 >
   <li
     aria-selected={false}
@@ -632,6 +634,7 @@ exports[`menu/Option renders Menu and Options with Headers 1`] = `
   role="listbox"
   selected={undefined}
   tabIndex="0"
+  unselect={true}
 >
   <li
     className="emotion-1"
@@ -800,6 +803,7 @@ exports[`menu/Option renders Menu and Options with icons 1`] = `
   role="listbox"
   selected={undefined}
   tabIndex="0"
+  unselect={true}
 >
   <li
     aria-selected={false}
@@ -982,6 +986,7 @@ exports[`menu/Option renders Menu and Options with shortcuts 1`] = `
   role="listbox"
   selected={undefined}
   tabIndex="0"
+  unselect={true}
 >
   <li
     aria-selected={false}
@@ -1153,6 +1158,7 @@ exports[`menu/Option renders checkmark indicator Menu and Options 1`] = `
   role="listbox"
   selected={undefined}
   tabIndex="0"
+  unselect={true}
 >
   <li
     aria-selected={false}
@@ -1316,6 +1322,7 @@ exports[`menu/Option renders default Menu and Options 1`] = `
   role="listbox"
   selected={undefined}
   tabIndex="0"
+  unselect={true}
 >
   <li
     aria-selected={false}

--- a/packages/menu/src/presenters/MenuGroupPresenter.js
+++ b/packages/menu/src/presenters/MenuGroupPresenter.js
@@ -137,7 +137,6 @@ export default class MenuGroupPresenter extends Component {
       menuRef,
       multiple,
       stylesheet: customStylesheet,
-      unselect,
       ...otherProps
     } = this.props;
     const { className } = otherProps;

--- a/packages/menu/src/presenters/MenuPresenter.js
+++ b/packages/menu/src/presenters/MenuPresenter.js
@@ -102,7 +102,6 @@ export default class MenuPresenter extends Component {
       menuRef,
       multiple,
       stylesheet: customStylesheet,
-      unselect,
       ...otherProps
     } = this.props;
     const {
@@ -136,7 +135,6 @@ export default class MenuPresenter extends Component {
     delete payload.setHighlightIndex;
     delete payload.setOptionsInfo;
     delete payload.setPreviousEvent;
-    delete payload.unselect;
 
     return (
       <ThemeContext.Consumer>

--- a/packages/menu/src/presenters/OptionPresenter.js
+++ b/packages/menu/src/presenters/OptionPresenter.js
@@ -37,8 +37,8 @@ export default class OptionPresenter extends Component {
       role,
       selected,
       shortcut,
-      stylesheet: customStylesheet,
       unselect,
+      stylesheet: customStylesheet,
       ...otherProps
     } = this.props;
     const { className } = otherProps;
@@ -83,8 +83,8 @@ export default class OptionPresenter extends Component {
               role,
               selected,
               shortcut,
-              stylesheet: customStylesheet,
-              unselect
+              unselect,
+              stylesheet: customStylesheet
             },
             resolvedRoles
           );


### PR DESCRIPTION
I'm so confused right now, this is clearly squashed but doesn't show that in the PR for dev to master.