### PR TITLE
fix: Sending correct parameters in the textareaStylesheet callback function of TextArea component

### DIFF
--- a/packages/text-area/src/TextArea.js
+++ b/packages/text-area/src/TextArea.js
@@ -16,10 +16,10 @@ const TextArea = props => {
       .split(" ")
       .reduce((acc, cur) => cx(acc, `${cur.trim()}-textarea`), "");
 
-  const textareaStylesheet = (styles, themeData) => {
-    const textareaStyles = customStylesheet(styles, props, themeData);
+  const textareaStylesheet = (styles, customProps, themeData) => {
+    const textareaStyles = customStylesheet(styles, customProps, themeData);
     return stylesheet
-      ? stylesheet(textareaStyles, props, themeData)
+      ? stylesheet(textareaStyles, customProps, themeData)
       : textareaStyles;
   };
 

--- a/packages/text-area/src/__snapshots__/TextArea.test.js.snap
+++ b/packages/text-area/src/__snapshots__/TextArea.test.js.snap
@@ -13,6 +13,9 @@ exports[`TextArea integration renders correctly 1`] = `
   border-bottom-color: rgba(128,128,128,0.35);
   border-bottom-style: solid;
   border-bottom-width: 1px;
+  border-left-color: rgba(128,128,128,0.2);
+  border-right-color: rgba(128,128,128,0.2);
+  border-top-color: rgba(128,128,128,0.2);
 }
 
 .emotion-1 {
@@ -46,14 +49,14 @@ exports[`TextArea integration renders correctly 1`] = `
   line-height: 1.4;
   width: 100%;
   color: #3c3c3c;
-  height: calc((undefined - 2px) * 2);
+  height: calc((36px - 2px) * 2);
   -webkit-transition-property: color;
   transition-property: color;
   -webkit-transition-duration: 0.3s;
   transition-duration: 0.3s;
   display: block;
   resize: vertical;
-  padding: undefined undefined;
+  padding: 4px 12px;
 }
 
 .emotion-0::-webkit-input-placeholder {
@@ -117,6 +120,9 @@ exports[`TextArea integration renders with stylesheet prop 1`] = `
   border-bottom-color: rgba(128,128,128,0.35);
   border-bottom-style: solid;
   border-bottom-width: 1px;
+  border-left-color: rgba(128,128,128,0.2);
+  border-right-color: rgba(128,128,128,0.2);
+  border-top-color: rgba(128,128,128,0.2);
 }
 
 .emotion-1 {
@@ -150,14 +156,15 @@ exports[`TextArea integration renders with stylesheet prop 1`] = `
   line-height: 1.4;
   width: 100%;
   color: #3c3c3c;
-  height: calc((undefined - 2px) * 2);
+  height: calc((36px - 2px) * 2);
   -webkit-transition-property: color;
   transition-property: color;
   -webkit-transition-duration: 0.3s;
   transition-duration: 0.3s;
   display: block;
   resize: vertical;
-  padding: undefined undefined;
+  padding: 4px 12px;
+  background: #e7f2d9;
 }
 
 .emotion-0::-webkit-input-placeholder {


### PR DESCRIPTION
After React17 upgrade of HIG TextArea component, textareaStylesheet callback is missing one parameter because of which the styles in the textarea are getting some undefined values

Before:
![textarea-before](https://user-images.githubusercontent.com/8447950/164665972-8d12afb1-1e08-425f-8a53-545e1525d622.PNG)

After:
![textarea-after](https://user-images.githubusercontent.com/8447950/164666222-21844a11-8c35-46ee-b24f-05423b13db71.PNG)
