### PR TITLE
fix: update number version of avatar dependencie of top-nav component. Issue HIG1-32

### DIFF
--- a/packages/top-nav/package.json
+++ b/packages/top-nav/package.json
@@ -17,7 +17,7 @@
     "build/*"
   ],
   "dependencies": {
-    "@hig/avatar": "2.0.0",
+    "@hig/avatar": "^2.1.0",
     "@hig/flyout": "^2.1.0",
     "@hig/icon-button": "^3.1.0",
     "@hig/icons": "^4.1.0",


### PR DESCRIPTION
There is a problem with the version number of the avatar component in the package.json of the tov-nav component. This is probably the source of the problems with theme-context, because the avatar component with version 2.0.0 works with theme-context 3.0.3. The current version of the theme-context is 4.1.0 and the avatar is 2.1.0. The version of create-react-context 0.3.0 has been the same in previous versions of theme-context.

https://jira.autodesk.com/browse/HIG1-32