### PR TITLE
fix: Fixing flyout component bug, extra space on the right

### DIFF
--- a/packages/flyout/src/__snapshots__/Flyout.test.js.snap
+++ b/packages/flyout/src/__snapshots__/Flyout.test.js.snap
@@ -46,7 +46,6 @@ exports[`flyout/Flyout snapshots renders a custom pointer 1`] = `
 .emotion-6 {
   position: absolute;
   display: table;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;
@@ -234,7 +233,6 @@ exports[`flyout/Flyout snapshots renders children from the given render function
 .emotion-8 {
   position: absolute;
   display: table;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;
@@ -433,7 +431,6 @@ exports[`flyout/Flyout snapshots renders content from the given render function 
 .emotion-8 {
   position: absolute;
   display: table;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;
@@ -632,7 +629,6 @@ exports[`flyout/Flyout snapshots renders open by default 1`] = `
 .emotion-7 {
   position: absolute;
   display: table;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;
@@ -745,7 +741,6 @@ exports[`flyout/Flyout snapshots renders the panel from a basic render function 
 .emotion-5 {
   position: absolute;
   display: table;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;
@@ -920,7 +915,6 @@ exports[`flyout/Flyout snapshots renders the panel from a complex render functio
 .emotion-7 {
   position: absolute;
   display: table;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;
@@ -1124,7 +1118,6 @@ exports[`flyout/Flyout snapshots renders with a basic set of props 1`] = `
 .emotion-8 {
   position: absolute;
   display: table;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;
@@ -1323,7 +1316,6 @@ exports[`flyout/Flyout snapshots renders with className prop 1`] = `
 .emotion-8 {
   position: absolute;
   display: table;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;
@@ -1555,7 +1547,6 @@ exports[`flyout/Flyout snapshots renders with custom stylesheet function 1`] = `
 .emotion-8 {
   position: absolute;
   display: table;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;
@@ -1684,7 +1675,6 @@ exports[`flyout/Flyout snapshots renders without props 1`] = `
 .emotion-7 {
   position: absolute;
   display: none;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;

--- a/packages/flyout/src/presenters/__snapshots__/FlyoutPresenter.test.js.snap
+++ b/packages/flyout/src/presenters/__snapshots__/FlyoutPresenter.test.js.snap
@@ -27,7 +27,6 @@ exports[`flyout/FlyoutPresenter/FlyoutPresenter renders with all props 1`] = `
 .emotion-3 {
   position: absolute;
   display: table;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;
@@ -157,7 +156,6 @@ exports[`flyout/FlyoutPresenter/FlyoutPresenter renders without props 1`] = `
 .emotion-4 {
   position: absolute;
   display: table;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;

--- a/packages/flyout/src/presenters/stylesheet.js
+++ b/packages/flyout/src/presenters/stylesheet.js
@@ -78,7 +78,6 @@ export default function(props, themeData) {
       position: `absolute`,
       // Resolves issues with negative positions and container overflow
       display: isHidden ? `none` : `table`,
-      width: `100%`,
       zIndex: 9999,
       transitionProperty: `opacity, transform`,
       transitionDuration: `250ms`,

--- a/packages/notifications-flyout/src/__snapshots__/NotificationsFlyout.test.js.snap
+++ b/packages/notifications-flyout/src/__snapshots__/NotificationsFlyout.test.js.snap
@@ -16,7 +16,6 @@ exports[`notifications-flyout/NotificationsFlyout renders a notification with th
 .emotion-17 {
   position: absolute;
   display: none;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;
@@ -488,7 +487,6 @@ exports[`notifications-flyout/NotificationsFlyout renders a notification with th
 .emotion-17 {
   position: absolute;
   display: none;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;
@@ -1224,7 +1222,6 @@ exports[`notifications-flyout/NotificationsFlyout renders with all props 1`] = `
 .emotion-21 {
   position: absolute;
   display: table;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;
@@ -1457,7 +1454,6 @@ exports[`notifications-flyout/NotificationsFlyout renders without props 1`] = `
 .emotion-16 {
   position: absolute;
   display: none;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;

--- a/packages/profile-flyout/src/__snapshots__/ProfileFlyout.test.js.snap
+++ b/packages/profile-flyout/src/__snapshots__/ProfileFlyout.test.js.snap
@@ -72,7 +72,6 @@ exports[`profile-flyout/ProfileFlyout renders with all props 1`] = `
 .emotion-9 {
   position: absolute;
   display: table;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;
@@ -202,7 +201,6 @@ exports[`profile-flyout/ProfileFlyout renders with no props 1`] = `
 .emotion-9 {
   position: absolute;
   display: none;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;

--- a/packages/project-account-switcher/src/__snapshots__/ProjectAccountSwitcher.test.js.snap
+++ b/packages/project-account-switcher/src/__snapshots__/ProjectAccountSwitcher.test.js.snap
@@ -16,7 +16,6 @@ exports[`project-account-switcher/ProjectAccountSwitcher integration renders wit
 .emotion-35 {
   position: absolute;
   display: none;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;
@@ -506,7 +505,6 @@ exports[`project-account-switcher/ProjectAccountSwitcher integration renders wit
 .emotion-35 {
   position: absolute;
   display: none;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;

--- a/packages/tooltip/src/__snapshots__/Tooltip.test.js.snap
+++ b/packages/tooltip/src/__snapshots__/Tooltip.test.js.snap
@@ -35,7 +35,6 @@ exports[`tooltip/Tooltip renders with props 1`] = `
 .emotion-7 {
   position: absolute;
   display: table;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;
@@ -194,7 +193,6 @@ exports[`tooltip/Tooltip renders without props 1`] = `
 .emotion-6 {
   position: absolute;
   display: none;
-  width: 100%;
   z-index: 9999;
   -webkit-transition-property: opacity,-webkit-transform;
   -webkit-transition-property: opacity,transform;


### PR DESCRIPTION
[BUG] Fixing flyout component bug, extra space on the right:

PR repo: https://github.com/Autodesk/hig/issues/2516

PR board HIG 1.0: https://jira.autodesk.com/browse/HIG1-38

The error was found in the "tooltip" component but it comes from the "flyout" component because "tooltip" consumes "flyout". We had extra space on the right that was fixed by removing the fixed width of 100%.

In addition, another commit was created to fix the snapshots tests of other components.

![image](https://user-images.githubusercontent.com/99756319/162100138-57f7c556-fc0f-41bc-a825-fc44e10ea989.png)
