### PR TITLE
fix: not passing events onMouseEnter & onMouseLeave

### DIFF
--- a/packages/flyout/src/Flyout.js
+++ b/packages/flyout/src/Flyout.js
@@ -194,15 +194,21 @@ export default class Flyout extends Component {
   }
 
   handleChildMouseEnter = () => {
+    const { props } = this.props.children;
     if (this.props.openOnHover) {
       this.setOpen(true);
+      return props.onMouseEnter();
     }
+    return null;
   };
 
   handleChildMouseLeave = () => {
+    const { props } = this.props.children;
     if (this.props.openOnHover) {
       this.setOpen(false);
+      return props.onMouseLeave();
     }
+    return null;
   };
 
   handleChildClick = () => {


### PR DESCRIPTION
This issue affects to Icon Button related to passing events onMouseEnter , onMouseLeave from ControlBehavior

Issue: #2473