### PR TITLE
fix: Fixing slider component bug, transparency in Firefox

### DIFF
--- a/packages/slider/src/__snapshots__/Slider.test.js.snap
+++ b/packages/slider/src/__snapshots__/Slider.test.js.snap
@@ -10,6 +10,7 @@ exports[`slider/Slider renders 1`] = `
   margin: 0;
   position: relative;
   outline: none;
+  opacity: initial;
 }
 
 .emotion-0::-ms-tooltip {
@@ -156,6 +157,7 @@ exports[`slider/Slider renders disabled 1`] = `
   margin: 0;
   position: relative;
   outline: none;
+  opacity: 0.4;
 }
 
 .emotion-0::-ms-tooltip {
@@ -206,7 +208,6 @@ exports[`slider/Slider renders disabled 1`] = `
   -webkit-transition-timing-function: cubic-bezier(0.4,0,0.2,1);
   transition-timing-function: cubic-bezier(0.4,0,0.2,1);
   -webkit-appearance: none;
-  opacity: 0.4;
 }
 
 .emotion-0::-webkit-slider-thumb {
@@ -238,7 +239,6 @@ exports[`slider/Slider renders disabled 1`] = `
   background-color: rgba(128,128,128,0.2);
   color: transparent;
   outline: none;
-  opacity: 0.4;
 }
 
 .emotion-0::-moz-range-track {
@@ -248,7 +248,6 @@ exports[`slider/Slider renders disabled 1`] = `
   background-color: rgba(128,128,128,0.2);
   color: transparent;
   outline: none;
-  opacity: 0.4;
 }
 
 .emotion-0::-webkit-slider-runnable-track {
@@ -258,7 +257,6 @@ exports[`slider/Slider renders disabled 1`] = `
   background-color: rgba(128,128,128,0.2);
   color: transparent;
   outline: none;
-  opacity: 0.4;
   background-image: linear-gradient(#808080,#808080);
   background-position: 0;
   background-size: calc((0.5 * 6px)  + (0.5 * (100% - 6px))) 100%;
@@ -273,7 +271,6 @@ exports[`slider/Slider renders disabled 1`] = `
 .emotion-0::-moz-range-progress {
   border: none;
   background-color: #808080;
-  opacity: 0.4;
 }
 
 <input

--- a/packages/slider/src/presenters/__snapshots__/SliderPresenter.test.js.snap
+++ b/packages/slider/src/presenters/__snapshots__/SliderPresenter.test.js.snap
@@ -10,6 +10,7 @@ exports[`Slider/presenters/SliderPresenter renders 1`] = `
   margin: 0;
   position: relative;
   outline: none;
+  opacity: initial;
 }
 
 .emotion-0::-ms-tooltip {
@@ -141,6 +142,7 @@ exports[`Slider/presenters/SliderPresenter renders disabled 1`] = `
   margin: 0;
   position: relative;
   outline: none;
+  opacity: 0.4;
 }
 
 .emotion-0::-ms-tooltip {
@@ -191,7 +193,6 @@ exports[`Slider/presenters/SliderPresenter renders disabled 1`] = `
   -webkit-transition-timing-function: cubic-bezier(0.4,0,0.2,1);
   transition-timing-function: cubic-bezier(0.4,0,0.2,1);
   -webkit-appearance: none;
-  opacity: 0.4;
 }
 
 .emotion-0::-webkit-slider-thumb {
@@ -223,7 +224,6 @@ exports[`Slider/presenters/SliderPresenter renders disabled 1`] = `
   background-color: rgba(128,128,128,0.2);
   color: transparent;
   outline: none;
-  opacity: 0.4;
 }
 
 .emotion-0::-moz-range-track {
@@ -233,7 +233,6 @@ exports[`Slider/presenters/SliderPresenter renders disabled 1`] = `
   background-color: rgba(128,128,128,0.2);
   color: transparent;
   outline: none;
-  opacity: 0.4;
 }
 
 .emotion-0::-webkit-slider-runnable-track {
@@ -243,7 +242,6 @@ exports[`Slider/presenters/SliderPresenter renders disabled 1`] = `
   background-color: rgba(128,128,128,0.2);
   color: transparent;
   outline: none;
-  opacity: 0.4;
   background-image: linear-gradient(#808080,#808080);
   background-position: 0;
   background-size: calc((0.5 * 6px)  + (NaN * (100% - 6px))) 100%;
@@ -258,7 +256,6 @@ exports[`Slider/presenters/SliderPresenter renders disabled 1`] = `
 .emotion-0::-moz-range-progress {
   border: none;
   background-color: #808080;
-  opacity: 0.4;
 }
 
 <input
@@ -278,6 +275,7 @@ exports[`Slider/presenters/SliderPresenter renders discrete slider 1`] = `
   margin: 0;
   position: relative;
   outline: none;
+  opacity: initial;
 }
 
 .emotion-0::-ms-tooltip {
@@ -487,6 +485,7 @@ exports[`Slider/presenters/SliderPresenter renders discrete slider with step 0 1
   margin: 0;
   position: relative;
   outline: none;
+  opacity: initial;
 }
 
 .emotion-0::-ms-tooltip {
@@ -660,6 +659,7 @@ exports[`Slider/presenters/SliderPresenter renders focused 1`] = `
   margin: 0;
   position: relative;
   outline: none;
+  opacity: initial;
 }
 
 .emotion-0::-ms-tooltip {
@@ -791,6 +791,7 @@ exports[`Slider/presenters/SliderPresenter renders hovered 1`] = `
   margin: 0;
   position: relative;
   outline: none;
+  opacity: initial;
 }
 
 .emotion-0::-ms-tooltip {
@@ -922,6 +923,7 @@ exports[`Slider/presenters/SliderPresenter renders pressed 1`] = `
   margin: 0;
   position: relative;
   outline: none;
+  opacity: initial;
 }
 
 .emotion-0::-ms-tooltip {

--- a/packages/slider/src/presenters/stylesheet.js
+++ b/packages/slider/src/presenters/stylesheet.js
@@ -72,14 +72,9 @@ function stylesheet(props, themeData) {
 
     "&::-moz-focus-outer": {
       border: 0
-    }
+    },
+    opacity: disabled ? themeData["colorScheme.opacity.disabled"] : "initial"
   };
-
-  const thumbDisabledRules = disabled
-    ? {
-        opacity: themeData["colorScheme.opacity.disabled"]
-      }
-    : {};
 
   const thumbStateRules = () => {
     const isInActiveState = Object.values(activeStates).every(
@@ -126,9 +121,6 @@ function stylesheet(props, themeData) {
       ...thumbStateRules()
     },
     {
-      mozilla: {
-        ...thumbDisabledRules
-      },
       webkit: {
         transform: "translateY(-50%)"
       }
@@ -152,9 +144,7 @@ function stylesheet(props, themeData) {
       border: "none",
       backgroundColor: themeData["slider.track.backgroundColor"],
       color: "transparent",
-      outline: "none",
-
-      ...trackDisabledRules
+      outline: "none"
     },
     {
       // WebKit does not have a built-in way to target the progress/lower fill of a slider track.
@@ -174,11 +164,6 @@ function stylesheet(props, themeData) {
     {
       border: "none",
       backgroundColor: themeData["slider.value.backgroundColor"]
-    },
-    {
-      mozilla: {
-        ...trackDisabledRules
-      }
     }
   );
 

--- a/packages/slider/src/presenters/stylesheet.test.js
+++ b/packages/slider/src/presenters/stylesheet.test.js
@@ -102,8 +102,8 @@ describe("stylesheet", () => {
       );
     });
 
-    it("changes the track to the theme's disabled opacity ", () => {
-      expect(styles.slider["&::-webkit-slider-runnable-track"].opacity).toMatch(
+    it("changes the slider to the theme's disabled opacity ", () => {
+      expect(styles.slider.opacity).toMatch(
         themeData["colorScheme.opacity.disabled"]
       );
     });


### PR DESCRIPTION
[BUG] Slider is transparent when disabled in Firefox:

PR repo: https://github.com/Autodesk/hig/issues/2621

PR board HIG 1.0: https://jira.autodesk.com/browse/HIG1-39

![image](https://user-images.githubusercontent.com/99756319/161872015-185b8af7-91c2-482f-95d0-c61bd05fcd12.png)
