### PR TITLE
fix: remove lineHeight in topNavLogoWrapper

### DIFF
--- a/packages/top-nav/src/presenters/__snapshots__/TopNavPresenter.test.js.snap
+++ b/packages/top-nav/src/presenters/__snapshots__/TopNavPresenter.test.js.snap
@@ -36,7 +36,6 @@ exports[`top-nav/presenters/TopNavPresenter renders with actions and logo 1`] = 
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  line-height: 0;
 }
 
 .emotion-1 {
@@ -105,7 +104,6 @@ exports[`top-nav/presenters/TopNavPresenter renders with no props 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  line-height: 0;
 }
 
 .emotion-1 {

--- a/packages/top-nav/src/presenters/stylesheet.js
+++ b/packages/top-nav/src/presenters/stylesheet.js
@@ -29,7 +29,6 @@ export default function stylesheet(props, themeData) {
       display: `flex`,
       padding: `0 12px 0 5px`,
       alignItems: `center`,
-      lineHeight: 0,
     },
     topNavSeparator: {
       width: 0,


### PR DESCRIPTION
This issue affects Top-Nav related to updating stylesheet (remove lineHeight)
Issue: https://github.com/Autodesk/hig/issues/2226