### PR TITLE
fix: SubTreeItem display style

### DIFF
--- a/packages/tree-view/src/presenters/fileview/__snapshots__/TreeObjectNestedSubTreeItem.test.js.snap
+++ b/packages/tree-view/src/presenters/fileview/__snapshots__/TreeObjectNestedSubTreeItem.test.js.snap
@@ -4,6 +4,10 @@ exports[`tree-view/TreeObjectNestedSubTreeItem renders tree with tree node 1`] =
 .emotion-4 {
   border: 1px solid transparent;
   box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   height: 40px;
   padding: 8px 12px 8px calc((24px + 8px) + ((24px + 8px) * 0));
   position: relative;

--- a/packages/tree-view/src/presenters/fileview/__snapshots__/TreeObjectView.test.js.snap
+++ b/packages/tree-view/src/presenters/fileview/__snapshots__/TreeObjectView.test.js.snap
@@ -220,6 +220,10 @@ exports[`tree-view/TreeObjectView takes a treeNodeObject 1`] = `
 .emotion-18 {
   border: 1px solid transparent;
   box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   height: 40px;
   padding: 8px 12px 8px calc((24px + 8px) + ((24px + 8px) * 2));
   position: relative;
@@ -333,6 +337,10 @@ exports[`tree-view/TreeObjectView takes a treeNodeObject 1`] = `
 .emotion-35 {
   border: 1px solid transparent;
   box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   height: 40px;
   padding: 8px 12px 8px calc((24px + 8px) + ((24px + 8px) * 3));
   position: relative;

--- a/packages/tree-view/src/presenters/stylesheet.js
+++ b/packages/tree-view/src/presenters/stylesheet.js
@@ -173,6 +173,7 @@ export default function stylesheet(props, themeData) {
     higTreeItemSubTreeItem: {
       border: `1px solid transparent`,
       boxSizing: `border-box`,
+      display: `flex`,
       height: themeData[`treeView.row.height`],
       padding: `${themeData["treeView.row.paddingVertical"]} ${themeData["treeView.row.paddingHorizontal"]} ${themeData["treeView.row.paddingVertical"]}
         calc((${contentHeight} + ${themeData["treeView.icon.marginRight"]}) + ((${contentHeight} + ${themeData["treeView.icon.marginRight"]}) * ${level}))`,


### PR DESCRIPTION
The display style should be `flex` for sub-tree-item.