### PR TITLE
fix: change Toast and Flyout notifications to wrap long words properly

### DIFF
--- a/packages/notifications-flyout/src/__snapshots__/Notification.test.js.snap
+++ b/packages/notifications-flyout/src/__snapshots__/Notification.test.js.snap
@@ -18,6 +18,8 @@ exports[`notifications-flyout/Notification renders correctly with the featured p
 
 .emotion-4 {
   margin: 12px;
+  word-wrap: break-word;
+  overflow: hidden;
 }
 
 .emotion-0 {
@@ -296,6 +298,8 @@ exports[`notifications-flyout/Notification renders correctly with the unread pro
 
 .emotion-1 {
   margin: 12px;
+  word-wrap: break-word;
+  overflow: hidden;
 }
 
 .emotion-0 {

--- a/packages/notifications-flyout/src/__snapshots__/NotificationsFlyout.test.js.snap
+++ b/packages/notifications-flyout/src/__snapshots__/NotificationsFlyout.test.js.snap
@@ -209,6 +209,8 @@ exports[`notifications-flyout/NotificationsFlyout renders a notification with th
 
 .emotion-10 {
   margin: 12px;
+  word-wrap: break-word;
+  overflow: hidden;
 }
 
 .emotion-9 {
@@ -684,6 +686,8 @@ exports[`notifications-flyout/NotificationsFlyout renders a notification with th
 
 .emotion-10 {
   margin: 12px;
+  word-wrap: break-word;
+  overflow: hidden;
 }
 
 .emotion-9 {
@@ -1112,6 +1116,8 @@ exports[`notifications-flyout/NotificationsFlyout renders with all props 1`] = `
 
 .emotion-10 {
   margin: 12px;
+  word-wrap: break-word;
+  overflow: hidden;
 }
 
 .emotion-9 {

--- a/packages/notifications-flyout/src/presenters/__snapshots__/NotificationPresenter.test.js.snap
+++ b/packages/notifications-flyout/src/presenters/__snapshots__/NotificationPresenter.test.js.snap
@@ -18,6 +18,8 @@ exports[`notifications-flyout/presenters/NotificationPresenter renders with all 
 
 .emotion-4 {
   margin: 12px;
+  word-wrap: break-word;
+  overflow: hidden;
 }
 
 .emotion-0 {
@@ -282,6 +284,8 @@ exports[`notifications-flyout/presenters/NotificationPresenter renders without p
 
 .emotion-1 {
   margin: 12px;
+  word-wrap: break-word;
+  overflow: hidden;
 }
 
 .emotion-0 {

--- a/packages/notifications-flyout/src/presenters/stylesheet.js
+++ b/packages/notifications-flyout/src/presenters/stylesheet.js
@@ -74,7 +74,9 @@ export default function stylesheet(props, themeData) {
       } ${themeData["density.spacings.small"]}`
     },
     notificationContentText: {
-      margin: `${themeData["density.spacings.small"]}`
+      margin: `${themeData["density.spacings.small"]}`,
+      wordWrap: `break-word`,
+      overflow: `hidden`
     },
     panelTitle: {
       padding: `${themeData["density.spacings.small"]}

--- a/packages/notifications-toast/src/NotificationsToast.stylesheet.js
+++ b/packages/notifications-toast/src/NotificationsToast.stylesheet.js
@@ -53,7 +53,8 @@ export default function stylesheet(props, themeData) {
       flexGrow: 1,
       display: `flex`,
       position: `relative`,
-      paddingRight: `36px`
+      paddingRight: `36px`,
+      wordWrap: `break-word`
     },
     toastDismiss: {
       position: `absolute`,


### PR DESCRIPTION
This issue affects notifications related to Electron custom 3D model workflow
which might contain long 3D package name derived from IPC name
(E.g., STANDOFF_HEX_FEMALE_500X1200_M2.5X0.45_MTGP755H270.f3d).