### PR TITLE
fix: Fixing a bug in numeric input component

### DIFF
--- a/packages/numeric-input/src/behaviors/SpinnerBehavior.js
+++ b/packages/numeric-input/src/behaviors/SpinnerBehavior.js
@@ -78,7 +78,7 @@ const SpinnerBehavior = props => {
 
   const onDirectChange = event => {
     const newValue = event.target.value;
-    setValueHook(newValue);
+    setValue(newValue);
   };
 
   const setInputRef = element => {


### PR DESCRIPTION
A user found a bug in the "numeric input" component, the "onChange" event fires when you click the up and down arrows of the component, but the event is not fired when you manually type a value, you can replicate the bug in the storybook using the ACTION LOGGER.

[Storybook - Numeric Input](http://storybook.hig.autodesk.com/?knob-Step=1&knob-Options=%5B%22HIG%20Light%20Theme%22%2C%22HIG%20Dark%20Blue%20Theme%22%2C%22Matrix%20Theme%22%5D&knob-Alignment=left&knob-Density=medium-density&knob-Font%20Weight=normal&knob-Required=&knob-Children=This%20should%20render%20nicely.&knob-Color%20scheme=hig-light-gray&knob-Value=&knob-Placeholder=Select%20a%20theme&knob-Label=Foo&selectedKind=Forms%7CNumericInput&selectedStory=default&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybook%2Factions%2Factions-panel)

It was found that inside the "SpinnerBehavior.js" file a wrong method was being called on line 81, that's what was causing the bug.