### PR TITLE
fix: margin bottom of the rich-text component deleted. Issue HIG1-34

### DIFF
--- a/packages/rich-text/src/stylesheet.js
+++ b/packages/rich-text/src/stylesheet.js
@@ -8,16 +8,13 @@ export default function stylesheet(props, themeData) {
       fontWeight: themeData[`typography.${variant}.fontWeight`],
       lineHeight: themeData[`typography.${variant}.lineHeight`],
       margin: margin || 0,
-      textAlign: "initial"
+      textAlign: "initial",
     };
   }
 
   const { stylesheet: customStylesheet } = props;
 
-  const baseStyles = typographyStyle(
-    "body",
-    `0 0 ${themeData["density.spacings.small"]} 0`
-  );
+  const baseStyles = typographyStyle("body", `0 0 0 0`);
 
   const listStyles = {
     "ul, ol": { paddingLeft: themeData["density.spacings.large"] },
@@ -29,15 +26,15 @@ export default function stylesheet(props, themeData) {
         verticalAlign: "middle",
         fontSize: themeData["density.fontSizes.large"],
         paddingRight: themeData["density.spacings.small"],
-        marginLeft: "-14px"
-      }
-    }
+        marginLeft: "-14px",
+      },
+    },
   };
 
   const headerStyles = {
     h1: typographyStyle("h1"),
     h2: typographyStyle("h2"),
-    h3: typographyStyle("h3")
+    h3: typographyStyle("h3"),
   };
 
   const anchorStyles = {
@@ -50,18 +47,18 @@ export default function stylesheet(props, themeData) {
       "&:hover": {
         color: themeData["textLink.primary.hover.fontColor"],
         textDecoration: "underline",
-        textDecorationColor: themeData["textLink.primary.hover.underlineColor"]
+        textDecorationColor: themeData["textLink.primary.hover.underlineColor"],
       },
 
       "&:focus": {
         color: themeData["textLink.primary.focus.fontColor"],
-        outline: `solid ${themeData["textLink.focus.haloWidth"]} ${themeData["textLink.focus.haloColor"]}`
-      }
-    }
+        outline: `solid ${themeData["textLink.focus.haloWidth"]} ${themeData["textLink.focus.haloColor"]}`,
+      },
+    },
   };
 
   const boldStyles = {
-    "b, strong": { fontWeight: themeData["basics.fontWeights.bold"] }
+    "b, strong": { fontWeight: themeData["basics.fontWeights.bold"] },
   };
 
   const paragraphStyles = {
@@ -69,7 +66,7 @@ export default function stylesheet(props, themeData) {
     "h1 + p, h2 + p, h3 + p": typographyStyle(
       "body",
       `${themeData["density.spacings.medium"]} 0 ${themeData["density.spacings.small"]} 0`
-    )
+    ),
   };
 
   const styles = {
@@ -79,8 +76,8 @@ export default function stylesheet(props, themeData) {
       ...headerStyles,
       ...anchorStyles,
       ...paragraphStyles,
-      ...boldStyles
-    }
+      ...boldStyles,
+    },
   };
 
   return customStylesheet ? customStylesheet(styles, props, themeData) : styles;


### PR DESCRIPTION
The bottom margin value in the rich-text component was set to 0 in the stylesheet file. 

PR repo: https://github.com/Autodesk/hig/issues/2468

PR board HIG 1.0: https://jira.autodesk.com/browse/HIG1-34

**Screenshots**

**Before:**

<img width="1791" alt="Screen Shot 2022-02-03 at 2 57 45 PM" src="https://user-images.githubusercontent.com/96445939/152421406-c2ff744e-f740-4714-bb6f-51122c779462.png">

**After:**

<img width="1788" alt="Screen Shot 2022-02-03 at 3 00 08 PM" src="https://user-images.githubusercontent.com/96445939/152421452-8afa03ae-d462-48fe-ad00-0f9780587e8d.png">
