### PR TITLE
feat(TreeView): Make TreeItem support 'ref' property

### DIFF
--- a/packages/tree-view/src/TreeItem.js
+++ b/packages/tree-view/src/TreeItem.js
@@ -96,7 +96,14 @@ TreeItem.propTypes = {
   /**
    * Adds custom/overriding styles
    */
-  stylesheet: PropTypes.func
+  stylesheet: PropTypes.func,
+  /**
+   * Used to assign a ref object to the current tree item
+   */
+  itemRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.any })
+  ])
 };
 
 TreeItem.defaultProps = {

--- a/packages/tree-view/src/TreeItem.test.js
+++ b/packages/tree-view/src/TreeItem.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import React from "react";
+import React, { forwardRef, createRef } from "react";
 import { mount } from "enzyme";
 
 import TreeItem from "./TreeItem";
@@ -16,6 +16,14 @@ const FuncTreeItem = props => {
     <TreeItem {...props}>{props.children}</TreeItem>
   );
 };
+
+const RefTreeItem = forwardRef((props, ref) => {
+  return (
+    <TreeView>
+      <TreeItem itemRef={ref} id="tree-item-1" key="tree-item-1" label="Func Tree Item" />
+    </TreeView>
+  );
+});
 
 describe("tree-view/TreeItem", () => {
   it("support high order component", () => {
@@ -54,5 +62,19 @@ describe("tree-view/TreeItem", () => {
 
     const items = wrapper.find("TreeItem");
     expect(items.length).toEqual(6);
+  });
+
+  it("Ref TreeItem component", () => {
+    const itemRef = createRef();
+    const wrapper = mount(<RefTreeItem ref={itemRef}>
+      </RefTreeItem>);
+
+    const item = wrapper.find("TreeItem");
+    expect(item).toHaveLength(1);
+    expect(item.at(0).props().id).toEqual("tree-item-1");
+    expect(item.at(0).props().label).toEqual("Func Tree Item");
+    expect(itemRef).not.toBeNull();
+    expect(itemRef.current).not.toBeNull();
+    expect(itemRef.current.id).toEqual("tree-item-1");
   });
 });

--- a/packages/tree-view/src/TreeView.js
+++ b/packages/tree-view/src/TreeView.js
@@ -97,11 +97,10 @@ TreeView.propTypes = {
    */
   stylesheet: PropTypes.func,
   /**
-   * If treeNode prop is used it will render instead
-   * of children.
+   * If treeNode prop is used it will render instead of children.
    * Additional info can be passed into the meta property
-   * Additional HTML attributes can be added to the top
-   * level of and spread to the HTML elements
+   * Additional HTML attributes can be added to the top level of and spread to the HTML elements
+   * Assigning ref(s) to the treeNode is not supported, please use the children instead of treeNode if needed.
    */
   treeNode: PropTypes.arrayOf(
     PropTypes.shape({

--- a/packages/tree-view/src/presenters/SingleTreeNodeFolderPresenter.js
+++ b/packages/tree-view/src/presenters/SingleTreeNodeFolderPresenter.js
@@ -10,7 +10,15 @@ import IconIndicatorPresenter from "./IconIndicatorPresenter";
 import stylesheet from "./stylesheet";
 
 export default function SingleTreeNodeFolderPresenter(props) {
-  const { collapsed, icon, id, indicator, label, ...otherProps } = props;
+  const {
+    collapsed,
+    icon,
+    id,
+    indicator,
+    label,
+    itemRef,
+    ...otherProps
+  } = props;
   const {
     className,
     density,
@@ -97,6 +105,7 @@ export default function SingleTreeNodeFolderPresenter(props) {
               onMouseEnter={handleMouseEnter}
               onMouseLeave={handleMouseLeave}
               role="presentation"
+              ref={itemRef}
             >
               <div
                 className={cx([

--- a/packages/tree-view/src/presenters/SingleTreeNodePresenter.js
+++ b/packages/tree-view/src/presenters/SingleTreeNodePresenter.js
@@ -7,7 +7,7 @@ import { createButtonEventHandlers, createCustomClassNames } from "@hig/utils";
 import stylesheet from "./stylesheet";
 
 export default function SingleTreeNodePresenter(props) {
-  const { icon, id, label, ...otherProps } = props;
+  const { icon, id, label, itemRef, ...otherProps } = props;
   const {
     className,
     onClick,
@@ -73,6 +73,7 @@ export default function SingleTreeNodePresenter(props) {
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
             role="treeitem"
+            ref={itemRef}
           >
             <div
               className={cx([


### PR DESCRIPTION
- As the TreeItem is a function component, it can't support assigning a `ref` directly. In this change, a normal property named `itemRef` is used to forward and pass the ref object to the descendants HTML element of the TreeItem.
- update the unit test
- The screenshot is a sample of using a 3rd party component [react-dnd](https://github.com/react-dnd/react-dnd) which needs to assign a ref to the TreeItem to drag and drop.
- only support ref in the `children` render method. The TreeNode object render doesn't support ref now.

![TreeItem-ReactDnd](https://user-images.githubusercontent.com/2831220/152934632-5e064a26-d151-47b9-8cda-475a734413a1.gif)


