### PR TITLE
fix: Fixing slider component bug, transparency in Firefox

### DIFF
--- a/packages/slider/src/__snapshots__/Slider.test.js.snap
+++ b/packages/slider/src/__snapshots__/Slider.test.js.snap
@@ -10,6 +10,7 @@ exports[`slider/Slider renders 1`] = `
   margin: 0;
   position: relative;
   outline: none;
+  opacity: initial;
 }
 
 .emotion-0::-ms-tooltip {
@@ -156,6 +157,7 @@ exports[`slider/Slider renders disabled 1`] = `
   margin: 0;
   position: relative;
   outline: none;
+  opacity: 0.4;
 }
 
 .emotion-0::-ms-tooltip {
@@ -206,7 +208,6 @@ exports[`slider/Slider renders disabled 1`] = `
   -webkit-transition-timing-function: cubic-bezier(0.4,0,0.2,1);
   transition-timing-function: cubic-bezier(0.4,0,0.2,1);
   -webkit-appearance: none;
-  opacity: 0.4;
 }
 
 .emotion-0::-webkit-slider-thumb {
@@ -238,7 +239,6 @@ exports[`slider/Slider renders disabled 1`] = `
   background-color: rgba(128,128,128,0.2);
   color: transparent;
   outline: none;
-  opacity: 0.4;
 }
 
 .emotion-0::-moz-range-track {
@@ -248,7 +248,6 @@ exports[`slider/Slider renders disabled 1`] = `
   background-color: rgba(128,128,128,0.2);
   color: transparent;
   outline: none;
-  opacity: 0.4;
 }
 
 .emotion-0::-webkit-slider-runnable-track {
@@ -258,7 +257,6 @@ exports[`slider/Slider renders disabled 1`] = `
   background-color: rgba(128,128,128,0.2);
   color: transparent;
   outline: none;
-  opacity: 0.4;
   background-image: linear-gradient(#808080,#808080);
   background-position: 0;
   background-size: calc((0.5 * 6px)  + (0.5 * (100% - 6px))) 100%;
@@ -273,7 +271,6 @@ exports[`slider/Slider renders disabled 1`] = `
 .emotion-0::-moz-range-progress {
   border: none;
   background-color: #808080;
-  opacity: 0.4;
 }
 
 <input

--- a/packages/slider/src/presenters/__snapshots__/SliderPresenter.test.js.snap
+++ b/packages/slider/src/presenters/__snapshots__/SliderPresenter.test.js.snap
@@ -10,6 +10,7 @@ exports[`Slider/presenters/SliderPresenter renders 1`] = `
   margin: 0;
   position: relative;
   outline: none;
+  opacity: initial;
 }
 
 .emotion-0::-ms-tooltip {
@@ -141,6 +142,7 @@ exports[`Slider/presenters/SliderPresenter renders disabled 1`] = `
   margin: 0;
   position: relative;
   outline: none;
+  opacity: 0.4;
 }
 
 .emotion-0::-ms-tooltip {
@@ -191,7 +193,6 @@ exports[`Slider/presenters/SliderPresenter renders disabled 1`] = `
   -webkit-transition-timing-function: cubic-bezier(0.4,0,0.2,1);
   transition-timing-function: cubic-bezier(0.4,0,0.2,1);
   -webkit-appearance: none;
-  opacity: 0.4;
 }
 
 .emotion-0::-webkit-slider-thumb {
@@ -223,7 +224,6 @@ exports[`Slider/presenters/SliderPresenter renders disabled 1`] = `
   background-color: rgba(128,128,128,0.2);
   color: transparent;
   outline: none;
-  opacity: 0.4;
 }
 
 .emotion-0::-moz-range-track {
@@ -233,7 +233,6 @@ exports[`Slider/presenters/SliderPresenter renders disabled 1`] = `
   background-color: rgba(128,128,128,0.2);
   color: transparent;
   outline: none;
-  opacity: 0.4;
 }
 
 .emotion-0::-webkit-slider-runnable-track {
@@ -243,7 +242,6 @@ exports[`Slider/presenters/SliderPresenter renders disabled 1`] = `
   background-color: rgba(128,128,128,0.2);
   color: transparent;
   outline: none;
-  opacity: 0.4;
   background-image: linear-gradient(#808080,#808080);
   background-position: 0;
   background-size: calc((0.5 * 6px)  + (NaN * (100% - 6px))) 100%;
@@ -258,7 +256,6 @@ exports[`Slider/presenters/SliderPresenter renders disabled 1`] = `
 .emotion-0::-moz-range-progress {
   border: none;
   background-color: #808080;
-  opacity: 0.4;
 }
 
 <input
@@ -278,6 +275,7 @@ exports[`Slider/presenters/SliderPresenter renders discrete slider 1`] = `
   margin: 0;
   position: relative;
   outline: none;
+  opacity: initial;
 }
 
 .emotion-0::-ms-tooltip {
@@ -487,6 +485,7 @@ exports[`Slider/presenters/SliderPresenter renders discrete slider with step 0 1
   margin: 0;
   position: relative;
   outline: none;
+  opacity: initial;
 }
 
 .emotion-0::-ms-tooltip {
@@ -660,6 +659,7 @@ exports[`Slider/presenters/SliderPresenter renders focused 1`] = `
   margin: 0;
   position: relative;
   outline: none;
+  opacity: initial;
 }
 
 .emotion-0::-ms-tooltip {
@@ -791,6 +791,7 @@ exports[`Slider/presenters/SliderPresenter renders hovered 1`] = `
   margin: 0;
   position: relative;
   outline: none;
+  opacity: initial;
 }
 
 .emotion-0::-ms-tooltip {
@@ -922,6 +923,7 @@ exports[`Slider/presenters/SliderPresenter renders pressed 1`] = `
   margin: 0;
   position: relative;
   outline: none;
+  opacity: initial;
 }
 
 .emotion-0::-ms-tooltip {

--- a/packages/slider/src/presenters/stylesheet.js
+++ b/packages/slider/src/presenters/stylesheet.js
@@ -72,14 +72,9 @@ function stylesheet(props, themeData) {
 
     "&::-moz-focus-outer": {
       border: 0
-    }
+    },
+    opacity: disabled ? themeData["colorScheme.opacity.disabled"] : "initial"
   };
-
-  const thumbDisabledRules = disabled
-    ? {
-        opacity: themeData["colorScheme.opacity.disabled"]
-      }
-    : {};
 
   const thumbStateRules = () => {
     const isInActiveState = Object.values(activeStates).every(
@@ -127,7 +122,7 @@ function stylesheet(props, themeData) {
     },
     {
       mozilla: {
-        ...thumbDisabledRules
+        // ...thumbDisabledRules
       },
       webkit: {
         transform: "translateY(-50%)"
@@ -152,9 +147,9 @@ function stylesheet(props, themeData) {
       border: "none",
       backgroundColor: themeData["slider.track.backgroundColor"],
       color: "transparent",
-      outline: "none",
+      outline: "none"
 
-      ...trackDisabledRules
+      // ...trackDisabledRules
     },
     {
       // WebKit does not have a built-in way to target the progress/lower fill of a slider track.
@@ -177,7 +172,7 @@ function stylesheet(props, themeData) {
     },
     {
       mozilla: {
-        ...trackDisabledRules
+        // ...trackDisabledRules
       }
     }
   );

--- a/packages/slider/src/presenters/stylesheet.test.js
+++ b/packages/slider/src/presenters/stylesheet.test.js
@@ -102,11 +102,12 @@ describe("stylesheet", () => {
       );
     });
 
-    it("changes the track to the theme's disabled opacity ", () => {
-      expect(styles.slider["&::-webkit-slider-runnable-track"].opacity).toMatch(
-        themeData["colorScheme.opacity.disabled"]
-      );
-    });
+    // The theme's disabled opacity is now in the parent, this test is no longer necessary
+    // it("changes the track to the theme's disabled opacity ", () => {
+    //   expect(styles.slider["&::-webkit-slider-runnable-track"].opacity).toMatch(
+    //     themeData["colorScheme.opacity.disabled"]
+    //   );
+    // });
   });
 
   describe("when hasFocus", () => {

--- a/packages/table/CHANGELOG.md
+++ b/packages/table/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [@hig/table-v1.2.1](https://github.com/Autodesk/hig/compare/@hig/table@1.2.0...@hig/table@1.2.1) (2022-04-05)
+
+
+### Bug Fixes
+
+* Fix the customStylesheet not overridable issue in application level ([095e43a](https://github.com/Autodesk/hig/commit/095e43a))
+
 # [@hig/table-v1.2.0](https://github.com/Autodesk/hig/compare/@hig/table@1.1.0...@hig/table@1.2.0) (2022-03-30)
 
 

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hig/table",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "HIG Table",
   "author": "Autodesk Inc.",
   "license": "Apache-2.0",

--- a/packages/table/src/presenters/TablePresenter.js
+++ b/packages/table/src/presenters/TablePresenter.js
@@ -276,7 +276,7 @@ const TablePresenter = ({
                     {headerGroup.headers.map((column, columnIndex) => {
                       const resizingStyles = column.canResize
                         ? stylesheet(
-                            { isResizing: column.isResizing },
+                            { isResizing: column.isResizing, customStylesheet },
                             resolvedRoles,
                             metadata
                           )
@@ -307,6 +307,7 @@ const TablePresenter = ({
                           setActiveMultiSelectColumn={
                             setActiveMultiSelectColumn
                           }
+                          customStylesheet={customStylesheet}
                         >
                           <div className={css(styles.headerHolder)}>
                             {column.canGroupBy && meta.groupElements ? (
@@ -357,7 +358,8 @@ const TablePresenter = ({
                     {
                       alternateBg,
                       isCustomeContentExpanded: customContentArray[rowIndex],
-                      rowIndex
+                      rowIndex,
+                      customStylesheet
                     },
                     resolvedRoles,
                     metadata
@@ -429,6 +431,7 @@ const TablePresenter = ({
                                 setActiveMultiSelectRowArray
                               }
                               rowTypeToMap={paginateDynamic ? rows : page}
+                              customStylesheet={customStylesheet}
                             >
                               {/* eslint-disable */}
                               {cell.isGrouped ? (

--- a/packages/tree-view/CHANGELOG.md
+++ b/packages/tree-view/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [@hig/tree-view-v2.6.0](https://github.com/Autodesk/hig/compare/@hig/tree-view@2.5.1...@hig/tree-view@2.6.0) (2022-04-05)
+
+
+### Features
+
+* tree view label to return props ([b1a93fd](https://github.com/Autodesk/hig/commit/b1a93fd))
+
 # [@hig/tree-view-v2.5.1](https://github.com/Autodesk/hig/compare/@hig/tree-view@2.5.0...@hig/tree-view@2.5.1) (2022-03-17)
 
 

--- a/packages/tree-view/package.json
+++ b/packages/tree-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hig/tree-view",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "HIG Tree View",
   "author": "Autodesk Inc.",
   "license": "Apache-2.0",

--- a/packages/tree-view/src/TreeItem.js
+++ b/packages/tree-view/src/TreeItem.js
@@ -112,7 +112,7 @@ TreeItem.propTypes = {
   /**
    * Labels the TreeItem, this is rendered before all children
    */
-  label: PropTypes.node,
+  label: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   /**
    * Adds custom/overriding styles
    */

--- a/packages/tree-view/src/TreeView.js
+++ b/packages/tree-view/src/TreeView.js
@@ -131,7 +131,7 @@ TreeView.propTypes = {
         collapsed: PropTypes.bool,
         expandByDoubleClick: PropTypes.bool,
         icon: PropTypes.node,
-        label: PropTypes.node
+        label: PropTypes.oneOfType([PropTypes.node, PropTypes.func])
       })
     })
   )

--- a/packages/tree-view/src/behaviors/TreeViewBehavior.js
+++ b/packages/tree-view/src/behaviors/TreeViewBehavior.js
@@ -210,7 +210,7 @@ TreeViewBehavior.propTypes = {
         collapsed: PropTypes.bool,
         expandByDoubleClick: PropTypes.bool,
         icon: PropTypes.node,
-        label: PropTypes.node
+        label: PropTypes.oneOfType([PropTypes.node, PropTypes.func])
       })
     })
   ),

--- a/packages/tree-view/src/presenters/SingleTreeNodeFolderPresenter.js
+++ b/packages/tree-view/src/presenters/SingleTreeNodeFolderPresenter.js
@@ -59,6 +59,13 @@ export default function SingleTreeNodeFolderPresenter(props) {
   );
   const payload = { ...otherProps };
 
+  const renderLabel = () => {
+    if (typeof label === "function") {
+      return <div>{label(props)}</div>;
+    }
+    return label;
+  };
+
   delete payload.density;
   delete payload.defaultSelected;
   delete payload.getActiveTreeItemId;
@@ -148,7 +155,7 @@ export default function SingleTreeNodeFolderPresenter(props) {
                     higTreeItemLabelWrapperClassName
                   ])}
                 >
-                  {label}
+                  {renderLabel()}
                 </span>
               </div>
             </div>
@@ -169,5 +176,5 @@ SingleTreeNodeFolderPresenter.propTypes = {
     PropTypes.func,
     PropTypes.shape({ current: PropTypes.arrayOf(PropTypes.any) })
   ]),
-  label: PropTypes.node
+  label: PropTypes.oneOfType([PropTypes.node, PropTypes.func])
 };

--- a/packages/tree-view/src/presenters/SingleTreeNodePresenter.js
+++ b/packages/tree-view/src/presenters/SingleTreeNodePresenter.js
@@ -30,6 +30,13 @@ export default function SingleTreeNodePresenter(props) {
   );
   const payload = { ...otherProps };
 
+  const renderLabel = () => {
+    if (typeof label === "function") {
+      return <div>{label(props)}</div>;
+    }
+    return label;
+  };
+
   delete payload.collapsed;
   delete payload.defaultSelected;
   delete payload.getActiveTreeItemId;
@@ -99,7 +106,7 @@ export default function SingleTreeNodePresenter(props) {
                   higTreeItemLabelWrapperClassName
                 ])}
               >
-                {label}
+                {renderLabel()}
               </span>
             </div>
           </li>
@@ -116,5 +123,5 @@ SingleTreeNodePresenter.propTypes = {
     PropTypes.func,
     PropTypes.shape({ current: PropTypes.arrayOf(PropTypes.any) })
   ]),
-  label: PropTypes.node
+  label: PropTypes.oneOfType([PropTypes.node, PropTypes.func])
 };

--- a/packages/tree-view/src/presenters/TreeItemPresenter.js
+++ b/packages/tree-view/src/presenters/TreeItemPresenter.js
@@ -49,7 +49,7 @@ TreeItemPresenter.propTypes = {
    * child of another TreeItem. If your TreeItem has any
    * other elements as children this prop will not render
    */
-  label: PropTypes.node,
+  label: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   stylesheet: PropTypes.func
 };
 

--- a/packages/tree-view/src/presenters/fileview/TreeObjectSubTreeItem.js
+++ b/packages/tree-view/src/presenters/fileview/TreeObjectSubTreeItem.js
@@ -152,7 +152,7 @@ TreeObjectSubTreeItem.propTypes = {
       collapsed: PropTypes.bool,
       expandByDoubleClick: PropTypes.bool,
       icon: PropTypes.node,
-      label: PropTypes.node
+      label: PropTypes.oneOfType([PropTypes.node, PropTypes.func])
     })
   }),
   keyboardOpenId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),


### PR DESCRIPTION
[BUG] Slider is transparent when disabled in Firefox:

PR repo: https://github.com/Autodesk/hig/issues/2621

PR board HIG 1.0: https://jira.autodesk.com/browse/HIG1-39

![image](https://user-images.githubusercontent.com/99756319/161321993-6a8ddeba-520d-43e7-baeb-a631d0ea0b9d.png)

When you disable the Slider a new CSS line appears to its 3 pseudo-elements, to fix the Bug in Firefox, instead of adding the line to the 3 pseudo-elements it was added directly to its parent.

A unit test that checked that the CSS line was inside one of the three pseudo-elements had to be eliminated, now that the CSS line goes directly to the parent, that unit test is no longer necessary.