### PR TITLE
feat(dblClick): double click to expand or collapse tree item

### DIFF
--- a/packages/tree-view/src/TreeItem.js
+++ b/packages/tree-view/src/TreeItem.js
@@ -9,6 +9,7 @@ const TreeItem = props => {
     children,
     collapsed,
     defaultCollapsed,
+    expandByDoubleClick,
     getKeyboardOpenId,
     icon,
     id,
@@ -24,11 +25,13 @@ const TreeItem = props => {
       {...otherProps}
       collapsed={collapsed}
       defaultCollapsed={defaultCollapsed}
+      expandByDoubleClick={expandByDoubleClick}
       id={id}
     >
       {({
         getIsCollapsed,
         handleClick,
+        handleDoubleClick,
         handleOperatorClick,
         setIsCollapsed
       }) => (
@@ -43,6 +46,7 @@ const TreeItem = props => {
           keyboardOpenId={getKeyboardOpenId()}
           label={label}
           onClick={handleClick}
+          onDoubleClick={handleDoubleClick}
           onFocus={onFocus}
           onOperatorClick={handleOperatorClick}
           selected={getCurrentItemClicked() === id}
@@ -74,6 +78,10 @@ TreeItem.propTypes = {
    */
   defaultCollapsed: PropTypes.bool,
   /**
+   * Double click to expand or collapse tree item
+   */
+  expandByDoubleClick: PropTypes.bool,
+  /**
    * Presentational icon
    */
   icon: PropTypes.node,
@@ -92,7 +100,8 @@ TreeItem.propTypes = {
 };
 
 TreeItem.defaultProps = {
-  defaultCollapsed: true
+  defaultCollapsed: true,
+  expandByDoubleClick: false
 };
 
 export default TreeItem;

--- a/packages/tree-view/src/TreeView.js
+++ b/packages/tree-view/src/TreeView.js
@@ -108,10 +108,11 @@ TreeView.propTypes = {
       id: PropTypes.number,
       parentId: PropTypes.number,
       meta: PropTypes.shape({
-        label: PropTypes.node,
-        collapsed: PropTypes.bool,
         active: PropTypes.bool,
-        icon: PropTypes.node
+        collapsed: PropTypes.bool,
+        expandByDoubleClick: PropTypes.bool,
+        icon: PropTypes.node,
+        label: PropTypes.node
       })
     })
   )

--- a/packages/tree-view/src/__fixtures__/sampleTreeNodeObject.js
+++ b/packages/tree-view/src/__fixtures__/sampleTreeNodeObject.js
@@ -14,9 +14,10 @@ const sampleTreeNodeObject = [
     id: 1,
     parentId: null,
     meta: {
-      label: "Tree Item 1",
+      label: "dbl click to expand/collapse",
       collapsed: false,
       active: false,
+      expandByDoubleClick: true,
       icon: <Report24 />
     },
     draggable: true,

--- a/packages/tree-view/src/__snapshots__/TreeView.test.js.snap
+++ b/packages/tree-view/src/__snapshots__/TreeView.test.js.snap
@@ -101,6 +101,7 @@ exports[`tree-view/TreeView renders default TreeView 1`] = `
   className="emotion-4"
   id="tree-item-18"
   onClick={[Function]}
+  onDoubleClick={[Function]}
   onFocus={[Function]}
   onKeyDown={[Function]}
   onMouseEnter={[Function]}

--- a/packages/tree-view/src/__stories__/stories.js
+++ b/packages/tree-view/src/__stories__/stories.js
@@ -307,5 +307,97 @@ export default [
       indicator: "caret",
       treeNode: sampleTreeNodeObject
     })
+  },
+  {
+    description: "expand tree by double click",
+    getProps: () => ({
+      guidelines: false,
+      indicator: "caret",
+      children: [
+        <TreeItem
+          id="tree-item-0"
+          key="tree-item-0"
+          label="Tree Item 0"
+          icon={<Hierarchy24 />}
+          expandByDoubleClick="true"
+          draggable="true"
+        >
+          <TreeItem
+            label="Tree Item 1"
+            id="tree-item-1"
+            key="tree-item-1"
+            icon={<Calendar24 />}
+            expandByDoubleClick="true"
+          >
+            <TreeItem
+              label="Tree Item 2"
+              id="tree-item-2"
+              key="tree-item-2"
+              icon={<Folder24 />}
+              expandByDoubleClick="true"
+            >
+              <TreeItem
+                label="Tree Item 3"
+                id="tree-item-3"
+                key="tree-item-3"
+                icon={<ProductsAndServices24 />}
+                expandByDoubleClick="true"
+              >
+                <TreeItem
+                  label="Tree Item 4"
+                  id="tree-item-4"
+                  key="tree-item-4"
+                  icon={<AddFolder24 />}
+                />
+                <TreeItem
+                  label="Tree Item 5"
+                  id="tree-item-5"
+                  key="tree-item-5"
+                  icon={<Report24 />}
+                />
+                <TreeItem
+                  label="Tree Item 6"
+                  id="tree-item-6"
+                  key="tree-item-6"
+                  icon={<ProductsAndServices24 />}
+                />
+              </TreeItem>
+              <TreeItem
+                label="Tree Item 7"
+                id="tree-item-7"
+                key="tree-item-7"
+                icon={<Calendar24 />}
+              />
+              <TreeItem
+                label="Tree Item 8"
+                id="tree-item-8"
+                key="tree-item-8"
+                icon={<Report24 />}
+              />
+              <TreeItem
+                label={
+                  <div>
+                    <strong>Tree</strong>
+                    <em>Item 9</em>
+                  </div>
+                }
+                id="tree-item-9"
+                key="tree-item-9"
+              />
+              <TreeItem
+                label="Tree Item 10"
+                id="tree-item-10"
+                key="tree-item-10"
+              />
+              <TreeItem
+                label="Tree Item 11"
+                id="tree-item-11"
+                key="tree-item-11"
+              />
+            </TreeItem>
+          </TreeItem>
+        </TreeItem>
+      ]
+    })
   }
 ];

--- a/packages/tree-view/src/behaviors/TreeItemBehavior.js
+++ b/packages/tree-view/src/behaviors/TreeItemBehavior.js
@@ -57,9 +57,20 @@ const TreeItemBehavior = props => {
     }
   };
 
+  const handleDoubleClick = event => {
+    if (props.onDoubleClick) {
+      props.onDoubleClick(event);
+    }
+
+    if (props.expandByDoubleClick) {
+      setIsCollapsedHook(!getIsCollapsed());
+    }
+  };
+
   return props.children({
     getIsCollapsed,
     handleClick,
+    handleDoubleClick,
     handleOperatorClick,
     setIsCollapsed
   });
@@ -71,9 +82,11 @@ TreeItemBehavior.propTypes = {
   children: PropTypes.func,
   collapsed: PropTypes.bool,
   defaultCollapsed: PropTypes.bool,
+  expandByDoubleClick: PropTypes.bool,
   getTreeItemArray: PropTypes.func,
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   onClick: PropTypes.func,
+  onDoubleClick: PropTypes.func,
   setActiveTreeItemId: PropTypes.func,
   setActiveTreeItemIndex: PropTypes.func,
   payload: PropTypes.shape({

--- a/packages/tree-view/src/behaviors/TreeItemBehavior.test.js
+++ b/packages/tree-view/src/behaviors/TreeItemBehavior.test.js
@@ -1,0 +1,62 @@
+/* eslint-disable */
+import React from "react";
+import { mount } from "enzyme";
+
+import TreeItemBehavior from "./TreeItemBehavior";
+
+describe("tree-view/TreeItemBehavior", () => {
+  const setState = jest.fn();
+  const useStateMock = initState => [initState, setState];
+
+  jest.spyOn(React, "useState").mockImplementation(useStateMock);
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  it("double click to unwrap tree item", () => {
+    const props = {
+      defaultCollapsed: true,
+      expandByDoubleClick: true,
+      getTreeItemArray: jest.fn(),
+      setActiveTreeItemId: jest.fn(),
+      setActiveTreeItemIndex: jest.fn()
+    };
+    const wrapper = mount(
+      <TreeItemBehavior {...props}>
+        {({ handleClick, handleDoubleClick }) => (
+          <div onClick={handleClick} onDoubleClick={handleDoubleClick}>
+            {"test"}
+          </div>
+        )}
+      </TreeItemBehavior>
+    );
+    const child = wrapper.find("div");
+    expect(child).toHaveLength(1);
+
+    child.simulate("doubleClick");
+    expect(setState).toBeCalledWith(false);
+  });
+
+  it("double click to wrap tree item", () => {
+    const props = {
+      defaultCollapsed: false,
+      expandByDoubleClick: true,
+      getTreeItemArray: jest.fn(),
+      setActiveTreeItemId: jest.fn(),
+      setActiveTreeItemIndex: jest.fn()
+    };
+    const wrapper = mount(
+      <TreeItemBehavior {...props}>
+        {({ handleClick, handleDoubleClick }) => (
+          <div onClick={handleClick} onDoubleClick={handleDoubleClick}>
+            {"test"}
+          </div>
+        )}
+      </TreeItemBehavior>
+    );
+    const child = wrapper.find("div");
+
+    child.simulate("doubleClick");
+    expect(setState).toBeCalledWith(true);
+  });
+});

--- a/packages/tree-view/src/behaviors/TreeViewBehavior.js
+++ b/packages/tree-view/src/behaviors/TreeViewBehavior.js
@@ -194,10 +194,11 @@ TreeViewBehavior.propTypes = {
       id: PropTypes.number,
       parentId: PropTypes.number,
       meta: PropTypes.shape({
-        label: PropTypes.node,
-        collapsed: PropTypes.bool,
         active: PropTypes.bool,
-        icon: PropTypes.node
+        collapsed: PropTypes.bool,
+        expandByDoubleClick: PropTypes.bool,
+        icon: PropTypes.node,
+        label: PropTypes.node
       })
     })
   ),

--- a/packages/tree-view/src/presenters/fileview/TreeObjectNestedSubTreeItem.js
+++ b/packages/tree-view/src/presenters/fileview/TreeObjectNestedSubTreeItem.js
@@ -14,7 +14,7 @@ const TreeObjectNestedSubTreeItem = props => {
     treeItem: {
       children,
       id,
-      meta: { className, icon, label },
+      meta: { className, icon, label, expandByDoubleClick },
       payload: {
         indicator,
         getActiveTreeItemId,
@@ -23,6 +23,7 @@ const TreeObjectNestedSubTreeItem = props => {
         guidelines
       },
       onClick: userOnClick,
+      onDoubleClick: userOnDoubleClick,
       ...otherTreeItemProps
     },
     collapsed,
@@ -131,6 +132,14 @@ const TreeObjectNestedSubTreeItem = props => {
               onClick={event => {
                 if (userOnClick) {
                   userOnClick(event);
+                }
+              }}
+              onDoubleClick={event => {
+                if (userOnDoubleClick) {
+                  userOnDoubleClick(event);
+                }
+                if (expandByDoubleClick) {
+                  handleOperatorClick(event, treeItem);
                 }
               }}
             >

--- a/packages/tree-view/src/presenters/fileview/TreeObjectNestedSubTreeItem.test.js
+++ b/packages/tree-view/src/presenters/fileview/TreeObjectNestedSubTreeItem.test.js
@@ -1,0 +1,31 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { Report24 } from "@hig/icons";
+
+import TreeObjectView from "./TreeObjectView";
+
+describe("tree-view/TreeObjectNestedSubTreeItem", () => {
+  it("renders tree with tree node", () => {
+    const sampleTreeNodeObject = {
+      id: 1,
+      parentId: null,
+      meta: {
+        label: "Tree Item 1",
+        collapsed: false,
+        active: false,
+        expandByDoubleClick: true,
+        icon: <Report24 />
+      },
+      payload: {
+        getActiveTreeItemId: () => {},
+        getKeyboardOpenId: () => {},
+        setKeyboardOpenId: () => {},
+        getCurrentItemClicked: () => {}
+      }
+    };
+
+    const wrapper = <TreeObjectView tree={sampleTreeNodeObject} />;
+    const tree = renderer.create(wrapper);
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/tree-view/src/presenters/fileview/TreeObjectSubTreeItem.js
+++ b/packages/tree-view/src/presenters/fileview/TreeObjectSubTreeItem.js
@@ -141,10 +141,11 @@ TreeObjectSubTreeItem.propTypes = {
   treeItem: PropTypes.shape({
     id: PropTypes.number,
     meta: PropTypes.shape({
-      label: PropTypes.node,
-      collapsed: PropTypes.bool,
       active: PropTypes.bool,
-      icon: PropTypes.element
+      collapsed: PropTypes.bool,
+      expandByDoubleClick: PropTypes.bool,
+      icon: PropTypes.node,
+      label: PropTypes.node
     })
   }),
   keyboardOpenId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),

--- a/packages/tree-view/src/presenters/fileview/__snapshots__/TreeObjectNestedSubTreeItem.test.js.snap
+++ b/packages/tree-view/src/presenters/fileview/__snapshots__/TreeObjectNestedSubTreeItem.test.js.snap
@@ -1,0 +1,137 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`tree-view/TreeObjectNestedSubTreeItem renders tree with tree node 1`] = `
+.emotion-4 {
+  border: 1px solid transparent;
+  box-sizing: border-box;
+  height: 40px;
+  padding: 8px 12px 8px calc((24px + 8px) + ((24px + 8px) * 0));
+  position: relative;
+  -webkit-transition: background-color 0.3s cubic-bezier(0.4,0,0.2,1),border-color 0.3s cubic-bezier(0.4,0,0.2,1);
+  transition: background-color 0.3s cubic-bezier(0.4,0,0.2,1),border-color 0.3s cubic-bezier(0.4,0,0.2,1);
+}
+
+.emotion-4::before {
+  display: inline-block;
+  content: "";
+  left: calc((24px * 0) + (8px * -1));
+  margin: 0;
+  position: absolute;
+  top: 9px;
+  -webkit-transform: translateY(10px);
+  -ms-transform: translateY(10px);
+  transform: translateY(10px);
+  width: 42px;
+}
+
+.emotion-4::after {
+  display: inline-block;
+  content: "";
+  height: 100%;
+  left: calc(24px + ((24px + 8px) * -1) - 1px);
+  position: absolute;
+  top: 0;
+  width: 20px;
+}
+
+.emotion-4:first-of-type::after {
+  top: -10px;
+  height: calc(100% + 10px);
+}
+
+.emotion-4:last-child::after {
+  top: -9px;
+  height: 24px;
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 0 12px;
+  width: calc(100% - 12px);
+}
+
+.emotion-3 > svg {
+  margin-right: 8px;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 0 0 24px;
+  -ms-flex: 0 0 24px;
+  flex: 0 0 24px;
+  height: 24px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: 8px;
+  width: 24px;
+}
+
+.emotion-2 {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.emotion-0 {
+  fill: #808080;
+}
+
+.emotion-0 > * {
+  fill: #808080;
+}
+
+<li
+  className="emotion-4"
+  id={1}
+  onClick={[Function]}
+  onKeyDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  role="treeitem"
+>
+  <div
+    className="emotion-3"
+  >
+    <div
+      className="emotion-1"
+    >
+      <svg
+        className="emotion-0"
+        height="24px"
+        viewBox="0 0 24 24"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M3 2v20h17V2zm16 19H4V3h15z"
+        />
+        <path
+          d="M18 19h-1v-7h-3v7h-1v-5h-3v5H9v-9H6v9H5v1h13zM8 19H7v-8h1zm4 0h-1v-4h1zm4 0h-1v-6h1zM5 5h13v1H5zm0 2h6v1H5z"
+        />
+      </svg>
+    </div>
+    <span
+      className="emotion-2"
+    >
+      Tree Item 1
+    </span>
+  </div>
+</li>
+`;

--- a/packages/tree-view/src/presenters/fileview/__snapshots__/TreeObjectView.test.js.snap
+++ b/packages/tree-view/src/presenters/fileview/__snapshots__/TreeObjectView.test.js.snap
@@ -382,6 +382,7 @@ exports[`tree-view/TreeObjectView takes a treeNodeObject 1`] = `
   <div
     className="emotion-6"
     onClick={[Function]}
+    onDoubleClick={[Function]}
   >
     <div
       className="emotion-5"
@@ -452,6 +453,7 @@ exports[`tree-view/TreeObjectView takes a treeNodeObject 1`] = `
         <div
           className="emotion-13"
           onClick={[Function]}
+          onDoubleClick={[Function]}
         >
           <div
             className="emotion-5"
@@ -590,6 +592,7 @@ exports[`tree-view/TreeObjectView takes a treeNodeObject 1`] = `
               <div
                 className="emotion-30"
                 onClick={[Function]}
+                onDoubleClick={[Function]}
               >
                 <div
                   className="emotion-5"


### PR DESCRIPTION
The function is quite the same as clicking on the operator icon, but easier to operate for end users. 
- Add property `expandByDoubleClick` to component `TreeItem` as an optional one and default value is false.
- Add meta property `expandByDoubleClick` to tree node object.
- Add a new storybook entry of treeview to present the function.

A video to show the function:
https://user-images.githubusercontent.com/37433962/150101817-969e2d95-3236-4fd2-8a9f-85b5398ea2e2.mp4


