### PR TITLE
docs: Icon documentation add color props in Readme.md

### DIFF
--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -7,12 +7,12 @@ You can import individual icons to render on your app.
 import { Assets24 } from "@hig/icons";
 
 const MyComponent = () => (
-    <div className="my-class">
-        <Assets24 />
-    </div>
+  <div className="my-class">
+    <Assets24 color="#fff" />
+  </div>
 );
 
-export default MyComponent
+export default MyComponent;
 ```
 
 Read more about where and how to use icons on [the website](https://hig.autodesk.com/web/basics/icons).
@@ -45,6 +45,6 @@ SVG source files for all icons are available in the `build/svg` subdirectory of 
 
 ## Styling
 
-Use the `className` prop to pass in a css class name to the outermost container of the component. The class name will also pass down to most of the other styled elements within the component. 
+Use the `className` prop to pass in a css class name to the outermost container of the component. The class name will also pass down to most of the other styled elements within the component.
 
 Icons can take a `color` prop that will accept any hex code, rgb, rgba, or color string that can change the default color. Icons also has a `stylesheet` prop that accepts a function wherein you can modify its styles.


### PR DESCRIPTION
This issue affects Icon related to documentation in Readme.md
Issue: https://github.com/Autodesk/hig/issues/2228