### PR TITLE
feat(HOC): TreeView can contain high order component of TreeItem

### DIFF
--- a/packages/tree-view/src/TreeItem.test.js
+++ b/packages/tree-view/src/TreeItem.test.js
@@ -1,0 +1,58 @@
+/* eslint-disable */
+import React from "react";
+import { mount } from "enzyme";
+
+import TreeItem from "./TreeItem";
+import TreeView from "./TreeView";
+
+class HocTreeItem extends React.Component {
+  render() {
+    return <TreeItem {...this.props}>{this.props.children}</TreeItem>;
+  }
+}
+
+const FuncTreeItem = props => {
+  return (
+    <TreeItem {...props}>{props.children}</TreeItem>
+  );
+};
+
+describe("tree-view/TreeItem", () => {
+  it("support high order component", () => {
+    const wrapper = mount(<TreeView>
+        <HocTreeItem id="tree-item-1" key="tree-item-1" label="Hoc Tree Item" />
+      </TreeView>);
+
+    const item = wrapper.find("TreeItem");
+    expect(item).toHaveLength(1);
+    expect(item.at(0).props().id).toEqual("tree-item-1");
+    expect(item.at(0).props().label).toEqual("Hoc Tree Item");
+  });
+
+  it("support function component", () => {
+    const wrapper = mount(<TreeView>
+        <FuncTreeItem id="tree-item-1" key="tree-item-1" label="Func Tree Item" />
+      </TreeView>);
+
+    const item = wrapper.find("TreeItem");
+    expect(item).toHaveLength(1);
+    expect(item.at(0).props().id).toEqual("tree-item-1");
+    expect(item.at(0).props().label).toEqual("Func Tree Item");
+  });
+
+  it("multi and nested items", () => {
+    const wrapper = mount(<TreeView>
+        <FuncTreeItem id="tree-item-0" key="tree-item-0" label="Func Tree Item" defaultCollapsed={false}>
+          <FuncTreeItem id="tree-item-1" key="tree-item-1" label="Func Tree Item" />
+          <FuncTreeItem id="tree-item-2" key="tree-item-2" label="Func Tree Item" defaultCollapsed={false}>
+            <FuncTreeItem id="tree-item-21" key="tree-item-21" label="Func Tree Item" />
+          </FuncTreeItem>
+          <FuncTreeItem id="tree-item-3" key="tree-item-3" label="Func Tree Item" />
+        </FuncTreeItem>
+        <FuncTreeItem id="tree-item-4" key="tree-item-4" label="Func Tree Item" />
+      </TreeView>);
+
+    const items = wrapper.find("TreeItem");
+    expect(items.length).toEqual(6);
+  });
+});

--- a/packages/tree-view/src/__snapshots__/TreeView.test.js.snap
+++ b/packages/tree-view/src/__snapshots__/TreeView.test.js.snap
@@ -1,17 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`tree-view/TreeView renders default TreeView 1`] = `
-.emotion-4 {
-  border: 1px solid transparent;
-  box-sizing: border-box;
-  height: 40px;
-  padding: 8px 12px 8px calc((24px + 8px) + ((24px + 8px) * undefined));
+.emotion-8 {
+  margin: 0;
+  padding: 0;
   position: relative;
-  -webkit-transition: background-color 0.3s cubic-bezier(0.4,0,0.2,1),border-color 0.3s cubic-bezier(0.4,0,0.2,1);
-  transition: background-color 0.3s cubic-bezier(0.4,0,0.2,1),border-color 0.3s cubic-bezier(0.4,0,0.2,1);
 }
 
-.emotion-4::before {
+.emotion-8::before {
   display: inline-block;
   content: "";
   left: calc((24px * NaN) + (8px * NaN));
@@ -21,30 +17,44 @@ exports[`tree-view/TreeView renders default TreeView 1`] = `
   -webkit-transform: translateY(10px);
   -ms-transform: translateY(10px);
   transform: translateY(10px);
-  width: 42px;
+  width: 20px;
 }
 
-.emotion-4::after {
+.emotion-8::after {
   display: inline-block;
   content: "";
   height: 100%;
-  left: calc(24px + ((24px + 8px) * NaN) - 1px);
+  left: calc(24px + ((24px + 8px) * NaN) - 0px);
   position: absolute;
   top: 0;
   width: 20px;
 }
 
-.emotion-4:first-of-type::after {
+.emotion-8:first-of-type::after {
   top: -10px;
   height: calc(100% + 10px);
 }
 
-.emotion-4:last-child::after {
+.emotion-8:last-child::after {
   top: -9px;
   height: 24px;
 }
 
-.emotion-3 {
+.emotion-6 {
+  border: 1px solid transparent;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 40px;
+  line-height: 1.428571429;
+  padding: 8px 12px 8px calc((24px + 8px) * NaN);
+  -webkit-transition: background-color 0.3s cubic-bezier(0.4,0,0.2,1),border-color 0.3s cubic-bezier(0.4,0,0.2,1);
+  transition: background-color 0.3s cubic-bezier(0.4,0,0.2,1),border-color 0.3s cubic-bezier(0.4,0,0.2,1);
+}
+
+.emotion-5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -57,11 +67,38 @@ exports[`tree-view/TreeView renders default TreeView 1`] = `
   width: calc(100% - 12px);
 }
 
-.emotion-3 > svg {
+.emotion-5 > svg {
   margin-right: 8px;
 }
 
+.emotion-5 > svg:first-of-type {
+  fill: #3c3c3c;
+}
+
 .emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 0 0 24px;
+  -ms-flex: 0 0 24px;
+  flex: 0 0 24px;
+  height: 24px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-right: 8px;
+  outline: 0;
+  width: 24px;
+}
+
+.emotion-3 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -82,7 +119,7 @@ exports[`tree-view/TreeView renders default TreeView 1`] = `
   width: 24px;
 }
 
-.emotion-2 {
+.emotion-4 {
   display: block;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -91,50 +128,103 @@ exports[`tree-view/TreeView renders default TreeView 1`] = `
 
 .emotion-0 {
   fill: #808080;
+  cursor: pointer;
+  -webkit-transition: -webkit-transform 0.3s ease-in-out;
+  -webkit-transition: transform 0.3s ease-in-out;
+  transition: transform 0.3s ease-in-out;
 }
 
 .emotion-0 > * {
   fill: #808080;
 }
 
+.emotion-2 {
+  fill: #808080;
+}
+
+.emotion-2 > * {
+  fill: #808080;
+}
+
+.emotion-7 {
+  -webkit-transition-property: height;
+  transition-property: height;
+  -webkit-transition-duration: .3s;
+  transition-duration: .3s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  height: 0;
+  overflow: hidden;
+  visibility: hidden;
+}
+
 <li
-  className="emotion-4"
+  aria-expanded={false}
+  className="emotion-8"
   id="tree-item-18"
-  onClick={[Function]}
-  onDoubleClick={[Function]}
-  onFocus={[Function]}
-  onKeyDown={[Function]}
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
   role="treeitem"
-  selected={false}
 >
   <div
-    className="emotion-3"
+    className="emotion-6"
+    onClick={[Function]}
+    onDoubleClick={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    role="presentation"
+    selected={false}
   >
     <div
-      className="emotion-1"
+      className="emotion-5"
     >
-      <svg
-        className="emotion-0"
-        height="24px"
-        viewBox="0 0 24 24"
-        width="24px"
-        xmlns="http://www.w3.org/2000/svg"
+      <div
+        className="emotion-1"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="button"
+        tabIndex="-1"
       >
-        <path
-          d="M3 2v20h17V2zm16 19H4V3h15z"
-        />
-        <path
-          d="M18 19h-1v-7h-3v7h-1v-5h-3v5H9v-9H6v9H5v1h13zM8 19H7v-8h1zm4 0h-1v-4h1zm4 0h-1v-6h1zM5 5h13v1H5zm0 2h6v1H5z"
-        />
-      </svg>
+        <svg
+          className="emotion-0"
+          height="10px"
+          viewBox="0 0 10 10"
+          width="10px"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3.22 1.29a.75.75 0 0 0 0 1.06L5.87 5 3.22 7.65a.75.75 0 0 0 0 1.06.74.74 0 0 0 1.06 0l3.36-3.36a.5.5 0 0 0 0-.7L4.28 1.29a.74.74 0 0 0-1.06 0z"
+          />
+        </svg>
+      </div>
+      <div
+        className="emotion-3"
+      >
+        <svg
+          className="emotion-2"
+          height="24px"
+          viewBox="0 0 24 24"
+          width="24px"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 2v20h17V2zm16 19H4V3h15z"
+          />
+          <path
+            d="M18 19h-1v-7h-3v7h-1v-5h-3v5H9v-9H6v9H5v1h13zM8 19H7v-8h1zm4 0h-1v-4h1zm4 0h-1v-6h1zM5 5h13v1H5zm0 2h6v1H5z"
+          />
+        </svg>
+      </div>
+      <span
+        className="emotion-4"
+      >
+        Tree Item 18
+      </span>
     </div>
-    <span
-      className="emotion-2"
-    >
-      Tree Item 18
-    </span>
   </div>
+  <div
+    className="emotion-7"
+    onTransitionEnd={[Function]}
+  />
 </li>
 `;

--- a/packages/tree-view/src/__stories__/stories.js
+++ b/packages/tree-view/src/__stories__/stories.js
@@ -1,4 +1,6 @@
 import React from "react";
+import PropTypes from "prop-types";
+
 import {
   AddFolder24,
   Folder24,
@@ -20,6 +22,30 @@ import {
 
 import { TreeItem } from "../index";
 import sampleTreeNodeObject from "../__fixtures__/sampleTreeNodeObject";
+
+// test that the TreeView can render a high-order TreeItem component or a function TreeItem component
+export class HighOrderComponentWrappedTreeItem extends React.Component {
+  render() {
+    return <TreeItem {...this.props}>{this.props.children}</TreeItem>;
+  }
+}
+HighOrderComponentWrappedTreeItem.propTypes = {
+  /**
+   * Accepts other high order TreeItem components
+   */
+  children: PropTypes.node
+};
+
+export const FunctionComponentWrappedTreeItem = props => (
+  <TreeItem {...props}>{props.children}</TreeItem>
+);
+FunctionComponentWrappedTreeItem.defaultName = "FuncTreeItem";
+FunctionComponentWrappedTreeItem.propTypes = {
+  /**
+   * Accepts other Function TreeItem components
+   */
+  children: PropTypes.node
+};
 
 export default [
   {
@@ -306,6 +332,83 @@ export default [
       guidelines: false,
       indicator: "caret",
       treeNode: sampleTreeNodeObject
+    })
+  },
+  {
+    description: "high order TreeItem",
+    getProps: () => ({
+      guidelines: false,
+      indicator: "caret",
+      children: [
+        <FunctionComponentWrappedTreeItem
+          id="tree-item-1"
+          key="tree-item-1"
+          label="Func Tree Item"
+          icon={<ProductsAndServices16 />}
+          expandByDoubleClick="true"
+        >
+          <FunctionComponentWrappedTreeItem
+            id="tree-item-2"
+            key="tree-item-2"
+            label="Func Tree Item"
+            icon={<ProductsAndServices16 />}
+            expandByDoubleClick="true"
+          >
+            <FunctionComponentWrappedTreeItem
+              label="Func Tree Item 3"
+              id="tree-item-3"
+              key="tree-item-3"
+              icon={<ProductsAndServices24 />}
+              expandByDoubleClick="true"
+            >
+              <FunctionComponentWrappedTreeItem
+                label="Func Tree Item 4"
+                id="tree-item-4"
+                key="tree-item-4"
+                icon={<AddFolder24 />}
+              />
+              <FunctionComponentWrappedTreeItem
+                label="Func Tree Item 5"
+                id="tree-item-5"
+                key="tree-item-5"
+                icon={<Report24 />}
+              />
+              <FunctionComponentWrappedTreeItem
+                label="Func Tree Item 6"
+                id="tree-item-6"
+                key="tree-item-6"
+                icon={<ProductsAndServices24 />}
+              />
+            </FunctionComponentWrappedTreeItem>
+          </FunctionComponentWrappedTreeItem>
+        </FunctionComponentWrappedTreeItem>,
+        <HighOrderComponentWrappedTreeItem
+          label="Hoc Tree Item 7"
+          id="tree-item-7"
+          key="tree-item-7"
+          icon={<ProductsAndServices24 />}
+          expandByDoubleClick="true"
+        >
+          <HighOrderComponentWrappedTreeItem
+            label="Hoc Tree Item 8"
+            id="tree-item-8"
+            key="tree-item-8"
+            icon={<AddFolder24 />}
+          />
+          <HighOrderComponentWrappedTreeItem
+            label="Hoc Tree Item 9"
+            id="tree-item-9"
+            key="tree-item-9"
+            icon={<Report24 />}
+          />
+          <HighOrderComponentWrappedTreeItem
+            label="Hoc Tree Item 10"
+            id="tree-item-10"
+            key="tree-item-10"
+            icon={<ProductsAndServices24 />}
+          />
+        </HighOrderComponentWrappedTreeItem>
+      ]
     })
   },
   {

--- a/packages/tree-view/src/presenters/SubTreeViewCombined.js
+++ b/packages/tree-view/src/presenters/SubTreeViewCombined.js
@@ -5,7 +5,6 @@ import { createCustomClassNames } from "@hig/utils";
 
 import TreeObjectNestedSubTreeItem from "./fileview/TreeObjectNestedSubTreeItem";
 import TreeObjectSubTreeItem from "./fileview/TreeObjectSubTreeItem";
-import TreeItem from "../TreeItem";
 import TreeItemBehavior from "../behaviors/TreeItemBehavior";
 
 import stylesheet from "./stylesheet";
@@ -304,15 +303,23 @@ const SubTreeViewCombined = props => {
               ])}
               role="group"
             >
-              {clonedChildren.map((child, index) => (
-                <TreeItem
-                  {...child.props}
-                  themeData={themeData}
-                  density={density}
-                  // eslint-disable-next-line react/no-array-index-key
-                  key={`${id}-${index}`}
-                />
-              ))}
+              {clonedChildren.map((child, index) => {
+                const { type: ComponentType } = child;
+                /*
+                  this is different to TreeViewPresenter.js
+                  all the props has been extracted in the file above and passed to the child.props
+                  so, we don't need to extract and assign again
+                */
+                return (
+                  <ComponentType
+                    {...child.props}
+                    themeData={themeData}
+                    density={density}
+                    // eslint-disable-next-line react/no-array-index-key
+                    key={`${id}-${index}`}
+                  />
+                );
+              })}
             </ul>
           )}
         {(!collapsed || mount) &&

--- a/packages/tree-view/src/presenters/TreeItemPresenter.js
+++ b/packages/tree-view/src/presenters/TreeItemPresenter.js
@@ -2,7 +2,6 @@ import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import { ThemeContext } from "@hig/theme-context";
 
-import TreeItem from "../TreeItem";
 import SingleTreeNodePresenter from "./SingleTreeNodePresenter";
 import SingleTreeNodeFolderPresenter from "./SingleTreeNodeFolderPresenter";
 
@@ -24,10 +23,7 @@ const TreeItemPresenter = props => {
     return (
       <ThemeContext.Consumer>
         {({ resolvedRoles, metadata }) => {
-          if (
-            (children && children.type === TreeItem) ||
-            Array.isArray(children)
-          ) {
+          if (children || Array.isArray(children)) {
             return (
               <SingleTreeNodeFolderPresenter
                 {...props}

--- a/packages/tree-view/src/presenters/TreeViewPresenter.js
+++ b/packages/tree-view/src/presenters/TreeViewPresenter.js
@@ -5,7 +5,6 @@ import { ThemeContext } from "@hig/theme-context";
 import { createCustomClassNames } from "@hig/utils";
 
 import TreeObjectView from "./fileview/TreeObjectView";
-import TreeItem from "../TreeItem";
 
 import stylesheet from "./stylesheet";
 
@@ -15,9 +14,7 @@ function createTreeItems(children) {
   return Children.toArray(children).reduce((result, child) => {
     const { type, key, props = {} } = child;
 
-    if (type === TreeItem) {
-      result.push({ key, props });
-    }
+    result.push({ key, props, ComponentType: type });
 
     return result;
   }, []);
@@ -73,7 +70,7 @@ const TreeViewPresenterObject = props => {
   const getTreeItems = () => createTreeItems(props.children);
 
   // eslint-disable-next-line react/sort-comp
-  const renderTreeItem = ({ key, props: propsRef }) => {
+  const renderTreeItem = ({ key, props: propsRef, ComponentType }) => {
     const {
       getActiveTreeItemId,
       getActiveTreeItemIndex,
@@ -103,7 +100,11 @@ const TreeViewPresenterObject = props => {
       level: 0
     };
 
-    return <TreeItem {...payload} />;
+    /*
+      all the methods and properties have been extracted from props and passed to payload
+      and then render the ComponentType (e.g. TreeItem) with the payload
+    */
+    return <ComponentType {...payload} />;
   };
 
   const renderTreeItems = () => getTreeItems().map(renderTreeItem);


### PR DESCRIPTION
- @hig/tree-view can only accept a TreeItem as child(ren). This PR is to make it be able to accept a high order component or function component wrapped TreeItem. 
- add unit test and storybook
<img width="727" alt="HOC TreeItem" src="https://user-images.githubusercontent.com/2831220/151282134-4986adb9-ca3b-47c6-a859-f7bedf04f3af.png">

