### PR TITLE
fix: Fixing flyout component bug, extra space on the right

### DIFF
--- a/packages/flyout/src/__snapshots__/Flyout.test.js.snap
+++ b/packages/flyout/src/__snapshots__/Flyout.test.js.snap
@@ -46,7 +46,6 @@ exports[`flyout/Flyout snapshots renders a custom pointer 1`] = `
 .emotion-6 {
   position: absolute;
   display: table;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;
@@ -234,7 +233,6 @@ exports[`flyout/Flyout snapshots renders children from the given render function
 .emotion-8 {
   position: absolute;
   display: table;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;
@@ -433,7 +431,6 @@ exports[`flyout/Flyout snapshots renders content from the given render function 
 .emotion-8 {
   position: absolute;
   display: table;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;
@@ -632,7 +629,6 @@ exports[`flyout/Flyout snapshots renders open by default 1`] = `
 .emotion-7 {
   position: absolute;
   display: table;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;
@@ -745,7 +741,6 @@ exports[`flyout/Flyout snapshots renders the panel from a basic render function 
 .emotion-5 {
   position: absolute;
   display: table;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;
@@ -920,7 +915,6 @@ exports[`flyout/Flyout snapshots renders the panel from a complex render functio
 .emotion-7 {
   position: absolute;
   display: table;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;
@@ -1124,7 +1118,6 @@ exports[`flyout/Flyout snapshots renders with a basic set of props 1`] = `
 .emotion-8 {
   position: absolute;
   display: table;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;
@@ -1323,7 +1316,6 @@ exports[`flyout/Flyout snapshots renders with className prop 1`] = `
 .emotion-8 {
   position: absolute;
   display: table;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;
@@ -1555,7 +1547,6 @@ exports[`flyout/Flyout snapshots renders with custom stylesheet function 1`] = `
 .emotion-8 {
   position: absolute;
   display: table;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;
@@ -1684,7 +1675,6 @@ exports[`flyout/Flyout snapshots renders without props 1`] = `
 .emotion-7 {
   position: absolute;
   display: none;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;

--- a/packages/flyout/src/presenters/__snapshots__/FlyoutPresenter.test.js.snap
+++ b/packages/flyout/src/presenters/__snapshots__/FlyoutPresenter.test.js.snap
@@ -27,7 +27,6 @@ exports[`flyout/FlyoutPresenter/FlyoutPresenter renders with all props 1`] = `
 .emotion-3 {
   position: absolute;
   display: table;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;
@@ -157,7 +156,6 @@ exports[`flyout/FlyoutPresenter/FlyoutPresenter renders without props 1`] = `
 .emotion-4 {
   position: absolute;
   display: table;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;

--- a/packages/flyout/src/presenters/stylesheet.js
+++ b/packages/flyout/src/presenters/stylesheet.js
@@ -78,7 +78,6 @@ export default function(props, themeData) {
       position: `absolute`,
       // Resolves issues with negative positions and container overflow
       display: isHidden ? `none` : `table`,
-      width: `100%`,
       zIndex: 9999,
       transitionProperty: `opacity, transform`,
       transitionDuration: `250ms`,


### PR DESCRIPTION
[BUG] Fixing flyout component bug, extra space on the right:

PR repo: https://github.com/Autodesk/hig/issues/2516

PR board HIG 1.0: https://jira.autodesk.com/browse/HIG1-38

![image](https://user-images.githubusercontent.com/99756319/161618434-70dc49af-791c-462f-be4d-8764cd2ff489.png)

The error was found in the "tooltip" component but it comes from the "flyout" component because "tooltip" consumes "flyout".

We had extra space on the right that was fixed by removing the fixed width of 100%.