### PR TITLE
fix: Fixing slider component bug, transparency in Firefox

### DIFF
--- a/packages/slider/src/presenters/stylesheet.js
+++ b/packages/slider/src/presenters/stylesheet.js
@@ -72,14 +72,10 @@ function stylesheet(props, themeData) {
 
     "&::-moz-focus-outer": {
       border: 0
-    }
-  };
+    },
 
-  const thumbDisabledRules = disabled
-    ? {
-        opacity: themeData["colorScheme.opacity.disabled"]
-      }
-    : {};
+    opacity: disabled ? themeData["colorScheme.opacity.disabled"] : "initial"
+  };
 
   const thumbStateRules = () => {
     const isInActiveState = Object.values(activeStates).every(
@@ -127,7 +123,7 @@ function stylesheet(props, themeData) {
     },
     {
       mozilla: {
-        ...thumbDisabledRules
+        // ...thumbDisabledRules
       },
       webkit: {
         transform: "translateY(-50%)"
@@ -152,9 +148,9 @@ function stylesheet(props, themeData) {
       border: "none",
       backgroundColor: themeData["slider.track.backgroundColor"],
       color: "transparent",
-      outline: "none",
+      outline: "none"
 
-      ...trackDisabledRules
+      // ...trackDisabledRules
     },
     {
       // WebKit does not have a built-in way to target the progress/lower fill of a slider track.
@@ -177,7 +173,7 @@ function stylesheet(props, themeData) {
     },
     {
       mozilla: {
-        ...trackDisabledRules
+        // ...trackDisabledRules
       }
     }
   );


### PR DESCRIPTION
[BUG] Slider is transparent when disabled in Firefox:

PR repo: https://github.com/Autodesk/hig/issues/2621

PR board HIG 1.0: https://jira.autodesk.com/browse/HIG1-39

![image](https://user-images.githubusercontent.com/99756319/161122892-2ca63f72-ab75-404d-ad0f-487988192022.png)

To fix it we moved the opacity from the pseudo-elements to the parent.

