### PR TITLE
fix: margin bottom of the rich-text component deleted

### DIFF
--- a/packages/notifications-flyout/src/__snapshots__/Notification.test.js.snap
+++ b/packages/notifications-flyout/src/__snapshots__/Notification.test.js.snap
@@ -29,7 +29,7 @@ exports[`notifications-flyout/Notification renders correctly with the featured p
   font-size: 14px;
   font-weight: 400;
   line-height: 1.428571429;
-  margin: 0 0 12px 0;
+  margin: 0;
   text-align: initial;
 }
 
@@ -306,7 +306,7 @@ exports[`notifications-flyout/Notification renders correctly with the unread pro
   font-size: 14px;
   font-weight: 400;
   line-height: 1.428571429;
-  margin: 0 0 12px 0;
+  margin: 0;
   text-align: initial;
 }
 

--- a/packages/notifications-flyout/src/__snapshots__/NotificationsFlyout.test.js.snap
+++ b/packages/notifications-flyout/src/__snapshots__/NotificationsFlyout.test.js.snap
@@ -220,7 +220,7 @@ exports[`notifications-flyout/NotificationsFlyout renders a notification with th
   font-size: 14px;
   font-weight: 400;
   line-height: 1.428571429;
-  margin: 0 0 12px 0;
+  margin: 0;
   text-align: initial;
 }
 

--- a/packages/notifications-flyout/src/__snapshots__/NotificationsFlyout.test.js.snap
+++ b/packages/notifications-flyout/src/__snapshots__/NotificationsFlyout.test.js.snap
@@ -692,7 +692,7 @@ exports[`notifications-flyout/NotificationsFlyout renders a notification with th
   font-size: 14px;
   font-weight: 400;
   line-height: 1.428571429;
-  margin: 0 0 12px 0;
+  margin: 0;
   text-align: initial;
 }
 
@@ -1117,7 +1117,7 @@ exports[`notifications-flyout/NotificationsFlyout renders with all props 1`] = `
   font-size: 14px;
   font-weight: 400;
   line-height: 1.428571429;
-  margin: 0 0 12px 0;
+  margin: 0;
   text-align: initial;
 }
 

--- a/packages/notifications-flyout/src/presenters/__snapshots__/NotificationPresenter.test.js.snap
+++ b/packages/notifications-flyout/src/presenters/__snapshots__/NotificationPresenter.test.js.snap
@@ -29,7 +29,7 @@ exports[`notifications-flyout/presenters/NotificationPresenter renders with all 
   font-size: 14px;
   font-weight: 400;
   line-height: 1.428571429;
-  margin: 0 0 12px 0;
+  margin: 0;
   text-align: initial;
 }
 
@@ -289,7 +289,7 @@ exports[`notifications-flyout/presenters/NotificationPresenter renders without p
   font-size: 14px;
   font-weight: 400;
   line-height: 1.428571429;
-  margin: 0 0 12px 0;
+  margin: 0;
   text-align: initial;
 }
 

--- a/packages/rich-text/src/__snapshots__/RichText.test.js.snap
+++ b/packages/rich-text/src/__snapshots__/RichText.test.js.snap
@@ -8,7 +8,7 @@ exports[`RichText renders 1`] = `
   font-size: 14px;
   font-weight: 400;
   line-height: 1.428571429;
-  margin: 0 0 12px 0;
+  margin: 0;
   text-align: initial;
 }
 
@@ -125,7 +125,7 @@ exports[`RichText renders with children 1`] = `
   font-size: 14px;
   font-weight: 400;
   line-height: 1.428571429;
-  margin: 0 0 12px 0;
+  margin: 0;
   text-align: initial;
 }
 
@@ -246,7 +246,7 @@ exports[`RichText renders with custom className 1`] = `
   font-size: 14px;
   font-weight: 400;
   line-height: 1.428571429;
-  margin: 0 0 12px 0;
+  margin: 0;
   text-align: initial;
 }
 
@@ -367,7 +367,7 @@ exports[`RichText renders with dangerouslySetInnerHTML 1`] = `
   font-size: 14px;
   font-weight: 400;
   line-height: 1.428571429;
-  margin: 0 0 12px 0;
+  margin: 0;
   text-align: initial;
 }
 

--- a/packages/rich-text/src/stylesheet.js
+++ b/packages/rich-text/src/stylesheet.js
@@ -14,10 +14,7 @@ export default function stylesheet(props, themeData) {
 
   const { stylesheet: customStylesheet } = props;
 
-  const baseStyles = typographyStyle(
-    "body",
-    `0 0 ${themeData["density.spacings.small"]} 0`
-  );
+  const baseStyles = typographyStyle("body", "0");
 
   const listStyles = {
     "ul, ol": { paddingLeft: themeData["density.spacings.large"] },


### PR DESCRIPTION
The bottom margin value in the rich-text component was set to 0 in the stylesheet file. 

Ticket repo: https://github.com/Autodesk/hig/issues/2468

Ticket board HIG 1.0: https://jira.autodesk.com/browse/HIG1-34

**Screenshots**

**Before:**

<img width="1791" alt="Screen Shot 2022-02-03 at 2 57 45 PM" src="https://user-images.githubusercontent.com/96445939/152421406-c2ff744e-f740-4714-bb6f-51122c779462.png">

**After:**

<img width="1788" alt="Screen Shot 2022-02-03 at 3 00 08 PM" src="https://user-images.githubusercontent.com/96445939/152421452-8afa03ae-d462-48fe-ad00-0f9780587e8d.png">
