### PR TITLE
Fix console error of text-link for issue 2626, no way to UT this

### DIFF
--- a/packages/text-link/src/TextLink.js
+++ b/packages/text-link/src/TextLink.js
@@ -19,6 +19,7 @@ const TextLink = props => {
     onMouseDown,
     onMouseLeave,
     onMouseEnter,
+    stylesheet: customStylesheet,
     ...otherProps
   } = props;
   const { className } = otherProps;
@@ -52,7 +53,6 @@ const TextLink = props => {
             onMouseLeave: handleMouseLeave,
             onMouseUp: handleMouseUp
           }) => {
-            const { stylesheet: customStylesheet } = props;
             const styles = stylesheet(
               {
                 stylesheet: customStylesheet,


### PR DESCRIPTION
Here is the console error:
Warning: Invalid value for prop 'stylesheet' on <a> tag. Either remove it from the element, or pass a string or number value to keep it in the DOM

Just implement what David Becroft suggested in the issue 2626.