### PR TITLE
fix: revert to class components

### DIFF
--- a/packages/accordion/src/Accordion.js
+++ b/packages/accordion/src/Accordion.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { cx, css } from "emotion";
 import { ThemeContext } from "@hig/theme-context";
@@ -14,144 +14,152 @@ import stylesheet from "./stylesheet";
 import HeaderPresenter from "./presenters/HeaderPresenter";
 import ContentPresenter from "./presenters/ContentPresenter";
 
-const Accordion = (props) => {
-  const [collapsed, setCollapsed] = useState(props.defaultCollapsed);
-
-  const isCollapsedControlled = () => props.collapsed !== undefined;
-
-  const isCollapsed = () =>
-    isCollapsedControlled() ? props.collapsed : collapsed;
-
-  const onClick = () => {
-    if (!isCollapsedControlled()) {
-      setCollapsed(!collapsed);
-    }
-    props.onClick(isCollapsed());
+export default class Accordion extends Component {
+  // eslint-disable-next-line react/static-property-placement
+  static propTypes = {
+    /** Content of the accordion */
+    children: PropTypes.node,
+    /** Controlled value, specifies whether the accordion is collapsed or not
+     * When provided, it overrides the accordion's collapsed state
+     */
+    collapsed: PropTypes.bool,
+    /** Specifies whether the accordion is default collapsed or not */
+    defaultCollapsed: PropTypes.bool,
+    /** Specifies whether the accordion is disabled or not */
+    disabled: PropTypes.bool,
+    /** Indicator icon */
+    indicator: PropTypes.oneOf(AVAILABLE_INDICATORS),
+    /** Indicator's position. */
+    indicatorPosition: PropTypes.oneOf(AVAILABLE_INDICATOR_POSITIONS),
+    /** Text label for the accordion header */
+    label: PropTypes.node.isRequired,
+    /** Function called when clicks the accordion's header */
+    onClick: PropTypes.func,
+    /** Function to modify the component's styles */
+    stylesheet: PropTypes.func,
   };
 
-  const {
-    children,
-    label,
-    indicator,
-    indicatorPosition,
-    disabled,
-    stylesheet: customStylesheet,
-    ...otherProps
-  } = props;
+  // eslint-disable-next-line react/static-property-placement
+  static defaultProps = {
+    indicator: indicators.CARET,
+    indicatorPosition: indicatorPositions.LEFT,
+    defaultCollapsed: true,
+    disabled: false,
+    onClick: () => {},
+  };
 
-  const {
-    className,
-    onBlur,
-    onFocus,
-    onMouseDown,
-    onMouseEnter,
-    onMouseLeave,
-    onMouseUp,
-    onHover,
-  } = otherProps;
+  constructor(props) {
+    super(props);
+    this.state = {
+      collapsed: this.props.defaultCollapsed,
+    };
+  }
 
-  return (
-    <ThemeContext.Consumer>
-      {({ resolvedRoles, metadata }) => {
-        const styles = stylesheet(
-          {
-            indicator,
-            indicatorPosition,
-            collapsed: isCollapsed(),
-            stylesheet: customStylesheet,
-          },
-          resolvedRoles,
-          metadata
-        );
+  onClick = () => {
+    if (!this.isCollapsedControlled()) {
+      const { collapsed } = this.state;
+      this.setState({ collapsed: !collapsed });
+    }
+    this.props.onClick(this.isCollapsed());
+  };
 
-        return (
-          <div className={cx(css(styles.wrapper), className)}>
-            <ControlBehavior
-              onBlur={onBlur}
-              onFocus={onFocus}
-              onMouseDown={onMouseDown}
-              onMouseEnter={onMouseEnter}
-              onMouseLeave={onMouseLeave}
-              onMouseUp={onMouseUp}
-            >
-              {({
-                hasFocus,
-                hasHover,
-                isPressed,
-                onBlur: handleBlur,
-                onFocus: handleFocus,
-                onMouseDown: handleMouseDown,
-                onMouseEnter: handleMouseEnter,
-                onMouseLeave: handleMouseLeave,
-                onMouseUp: handleMouseUp,
-              }) => (
-                <HeaderPresenter
-                  {...otherProps}
-                  hasFocus={hasFocus}
-                  hasHover={hasHover}
-                  isPressed={isPressed}
-                  onBlur={handleBlur}
-                  onClick={onClick}
-                  onFocus={handleFocus}
-                  onHover={onHover}
-                  onMouseDown={handleMouseDown}
-                  onMouseEnter={handleMouseEnter}
-                  onMouseLeave={handleMouseLeave}
-                  onMouseUp={handleMouseUp}
-                  stylesheet={customStylesheet}
-                  label={label}
-                  indicator={indicator}
-                  indicatorPosition={indicatorPosition}
-                  collapsed={isCollapsed()}
-                  disabled={disabled}
-                />
-              )}
-            </ControlBehavior>
-            <ContentPresenter
-              collapsed={isCollapsed()}
-              stylesheet={customStylesheet}
-              className={className}
-            >
-              {children}
-            </ContentPresenter>
-          </div>
-        );
-      }}
-    </ThemeContext.Consumer>
-  );
-};
+  isCollapsedControlled = () => this.props.collapsed !== undefined;
 
-Accordion.displayName = "Accordion";
+  isCollapsed = () =>
+    this.isCollapsedControlled() ? this.props.collapsed : this.state.collapsed;
 
-Accordion.propTypes = {
-  /** Content of the accordion */
-  children: PropTypes.node,
-  /** Controlled value, specifies whether the accordion is collapsed or not
-   * When provided, it overrides the accordion's collapsed state
-   */
-  collapsed: PropTypes.bool,
-  /** Specifies whether the accordion is default collapsed or not */
-  defaultCollapsed: PropTypes.bool,
-  /** Specifies whether the accordion is disabled or not */
-  disabled: PropTypes.bool,
-  /** Indicator icon */
-  indicator: PropTypes.oneOf(AVAILABLE_INDICATORS),
-  /** Indicator's position */
-  indicatorPosition: PropTypes.oneOf(AVAILABLE_INDICATOR_POSITIONS),
-  /** Text label for the accordion header */
-  label: PropTypes.node.isRequired,
-  /** Function called when clicks the accordion's header */
-  onClick: PropTypes.func,
-  /** Function to modify the component's styles */
-  stylesheet: PropTypes.func,
-};
+  render() {
+    const {
+      children,
+      label,
+      indicator,
+      indicatorPosition,
+      disabled,
+      stylesheet: customStylesheet,
+      ...otherProps
+    } = this.props;
 
-Accordion.defaultProps = {
-  indicator: indicators.CARET,
-  indicatorPosition: indicatorPositions.LEFT,
-  defaultCollapsed: true,
-  disabled: false,
-  onClick: () => {},
-};
+    const {
+      className,
+      onBlur,
+      onFocus,
+      onMouseDown,
+      onMouseEnter,
+      onMouseLeave,
+      onMouseUp,
+      onHover,
+    } = otherProps;
 
-export default Accordion;
+    const collapsed = this.isCollapsed();
+
+    return (
+      <ThemeContext.Consumer>
+        {({ resolvedRoles, metadata }) => {
+          const styles = stylesheet(
+            {
+              indicator,
+              indicatorPosition,
+              collapsed,
+              stylesheet: customStylesheet,
+            },
+            resolvedRoles,
+            metadata
+          );
+
+          return (
+            <div className={cx(css(styles.wrapper), className)}>
+              <ControlBehavior
+                onBlur={onBlur}
+                onFocus={onFocus}
+                onMouseDown={onMouseDown}
+                onMouseEnter={onMouseEnter}
+                onMouseLeave={onMouseLeave}
+                onMouseUp={onMouseUp}
+              >
+                {({
+                  hasFocus,
+                  hasHover,
+                  isPressed,
+                  onBlur: handleBlur,
+                  onFocus: handleFocus,
+                  onMouseDown: handleMouseDown,
+                  onMouseEnter: handleMouseEnter,
+                  onMouseLeave: handleMouseLeave,
+                  onMouseUp: handleMouseUp,
+                }) => (
+                  <HeaderPresenter
+                    {...otherProps}
+                    hasFocus={hasFocus}
+                    hasHover={hasHover}
+                    isPressed={isPressed}
+                    onBlur={handleBlur}
+                    onClick={this.onClick}
+                    onFocus={handleFocus}
+                    onHover={onHover}
+                    onMouseDown={handleMouseDown}
+                    onMouseEnter={handleMouseEnter}
+                    onMouseLeave={handleMouseLeave}
+                    onMouseUp={handleMouseUp}
+                    stylesheet={customStylesheet}
+                    label={label}
+                    indicator={indicator}
+                    indicatorPosition={indicatorPosition}
+                    collapsed={collapsed}
+                    disabled={disabled}
+                  />
+                )}
+              </ControlBehavior>
+              <ContentPresenter
+                collapsed={collapsed}
+                stylesheet={customStylesheet}
+                className={className}
+              >
+                {children}
+              </ContentPresenter>
+            </div>
+          );
+        }}
+      </ThemeContext.Consumer>
+    );
+  }
+}

--- a/packages/accordion/src/presenters/ContentPresenter.js
+++ b/packages/accordion/src/presenters/ContentPresenter.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useLayoutEffect } from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { css, cx } from "emotion";
 import { createCustomClassNames } from "@hig/utils";
@@ -13,49 +13,78 @@ const collapseStatus = {
   EXPANDED: "expanded",
 };
 
-function ContentPresenter(props) {
-  const { collapsed } = props;
-  const [status, setStatus] = useState(collapseStatus.COLLAPSED);
-  const previousCollapsed = useRef(collapsed);
-  const contentWrapper = useRef(null);
-
-  const expand = () => setStatus(collapseStatus.EXPANDING);
-  const afterCollapsed = () => setStatus(collapseStatus.COLLAPSED);
-  const afterExpanded = () => setStatus(collapseStatus.EXPANDED);
-
-  const setContentWrapperRef = (element) => {
-    contentWrapper.current = element;
+export default class ContentPresenter extends Component {
+  // eslint-disable-next-line react/static-property-placement
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    collapsed: PropTypes.bool,
   };
 
-  const onTransitionEnd = ({ target, propertyName }) => {
-    if (target === contentWrapper && propertyName === "height") {
-      if (collapsed) {
-        afterCollapsed();
+  // eslint-disable-next-line react/static-property-placement
+  static defaultProps = {
+    collapsed: false,
+  };
+
+  constructor(props) {
+    super(props);
+    this.contentWrapper = null;
+    this.setContentWrapperRef = (element) => {
+      this.contentWrapper = element;
+    };
+
+    this.state = {
+      status: collapseStatus.COLLAPSED,
+    };
+  }
+
+  componentDidMount() {
+    if (!this.props.collapsed && this.contentWrapper) {
+      this.afterExpanded();
+    }
+  }
+
+  componentDidUpdate({ collapsed: previousCollapsed }) {
+    const { collapsed: currentCollapsed } = this.props;
+
+    if (!this.contentWrapper) {
+      return;
+    }
+    if (currentCollapsed && !previousCollapsed) {
+      this.collapse();
+    }
+    if (!currentCollapsed && previousCollapsed) {
+      this.expand();
+    }
+  }
+
+  onTransitionEnd = ({ target, propertyName }) => {
+    if (target === this.contentWrapper && propertyName === "height") {
+      if (this.props.collapsed) {
+        this.afterCollapsed();
       } else {
-        afterExpanded();
+        this.afterExpanded();
       }
     }
   };
 
-  const getContentHeight = () =>
-    `${contentWrapper.current && contentWrapper.current.scrollHeight}px`;
+  getContentHeight = () => `${this.contentWrapper.scrollHeight}px`;
 
-  const getTransitionStyles = (statusParam) => {
+  getTransitionStyles = (status) => {
     const defaultCollapsedStyles = {
       height: "0",
       overflow: "hidden",
       visibility: "hidden",
     };
 
-    if (statusParam === collapseStatus.EXPANDING) {
+    if (status === collapseStatus.EXPANDING) {
       return {
         ...defaultCollapsedStyles,
-        height: getContentHeight(),
+        height: this.getContentHeight(),
         visibility: "visible",
         overflow: "hidden",
       };
     }
-    if (statusParam === collapseStatus.EXPANDED) {
+    if (status === collapseStatus.EXPANDED) {
       return {
         ...defaultCollapsedStyles,
         height: "auto",
@@ -63,15 +92,15 @@ function ContentPresenter(props) {
         overflow: "visible",
       };
     }
-    if (statusParam === collapseStatus.BEFORE_COLLAPSE) {
+    if (status === collapseStatus.BEFORE_COLLAPSE) {
       return {
         ...defaultCollapsedStyles,
-        height: getContentHeight(),
+        height: this.getContentHeight(),
         visibility: "visible",
         overflow: "visible",
       };
     }
-    if (statusParam === collapseStatus.COLLAPSING) {
+    if (status === collapseStatus.COLLAPSING) {
       return {
         ...defaultCollapsedStyles,
         height: "0",
@@ -79,67 +108,44 @@ function ContentPresenter(props) {
         overflow: "hidden",
       };
     }
+
     return defaultCollapsedStyles;
   };
 
-  const collapse = () => {
-    setStatus(collapseStatus.BEFORE_COLLAPSE);
+  collapse = () => {
+    this.setState({ status: collapseStatus.BEFORE_COLLAPSE });
     window.requestAnimationFrame(() => {
-      setTimeout(() => setStatus(collapseStatus.COLLAPSED));
+      setTimeout(() => this.setState({ status: collapseStatus.COLLAPSED }));
     });
   };
 
-  useEffect(() => {
-    if (!collapsed && contentWrapper) {
-      afterExpanded();
-    }
-  }, []);
+  expand = () => this.setState({ status: collapseStatus.EXPANDING });
 
-  useLayoutEffect(() => {
-    const { current: currentCollapsed } = previousCollapsed;
-    previousCollapsed.current = collapsed;
-    if (!contentWrapper) {
-      return;
-    }
-    if (!currentCollapsed && collapsed) {
-      collapse();
-    }
-    if (currentCollapsed && !collapsed) {
-      expand();
-    }
-  }, [collapsed]);
+  afterCollapsed = () => this.setState({ status: collapseStatus.COLLAPSED });
 
-  const { children, ...otherProps } = props;
-  const { className } = otherProps;
+  afterExpanded = () => this.setState({ status: collapseStatus.EXPANDED });
 
-  const contentClassName = createCustomClassNames(className, "content");
-  const styles = stylesheet();
-  const transitionStyles = getTransitionStyles(status);
+  render() {
+    const { children, ...otherProps } = this.props;
+    const { className } = otherProps;
+    const { status } = this.state;
 
-  return (
-    <div
-      ref={setContentWrapperRef}
-      className={cx(
-        css(styles.contentTransitionWrapper),
-        css(transitionStyles),
-        contentClassName
-      )}
-      onTransitionEnd={onTransitionEnd}
-    >
-      {children}
-    </div>
-  );
+    const contentClassName = createCustomClassNames(className, "content");
+    const styles = stylesheet();
+    const transitionStyles = this.getTransitionStyles(status);
+
+    return (
+      <div
+        ref={this.setContentWrapperRef}
+        className={cx(
+          css(styles.contentTransitionWrapper),
+          css(transitionStyles),
+          contentClassName
+        )}
+        onTransitionEnd={this.onTransitionEnd}
+      >
+        {children}
+      </div>
+    );
+  }
 }
-
-ContentPresenter.displayName = "ContentPresenter";
-
-ContentPresenter.propTypes = {
-  children: PropTypes.node.isRequired,
-  collapsed: PropTypes.bool,
-};
-
-ContentPresenter.defaultProps = {
-  collapsed: false,
-};
-
-export default ContentPresenter;

--- a/packages/accordion/src/presenters/HeaderPresenter.js
+++ b/packages/accordion/src/presenters/HeaderPresenter.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { css, cx } from "emotion";
 import { ThemeContext } from "@hig/theme-context";
@@ -19,111 +19,114 @@ import {
 } from "../constants";
 import stylesheet from "../stylesheet";
 
-const HeaderPresenter = (props) => {
-  const {
-    hasFocus,
-    hasHover,
-    isPressed,
-    onBlur,
-    onClick,
-    onFocus,
-    onHover,
-    onMouseDown,
-    onMouseEnter,
-    onMouseLeave,
-    onMouseUp,
-    stylesheet: customStylesheet,
-    label,
-    indicator,
-    indicatorPosition,
-    collapsed,
-    disabled,
-    children,
-    ...otherProps
-  } = props;
+export default class HeaderPresenter extends Component {
+  // eslint-disable-next-line react/static-property-placement
+  static propTypes = {
+    hasFocus: PropTypes.bool,
+    hasHover: PropTypes.bool,
+    isPressed: PropTypes.bool,
+    onBlur: PropTypes.func,
+    onClick: PropTypes.func,
+    onFocus: PropTypes.func,
+    onHover: PropTypes.func,
+    onMouseDown: PropTypes.func,
+    onMouseEnter: PropTypes.func,
+    onMouseLeave: PropTypes.func,
+    onMouseUp: PropTypes.func,
+    label: PropTypes.node.isRequired,
+    indicator: PropTypes.oneOf(AVAILABLE_INDICATORS),
+    indicatorPosition: PropTypes.oneOf(AVAILABLE_INDICATOR_POSITIONS),
+    collapsed: PropTypes.bool,
+    disabled: PropTypes.bool,
+    stylesheet: PropTypes.func,
+    children: PropTypes.node,
+  };
 
-  const { className } = otherProps;
-  const headerClassName = createCustomClassNames(className, "header");
-  const indicatorClassName = createCustomClassNames(
-    className,
-    "header-indicator"
-  );
-  const labelClassName = createCustomClassNames(className, "header-label");
+  render() {
+    const {
+      hasFocus,
+      hasHover,
+      isPressed,
+      onBlur,
+      onClick,
+      onFocus,
+      onHover,
+      onMouseDown,
+      onMouseEnter,
+      onMouseLeave,
+      onMouseUp,
+      stylesheet: customStylesheet,
+      label,
+      indicator,
+      indicatorPosition,
+      collapsed,
+      disabled,
+      children,
+      ...otherProps
+    } = this.props;
 
-  return (
-    <ThemeContext.Consumer>
-      {({ resolvedRoles, metadata }) => {
-        const styles = stylesheet(
-          {
-            hasFocus,
-            hasHover,
-            isPressed,
-            indicator,
-            indicatorPosition,
-            collapsed,
-            disabled,
-            stylesheet: customStylesheet,
-          },
-          resolvedRoles,
-          metadata
-        );
+    const { className } = otherProps;
+    const headerClassName = createCustomClassNames(className, "header");
+    const indicatorClassName = createCustomClassNames(
+      className,
+      "header-indicator"
+    );
+    const labelClassName = createCustomClassNames(className, "header-label");
 
-        const highDensity = metadata.densityId === "high-density";
-        let Indicator = highDensity ? CaretRightSUI : CaretRightMUI;
-        if (indicator === indicators.OPERATOR) {
-          Indicator = highDensity ? OperatorPlusXsUI : OperatorPlusSUI;
-          if (!collapsed) {
-            Indicator = highDensity ? OperatorMinusXsUI : OperatorMinusSUI;
+    return (
+      <ThemeContext.Consumer>
+        {({ resolvedRoles, metadata }) => {
+          const styles = stylesheet(
+            {
+              hasFocus,
+              hasHover,
+              isPressed,
+              indicator,
+              indicatorPosition,
+              collapsed,
+              disabled,
+              stylesheet: customStylesheet,
+            },
+            resolvedRoles,
+            metadata
+          );
+
+          const highDensity = metadata.densityId === "high-density";
+          let Indicator = highDensity ? CaretRightSUI : CaretRightMUI;
+          if (indicator === indicators.OPERATOR) {
+            Indicator = highDensity ? OperatorPlusXsUI : OperatorPlusSUI;
+            if (!collapsed) {
+              Indicator = highDensity ? OperatorMinusXsUI : OperatorMinusSUI;
+            }
           }
-        }
 
-        return (
-          <button
-            className={cx(css(styles.header), headerClassName)}
-            onBlur={onBlur}
-            onClick={onClick}
-            onFocus={onFocus}
-            onMouseDown={onMouseDown}
-            onMouseEnter={onMouseEnter}
-            onMouseLeave={onMouseLeave}
-            onMouseOver={onHover}
-            onMouseUp={onMouseUp}
-            disabled={disabled}
-            tabIndex={disabled ? "-1" : "0"}
-            type="button"
-          >
-            <div className={css(styles.indicatorWrapper)}>
-              <Indicator
-                className={cx(css(styles.indicator), indicatorClassName)}
-              />
-            </div>
-            <div className={cx(css(styles.label), labelClassName)}>{label}</div>
-          </button>
-        );
-      }}
-    </ThemeContext.Consumer>
-  );
-};
-
-HeaderPresenter.propTypes = {
-  hasFocus: PropTypes.bool,
-  hasHover: PropTypes.bool,
-  isPressed: PropTypes.bool,
-  onBlur: PropTypes.func,
-  onClick: PropTypes.func,
-  onFocus: PropTypes.func,
-  onHover: PropTypes.func,
-  onMouseDown: PropTypes.func,
-  onMouseEnter: PropTypes.func,
-  onMouseLeave: PropTypes.func,
-  onMouseUp: PropTypes.func,
-  label: PropTypes.node.isRequired,
-  indicator: PropTypes.oneOf(AVAILABLE_INDICATORS),
-  indicatorPosition: PropTypes.oneOf(AVAILABLE_INDICATOR_POSITIONS),
-  collapsed: PropTypes.bool,
-  disabled: PropTypes.bool,
-  stylesheet: PropTypes.func,
-  children: PropTypes.node,
-};
-
-export default HeaderPresenter;
+          return (
+            <button
+              className={cx(css(styles.header), headerClassName)}
+              onBlur={onBlur}
+              onClick={onClick}
+              onFocus={onFocus}
+              onMouseDown={onMouseDown}
+              onMouseEnter={onMouseEnter}
+              onMouseLeave={onMouseLeave}
+              onMouseOver={onHover}
+              onMouseUp={onMouseUp}
+              disabled={disabled}
+              tabIndex={disabled ? "-1" : "0"}
+              type="button"
+            >
+              <div className={css(styles.indicatorWrapper)}>
+                <Indicator
+                  className={cx(css(styles.indicator), indicatorClassName)}
+                />
+              </div>
+              <div className={cx(css(styles.label), labelClassName)}>
+                {label}
+              </div>
+            </button>
+          );
+        }}
+      </ThemeContext.Consumer>
+    );
+  }
+}


### PR DESCRIPTION
The conversion to functional components with the react17 upgrade caused the content expand/collapse to not work properly. Reverting back to class components as that was reported to be working as expected.