### PR TITLE
refactor: updated the fonts files url. Issue HIG1-35

### DIFF
--- a/packages/fonts/src/ArtifaktElement.css
+++ b/packages/fonts/src/ArtifaktElement.css
@@ -1,33 +1,54 @@
 @font-face {
-    font-family: 'ArtifaktElement';
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Regular.eot'); /* IE9 Compat Modes */
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Regular.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF2/Artifakt%20Element%20Regular.woff2') format('woff2'), /* Super Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF/Artifakt%20Element%20Regular.woff') format('woff'), /* Pretty Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/TTF/Artifakt%20Element%20Regular.ttf')  format('truetype'); /* Safari, Android, iOS */
-    font-weight: normal;
-    font-style: normal;
-    font-display: swap;
+  font-family: "ArtifaktElement";
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Regular.eot"); /* IE9 Compat Modes */
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Regular.eot?#iefix")
+      format("embedded-opentype"),
+    /* IE6-IE8 */
+      url("https://fonts.autodesk.com/ArtifaktElement/WOFF2/Artifakt%20Element%20Regular.woff2")
+      format("woff2"),
+    /* Super Modern Browsers */
+      url("https://fonts.autodesk.com/ArtifaktElement/WOFF/Artifakt%20Element%20Regular.woff")
+      format("woff"),
+    /* Pretty Modern Browsers */
+      url("https://fonts.autodesk.com/ArtifaktElement/TTF/Artifakt%20Element%20Regular.ttf")
+      format("truetype"); /* Safari, Android, iOS */
+  font-weight: normal;
+  font-style: normal;
+  font-display: swap;
 }
 @font-face {
-    font-family: 'ArtifaktElement';
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Medium.eot'); /* IE9 Compat Modes */
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Medium.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF2/Artifakt%20Element%20Medium.woff2') format('woff2'), /* Super Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF/Artifakt%20Element%20Medium.woff') format('woff'), /* Pretty Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/TTF/Artifakt%20Element%20Medium.ttf')  format('truetype'); /* Safari, Android, iOS */
-    font-weight: 600;
-    font-style: normal;
-    font-display: swap;
+  font-family: "ArtifaktElement";
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Medium.eot"); /* IE9 Compat Modes */
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Medium.eot?#iefix")
+      format("embedded-opentype"),
+    /* IE6-IE8 */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/WOFF2/Artifakt%20Element%20Semi%20Bold.woff2")
+      format("woff2"),
+    /* Super Modern Browsers */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/WOFF/Artifakt%20Element%20Semi%20Bold.woff")
+      format("woff"),
+    /* Pretty Modern Browsers */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/TTF/Artifakt%20Element%20Semi%20Bold.ttf")
+      format("truetype"); /* Safari, Android, iOS */
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
 }
 @font-face {
-    font-family: 'ArtifaktElement';
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Bold.eot'); /* IE9 Compat Modes */
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Bold.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF2/Artifakt%20Element%20Bold.woff2') format('woff2'), /* Super Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF/Artifakt%20Element%20Bold.woff') format('woff'), /* Pretty Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/TTF/Artifakt%20Element%20Bold.ttf')  format('truetype'); /* Safari, Android, iOS */
-    font-weight: 700;
-    font-style: normal;
-    font-display: swap;
+  font-family: "ArtifaktElement";
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Bold.eot"); /* IE9 Compat Modes */
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Bold.eot?#iefix")
+      format("embedded-opentype"),
+    /* IE6-IE8 */
+      url("https://fonts.autodesk.com/ArtifaktElement/WOFF2/Artifakt%20Element%20Bold.woff2")
+      format("woff2"),
+    /* Super Modern Browsers */
+      url("https://fonts.autodesk.com/ArtifaktElement/WOFF/Artifakt%20Element%20Bold.woff")
+      format("woff"),
+    /* Pretty Modern Browsers */
+      url("https://fonts.autodesk.com/ArtifaktElement/TTF/Artifakt%20Element%20Bold.ttf")
+      format("truetype"); /* Safari, Android, iOS */
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
 }

--- a/packages/fonts/src/ArtifaktElement100.css
+++ b/packages/fonts/src/ArtifaktElement100.css
@@ -1,11 +1,18 @@
 @font-face {
-    font-family: 'ArtifaktElement';
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Hair.eot'); /* IE9 Compat Modes */
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Hair.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF2/Artifakt%20Element%20Hair.woff2') format('woff2'), /* Super Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF/Artifakt%20Element%20Hair.woff') format('woff'), /* Pretty Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/TTF/Artifakt%20Element%20Hair.ttf')  format('truetype'); /* Safari, Android, iOS */
-    font-weight: 100;
-    font-style: normal;
-    font-display: swap;
+  font-family: "ArtifaktElement";
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Hair.eot"); /* IE9 Compat Modes */
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Hair.eot?#iefix")
+      format("embedded-opentype"),
+    /* IE6-IE8 */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/WOFF2/Artifakt%20Element%20Thin.woff2")
+      format("woff2"),
+    /* Super Modern Browsers */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/WOFF/Artifakt%20Element%20Thin.woff")
+      format("woff"),
+    /* Pretty Modern Browsers */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/TTF/Artifakt%20Element%20Thin.ttf")
+      format("truetype"); /* Safari, Android, iOS */
+  font-weight: 100;
+  font-style: normal;
+  font-display: swap;
 }

--- a/packages/fonts/src/ArtifaktElement200.css
+++ b/packages/fonts/src/ArtifaktElement200.css
@@ -1,13 +1,17 @@
 @font-face {
-    font-family: 'ArtifaktElement';
-    src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Thin.eot");
-    /* IE9 Compat Modes */
-    src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Thin.eot?#iefix") format("embedded-opentype"),
-         url("https://fonts.autodesk.com/ArtifaktElement/WOFF2/Artifakt%20Element%20Thin.woff2") format("woff2"),
-         url("https://fonts.autodesk.com/ArtifaktElement/WOFF/Artifakt%20Element%20Thin.woff") format("woff"),
-         url("https://fonts.autodesk.com/ArtifaktElement/TTF/Artifakt%20Element%20Thin.ttf") format("truetype");
-    /* Safari, Android, iOS */
-    font-weight: 200;
-    font-style: normal; 
-    font-display: swap;
+  font-family: "ArtifaktElement";
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Thin.eot");
+  /* IE9 Compat Modes */
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Thin.eot?#iefix")
+      format("embedded-opentype"),
+    url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/WOFF2/Artifakt%20Element%20Extra%20Light.woff2")
+      format("woff2"),
+    url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/WOFF/Artifakt%20Element%20Extra%20Light.woff")
+      format("woff"),
+    url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/TTF/Artifakt%20Element%20Extra%20Light.ttf")
+      format("truetype");
+  /* Safari, Android, iOS */
+  font-weight: 200;
+  font-style: normal;
+  font-display: swap;
 }

--- a/packages/fonts/src/ArtifaktElement500.css
+++ b/packages/fonts/src/ArtifaktElement500.css
@@ -1,11 +1,18 @@
 @font-face {
-    font-family: 'ArtifaktElement';
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Book.eot'); /* IE9 Compat Modes */
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Book.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF2/Artifakt%20Element%20Book.woff2') format('woff2'), /* Super Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF/Artifakt%20Element%20Book.woff') format('woff'), /* Pretty Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/TTF/Artifakt%20Element%20Book.ttf')  format('truetype'); /* Safari, Android, iOS */
-    font-weight: 500;
-    font-style: normal;
-    font-display: swap;
+  font-family: "ArtifaktElement";
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Book.eot"); /* IE9 Compat Modes */
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Book.eot?#iefix")
+      format("embedded-opentype"),
+    /* IE6-IE8 */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/WOFF2/Artifakt%20Element%20Medium.woff2")
+      format("woff2"),
+    /* Super Modern Browsers */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/WOFF/Artifakt%20Element%20Medium.woff")
+      format("woff"),
+    /* Pretty Modern Browsers */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/TTF/Artifakt%20Element%20Medium.ttf")
+      format("truetype"); /* Safari, Android, iOS */
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
 }

--- a/packages/fonts/src/ArtifaktElement600.css
+++ b/packages/fonts/src/ArtifaktElement600.css
@@ -1,11 +1,18 @@
 @font-face {
-    font-family: 'ArtifaktElement';
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Medium.eot'); /* IE9 Compat Modes */
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Medium.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF2/Artifakt%20Element%20Medium.woff2') format('woff2'), /* Super Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF/Artifakt%20Element%20Medium.woff') format('woff'), /* Pretty Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/TTF/Artifakt%20Element%20Medium.ttf')  format('truetype'); /* Safari, Android, iOS */
-    font-weight: 600;
-    font-style: normal;
-    font-display: swap;
+  font-family: "ArtifaktElement";
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Medium.eot"); /* IE9 Compat Modes */
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Medium.eot?#iefix")
+      format("embedded-opentype"),
+    /* IE6-IE8 */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/WOFF2/Artifakt%20Element%20Semi%20Bold.woff2")
+      format("woff2"),
+    /* Super Modern Browsers */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/WOFF/Artifakt%20Element%20Semi%20Bold.woff")
+      format("woff"),
+    /* Pretty Modern Browsers */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/TTF/Artifakt%20Element%20Semi%20Bold.ttf")
+      format("truetype"); /* Safari, Android, iOS */
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
 }

--- a/packages/fonts/src/ArtifaktElement800.css
+++ b/packages/fonts/src/ArtifaktElement800.css
@@ -1,11 +1,18 @@
 @font-face {
-    font-family: 'ArtifaktElement';
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Black.eot'); /* IE9 Compat Modes */
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Black.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF2/Artifakt%20Element%20Black.woff2') format('woff2'), /* Super Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF/Artifakt%20Element%20Black.woff') format('woff'), /* Pretty Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/TTF/Artifakt%20Element%20Black.ttf')  format('truetype'); /* Safari, Android, iOS */
-    font-weight: 800;
-    font-style: normal;
-    font-display: swap;
+  font-family: "ArtifaktElement";
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Black.eot"); /* IE9 Compat Modes */
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Black.eot?#iefix")
+      format("embedded-opentype"),
+    /* IE6-IE8 */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/WOFF2/Artifakt%20Element%20Extra%20Bold.woff2")
+      format("woff2"),
+    /* Super Modern Browsers */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/WOFF/Artifakt%20Element%20Extra%20Bold.woff")
+      format("woff"),
+    /* Pretty Modern Browsers */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/TTF/Artifakt%20Element%20Extra%20Bold.ttf")
+      format("truetype"); /* Safari, Android, iOS */
+  font-weight: 800;
+  font-style: normal;
+  font-display: swap;
 }

--- a/packages/fonts/src/ArtifaktElement900.css
+++ b/packages/fonts/src/ArtifaktElement900.css
@@ -1,11 +1,18 @@
 @font-face {
-    font-family: 'ArtifaktElement';
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Heavy.eot'); /* IE9 Compat Modes */
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Heavy.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF2/Artifakt%20Element%20Heavy.woff2') format('woff2'), /* Super Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF/Artifakt%20Element%20Heavy.woff') format('woff'), /* Pretty Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/TTF/Artifakt%20Element%20Heavy.ttf')  format('truetype'); /* Safari, Android, iOS */
-    font-weight: 900;
-    font-style: normal;
-    font-display: swap;
+  font-family: "ArtifaktElement";
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Heavy.eot"); /* IE9 Compat Modes */
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Heavy.eot?#iefix")
+      format("embedded-opentype"),
+    /* IE6-IE8 */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/WOFF2/Artifakt%20Element%20Black.woff2")
+      format("woff2"),
+    /* Super Modern Browsers */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/WOFF/Artifakt%20Element%20Black.woff")
+      format("woff"),
+    /* Pretty Modern Browsers */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/TTF/Artifakt%20Element%20Black.ttf")
+      format("truetype"); /* Safari, Android, iOS */
+  font-weight: 900;
+  font-style: normal;
+  font-display: swap;
 }

--- a/packages/fonts/src/ArtifaktElementAll.css
+++ b/packages/fonts/src/ArtifaktElementAll.css
@@ -1,99 +1,162 @@
 @font-face {
-    font-family: 'ArtifaktElement';
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Hair.eot'); /* IE9 Compat Modes */
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Hair.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF2/Artifakt%20Element%20Hair.woff2') format('woff2'), /* Super Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF/Artifakt%20Element%20Hair.woff') format('woff'), /* Pretty Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/TTF/Artifakt%20Element%20Hair.ttf')  format('truetype'); /* Safari, Android, iOS */
-    font-weight: 100;
-    font-style: normal;
-    font-display: swap;
+  font-family: "ArtifaktElement";
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Hair.eot"); /* IE9 Compat Modes */
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Hair.eot?#iefix")
+      format("embedded-opentype"),
+    /* IE6-IE8 */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/WOFF2/Artifakt%20Element%20Thin.woff2")
+      format("woff2"),
+    /* Super Modern Browsers */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/WOFF/Artifakt%20Element%20Thin.woff")
+      format("woff"),
+    /* Pretty Modern Browsers */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/TTF/Artifakt%20Element%20Thin.ttf")
+      format("truetype"); /* Safari, Android, iOS */
+  font-weight: 100;
+  font-style: normal;
+  font-display: swap;
 }
 @font-face {
-    font-family: 'ArtifaktElement';
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Thin.eot'); /* IE9 Compat Modes */
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Thin.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF2/Artifakt%20Element%20Thin.woff2') format('woff2'), /* Super Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF/Artifakt%20Element%20Thin.woff') format('woff'), /* Pretty Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/TTF/Artifakt%20Element%20Thin.ttf')  format('truetype'); /* Safari, Android, iOS */
-    font-weight: 200;
-    font-style: normal;
-    font-display: swap;
+  font-family: "ArtifaktElement";
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Thin.eot"); /* IE9 Compat Modes */
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Thin.eot?#iefix")
+      format("embedded-opentype"),
+    /* IE6-IE8 */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/WOFF2/Artifakt%20Element%20Extra%20Light.woff2")
+      format("woff2"),
+    /* Super Modern Browsers */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/WOFF/Artifakt%20Element%20Extra%20Light.woff")
+      format("woff"),
+    /* Pretty Modern Browsers */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/TTF/Artifakt%20Element%20Extra%20Light.ttf")
+      format("truetype"); /* Safari, Android, iOS */
+  font-weight: 200;
+  font-style: normal;
+  font-display: swap;
 }
 @font-face {
-    font-family: 'ArtifaktElement';
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Light.eot'); /* IE9 Compat Modes */
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Light.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF2/Artifakt%20Element%20Light.woff2') format('woff2'), /* Super Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF/Artifakt%20Element%20Light.woff') format('woff'), /* Pretty Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/TTF/Artifakt%20Element%20Light.ttf')  format('truetype'); /* Safari, Android, iOS */
-    font-weight: 300;
-    font-style: normal;
-    font-display: swap;
+  font-family: "ArtifaktElement";
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Light.eot"); /* IE9 Compat Modes */
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Light.eot?#iefix")
+      format("embedded-opentype"),
+    /* IE6-IE8 */
+      url("https://fonts.autodesk.com/ArtifaktElement/WOFF2/Artifakt%20Element%20Light.woff2")
+      format("woff2"),
+    /* Super Modern Browsers */
+      url("https://fonts.autodesk.com/ArtifaktElement/WOFF/Artifakt%20Element%20Light.woff")
+      format("woff"),
+    /* Pretty Modern Browsers */
+      url("https://fonts.autodesk.com/ArtifaktElement/TTF/Artifakt%20Element%20Light.ttf")
+      format("truetype"); /* Safari, Android, iOS */
+  font-weight: 300;
+  font-style: normal;
+  font-display: swap;
 }
 @font-face {
-    font-family: 'ArtifaktElement';
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Regular.eot'); /* IE9 Compat Modes */
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Regular.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF2/Artifakt%20Element%20Regular.woff2') format('woff2'), /* Super Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF/Artifakt%20Element%20Regular.woff') format('woff'), /* Pretty Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/TTF/Artifakt%20Element%20Regular.ttf')  format('truetype'); /* Safari, Android, iOS */
-    font-weight: normal;
-    font-style: normal;
-    font-display: swap;
+  font-family: "ArtifaktElement";
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Regular.eot"); /* IE9 Compat Modes */
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Regular.eot?#iefix")
+      format("embedded-opentype"),
+    /* IE6-IE8 */
+      url("https://fonts.autodesk.com/ArtifaktElement/WOFF2/Artifakt%20Element%20Regular.woff2")
+      format("woff2"),
+    /* Super Modern Browsers */
+      url("https://fonts.autodesk.com/ArtifaktElement/WOFF/Artifakt%20Element%20Regular.woff")
+      format("woff"),
+    /* Pretty Modern Browsers */
+      url("https://fonts.autodesk.com/ArtifaktElement/TTF/Artifakt%20Element%20Regular.ttf")
+      format("truetype"); /* Safari, Android, iOS */
+  font-weight: normal;
+  font-style: normal;
+  font-display: swap;
 }
 @font-face {
-    font-family: 'ArtifaktElement';
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Book.eot'); /* IE9 Compat Modes */
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Book.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF2/Artifakt%20Element%20Book.woff2') format('woff2'), /* Super Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF/Artifakt%20Element%20Book.woff') format('woff'), /* Pretty Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/TTF/Artifakt%20Element%20Book.ttf')  format('truetype'); /* Safari, Android, iOS */
-    font-weight: 500;
-    font-style: normal;
-    font-display: swap;
+  font-family: "ArtifaktElement";
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Book.eot"); /* IE9 Compat Modes */
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Book.eot?#iefix")
+      format("embedded-opentype"),
+    /* IE6-IE8 */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/WOFF2/Artifakt%20Element%20Medium.woff2")
+      format("woff2"),
+    /* Super Modern Browsers */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/WOFF/Artifakt%20Element%20Medium.woff")
+      format("woff"),
+    /* Pretty Modern Browsers */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/TTF/Artifakt%20Element%20Medium.ttf")
+      format("truetype"); /* Safari, Android, iOS */
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
 }
 @font-face {
-    font-family: 'ArtifaktElement';
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Medium.eot'); /* IE9 Compat Modes */
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Medium.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF2/Artifakt%20Element%20Medium.woff2') format('woff2'), /* Super Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF/Artifakt%20Element%20Medium.woff') format('woff'), /* Pretty Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/TTF/Artifakt%20Element%20Medium.ttf')  format('truetype'); /* Safari, Android, iOS */
-    font-weight: 600;
-    font-style: normal;
-    font-display: swap;
+  font-family: "ArtifaktElement";
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Medium.eot"); /* IE9 Compat Modes */
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Medium.eot?#iefix")
+      format("embedded-opentype"),
+    /* IE6-IE8 */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/WOFF2/Artifakt%20Element%20Semi%20Bold.woff2")
+      format("woff2"),
+    /* Super Modern Browsers */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/WOFF/Artifakt%20Element%20Semi%20Bold.woff")
+      format("woff"),
+    /* Pretty Modern Browsers */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/TTF/Artifakt%20Element%20Semi%20Bold.ttf")
+      format("truetype"); /* Safari, Android, iOS */
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
 }
 @font-face {
-    font-family: 'ArtifaktElement';
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Bold.eot'); /* IE9 Compat Modes */
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Bold.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF2/Artifakt%20Element%20Bold.woff2') format('woff2'), /* Super Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF/Artifakt%20Element%20Bold.woff') format('woff'), /* Pretty Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/TTF/Artifakt%20Element%20Bold.ttf')  format('truetype'); /* Safari, Android, iOS */
-    font-weight: 700;
-    font-style: normal;
-    font-display: swap;
+  font-family: "ArtifaktElement";
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Bold.eot"); /* IE9 Compat Modes */
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Bold.eot?#iefix")
+      format("embedded-opentype"),
+    /* IE6-IE8 */
+      url("https://fonts.autodesk.com/ArtifaktElement/WOFF2/Artifakt%20Element%20Bold.woff2")
+      format("woff2"),
+    /* Super Modern Browsers */
+      url("https://fonts.autodesk.com/ArtifaktElement/WOFF/Artifakt%20Element%20Bold.woff")
+      format("woff"),
+    /* Pretty Modern Browsers */
+      url("https://fonts.autodesk.com/ArtifaktElement/TTF/Artifakt%20Element%20Bold.ttf")
+      format("truetype"); /* Safari, Android, iOS */
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
 }
 @font-face {
-    font-family: 'ArtifaktElement';
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Black.eot'); /* IE9 Compat Modes */
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Black.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF2/Artifakt%20Element%20Black.woff2') format('woff2'), /* Super Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF/Artifakt%20Element%20Black.woff') format('woff'), /* Pretty Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/TTF/Artifakt%20Element%20Black.ttf')  format('truetype'); /* Safari, Android, iOS */
-    font-weight: 800;
-    font-style: normal;
-    font-display: swap;
+  font-family: "ArtifaktElement";
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Black.eot"); /* IE9 Compat Modes */
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Black.eot?#iefix")
+      format("embedded-opentype"),
+    /* IE6-IE8 */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/WOFF2/Artifakt%20Element%20Extra%20Bold.woff2")
+      format("woff2"),
+    /* Super Modern Browsers */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/WOFF/Artifakt%20Element%20Extra%20Bold.woff")
+      format("woff"),
+    /* Pretty Modern Browsers */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/TTF/Artifakt%20Element%20Extra%20Bold.ttf")
+      format("truetype"); /* Safari, Android, iOS */
+  font-weight: 800;
+  font-style: normal;
+  font-display: swap;
 }
 @font-face {
-    font-family: 'ArtifaktElement';
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Heavy.eot'); /* IE9 Compat Modes */
-    src:url('https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Heavy.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF2/Artifakt%20Element%20Heavy.woff2') format('woff2'), /* Super Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/WOFF/Artifakt%20Element%20Heavy.woff') format('woff'), /* Pretty Modern Browsers */
-        url('https://fonts.autodesk.com/ArtifaktElement/TTF/Artifakt%20Element%20Heavy.ttf')  format('truetype'); /* Safari, Android, iOS */
-    font-weight: 900;
-    font-style: normal;
-    font-display: swap;
+  font-family: "ArtifaktElement";
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Heavy.eot"); /* IE9 Compat Modes */
+  src: url("https://fonts.autodesk.com/ArtifaktElement/EOT/Artifakt%20Element%20Heavy.eot?#iefix")
+      format("embedded-opentype"),
+    /* IE6-IE8 */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/WOFF2/Artifakt%20Element%20Black.woff2")
+      format("woff2"),
+    /* Super Modern Browsers */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/WOFF/Artifakt%20Element%20Black.woff")
+      format("woff"),
+    /* Pretty Modern Browsers */
+      url("https://swc.autodesk.com/pharmacopeia/fonts/ArtifaktElement/v1.0/TTF/Artifakt%20Element%20Black.ttf")
+      format("truetype"); /* Safari, Android, iOS */
+  font-weight: 900;
+  font-style: normal;
+  font-display: swap;
 }


### PR DESCRIPTION
The URLs for each of the fonts referenced in the update document have been updated.

https://wiki.autodesk.com/pages/viewpage.action?spaceKey=DPEE&title=Upgrading+to+updated+Artifakt+font+set.

In the table at the bottom of the wiki you will find the reference to the old and new link for each of the sources.

- Modified links are for font weight 100, 200, 500, 600, 800 and 900.
- No update links found for font weight 300, 400 and 700.

This ticket is related to the following: https://jira.autodesk.com/browse/DEVX-2678

https://jira.autodesk.com/secure/RapidBoard.jspa?rapidView=12750&view=detail&selectedIssue=HIG1-35