### PR TITLE
fix: margin bottom of the rich-text component deleted. Issue HIG1-34

### DIFF
--- a/packages/rich-text/src/stylesheet.js
+++ b/packages/rich-text/src/stylesheet.js
@@ -14,10 +14,7 @@ export default function stylesheet(props, themeData) {
 
   const { stylesheet: customStylesheet } = props;
 
-  const baseStyles = typographyStyle(
-    "body",
-    `0 0 ${themeData["density.spacings.small"]} 0`
-  );
+  const baseStyles = typographyStyle("body",'0 0 0 0');
 
   const listStyles = {
     "ul, ol": { paddingLeft: themeData["density.spacings.large"] },


### PR DESCRIPTION
The bottom margin value in the rich-text component was set to 0 in the stylesheet file. 

PR repo: https://github.com/Autodesk/hig/issues/2468

PR board HIG 1.0: https://jira.autodesk.com/browse/HIG1-34

**Screenshots**

**Before:**

<img width="1791" alt="Screen Shot 2022-02-03 at 2 57 45 PM" src="https://user-images.githubusercontent.com/96445939/152421406-c2ff744e-f740-4714-bb6f-51122c779462.png">

**After:**

<img width="1788" alt="Screen Shot 2022-02-03 at 3 00 08 PM" src="https://user-images.githubusercontent.com/96445939/152421452-8afa03ae-d462-48fe-ad00-0f9780587e8d.png">
