### PR TITLE
fix: set transform on menu header to correct value

### DIFF
--- a/packages/menu/src/__snapshots__/Option.test.js.snap
+++ b/packages/menu/src/__snapshots__/Option.test.js.snap
@@ -563,7 +563,7 @@ exports[`menu/Option renders Menu and Options with Headers 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  color: #3c3c3c;
+  color: rgba(60,60,60,0.5);
   font-size: 12px;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/packages/theme-data/src/baseTheme/components/menu.js
+++ b/packages/theme-data/src/baseTheme/components/menu.js
@@ -67,6 +67,9 @@ export default {
     type: COLOR,
     value: {
       ref: "colorScheme.text.default"
+    },
+    transform: {
+      alpha: 0.5
     }
   },
   "menu.header.marginBottom": {


### PR DESCRIPTION
Added .5 transform to menu.header.fontColor role to match what's in the Figma files

![image](https://user-images.githubusercontent.com/30737037/150401750-b94a2d72-516a-40ca-863a-27f0b319366e.png)
